### PR TITLE
Use the shared SparkTales App Store key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ agent/build/
 agent/dist/
 
 # Secrets
+/apple-keys/
 .env
 .env.*
 *.p8

--- a/Docs/APP-STORE-RELEASE-2026-07-29.md
+++ b/Docs/APP-STORE-RELEASE-2026-07-29.md
@@ -129,5 +129,8 @@ the distribution audit and deep code-signature verification
 - The release script's default ASC key path was corrected to
   `SparkTales_Master/api-keys`; the previous StoryBook2 location no longer
   exists, which is what interrupted the first export run.
+- Current local setup supersedes that historical path: the shared SparkTales
+  team key is stored in each repository's gitignored
+  `apple-keys/AuthKey_QYV9PN42QS.p8` directory.
 - Build 10 is not yet assigned to the **Locus Internal Testers** TestFlight
   group and has not been submitted for review.

--- a/README.md
+++ b/README.md
@@ -493,19 +493,26 @@ To upload the exported archive directly to App Store Connect:
 LOCUS_UPLOAD=1 Tools/ArchiveAppStore.sh
 ```
 
-Both release scripts authenticate with an App Store Connect API key. The key id
-and issuer id are **not** defaulted in this repository — they are half of a
-credential pair and this repository is public — so export them alongside the
-`.p8`, which lives outside the tree:
+Both release scripts use the shared SparkTales App Store Connect Admin team
+key. The non-secret team metadata is configured by default:
+
+- key ID: `QYV9PN42QS`
+- issuer ID: `3675bb71-8667-42ca-a9ae-2b6091f0c076`
+- Apple team ID: `4X4RJA7GMD`
+
+On SparkTales development Macs, copy the private key from
+`/Users/andrew/code/StoryBook2/apple-keys/AuthKey_QYV9PN42QS.p8` to the
+gitignored local path `apple-keys/AuthKey_QYV9PN42QS.p8` and restrict it to the
+owner with `chmod 600`. The private key must never be committed. The defaults
+then work without credential environment variables; overrides remain available:
 
 ```bash
-export LOCUS_ASC_KEY_ID=…
-export LOCUS_ASC_ISSUER_ID=…
-export LOCUS_ASC_KEY_PATH=/path/to/AuthKey_<id>.p8   # optional; defaults next to the repo
+export LOCUS_ASC_KEY_ID=QYV9PN42QS
+export LOCUS_ASC_ISSUER_ID=3675bb71-8667-42ca-a9ae-2b6091f0c076
+export LOCUS_ASC_KEY_PATH=/secure/path/to/AuthKey_QYV9PN42QS.p8
 ```
 
-A missing value fails the script immediately with the variable's name rather
-than a confusing authentication error later.
+A missing private-key file fails the script before archiving.
 
 Every archive runs `Tools/AuditDistribution.sh` before export. The audit
 rejects unused GPL-licensed GNU gdbm content, the broken Tk extension, and

--- a/Tools/ArchiveAppStore.sh
+++ b/Tools/ArchiveAppStore.sh
@@ -14,12 +14,11 @@ set -euo pipefail
 script_dir="${0:A:h}"
 repo_root="${script_dir:h}"
 project_yml="${repo_root}/project.yml"
-# Not defaulted in-tree: these are half of an App Store Connect credential
-# pair, and this repository is public. Set them in your shell or a local
-# untracked env file; the values live with the .p8 key, outside the repo.
-key_id="${LOCUS_ASC_KEY_ID:?set LOCUS_ASC_KEY_ID (App Store Connect API key id)}"
-issuer_id="${LOCUS_ASC_ISSUER_ID:?set LOCUS_ASC_ISSUER_ID (App Store Connect issuer id)}"
-key_path="${LOCUS_ASC_KEY_PATH:-${repo_root:h}/SparkTales_Master/api-keys/AuthKey_${key_id}.p8}"
+# SparkTales team-key metadata is not secret. The private key stays in the
+# gitignored local apple-keys directory and may be overridden when necessary.
+key_id="${LOCUS_ASC_KEY_ID:-QYV9PN42QS}"
+issuer_id="${LOCUS_ASC_ISSUER_ID:-3675bb71-8667-42ca-a9ae-2b6091f0c076}"
+key_path="${LOCUS_ASC_KEY_PATH:-${repo_root}/apple-keys/AuthKey_${key_id}.p8}"
 team_id="${LOCUS_TEAM_ID:-4X4RJA7GMD}"
 version="${LOCUS_MARKETING_VERSION:-$(/usr/bin/awk '/MARKETING_VERSION/ { print $2; exit }' "${project_yml}" | /usr/bin/tr -d '"')}"
 build="${LOCUS_BUILD_VERSION:-$(/usr/bin/awk '/CURRENT_PROJECT_VERSION/ { print $2; exit }' "${project_yml}")}"

--- a/Tools/PackageRelease.sh
+++ b/Tools/PackageRelease.sh
@@ -115,10 +115,11 @@ fi
 /usr/bin/ditto -c -k --sequesterRsrc --keepParent "${app}" "${zip_out}"
 
 if [[ "${LOCUS_NOTARIZE:-0}" == "1" ]]; then
-    # See the note in ArchiveAppStore.sh: not defaulted in a public repo.
-    key_id="${LOCUS_ASC_KEY_ID:?set LOCUS_ASC_KEY_ID (App Store Connect API key id)}"
-    issuer_id="${LOCUS_ASC_ISSUER_ID:?set LOCUS_ASC_ISSUER_ID (App Store Connect issuer id)}"
-    key_path="${LOCUS_ASC_KEY_PATH:-${0:A:h:h:h}/SparkTales_Master/api-keys/AuthKey_${key_id}.p8}"
+    # See ArchiveAppStore.sh: metadata is shared, while the private key remains
+    # local in the gitignored apple-keys directory.
+    key_id="${LOCUS_ASC_KEY_ID:-QYV9PN42QS}"
+    issuer_id="${LOCUS_ASC_ISSUER_ID:-3675bb71-8667-42ca-a9ae-2b6091f0c076}"
+    key_path="${LOCUS_ASC_KEY_PATH:-${0:A:h:h}/apple-keys/AuthKey_${key_id}.p8}"
     [[ -f "${key_path}" ]] || {
         echo "error: App Store Connect key not found at ${key_path}" >&2
         exit 1


### PR DESCRIPTION
## What changed

- default App Store archive and notarization tooling to the shared SparkTales team key metadata
- use a gitignored local `apple-keys/` directory for the private key
- document the local credential setup and current release path

## Why

The previous default pointed at a missing `SparkTales_Master` directory even though the active SparkTales team key is maintained with Storybook Bible.

## Validation

- `zsh -n Tools/ArchiveAppStore.sh Tools/PackageRelease.sh`
- `git diff --check`
- ReleaseMAS archive and export succeeded for `1.8.0 (11)`
- distribution audit passed and the archive contains `AppIcon.icns` and `Assets.car`

The private `.p8` remains local and gitignored.
