### PR TITLE
Add explicit local models to LangGraph workflows

### DIFF
--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -132,6 +132,7 @@ final class AppModel: ObservableObject {
     @Published var settingsPresented = false
     @Published var settingsPage: SettingsPage = .general
     @Published var modelLibraryPresented = false
+    @Published var modelLibraryInitialQuery = ""
     @Published var commandPalettePresented = false
     @Published var checkpointPresented = false
     @Published var clearChatConfirmationPresented = false
@@ -163,9 +164,15 @@ final class AppModel: ObservableObject {
     @Published private(set) var activeGraphRunID: String?
     @Published private(set) var activeGraphStatus: String?
     @Published private(set) var graphNodeActivities: [GraphNodeActivity] = []
+    @Published private(set) var graphLocalModels: [ModelInfo] = []
+    @Published private(set) var graphOllamaAvailable = false
+    @Published private(set) var graphOllamaError = ""
+    @Published private(set) var graphPreflightIssues: [GraphPreflightIssue] = []
     @Published var graphReviewRequest: GraphReviewRequest?
     @Published var graphErrorMessage: String?
     @Published var graphStudioPresented = false
+    @Published var graphStudioFocusWorkflowID: String?
+    @Published var graphStudioFocusNodeID: String?
     @Published var workflowRunPresented = false
 
     /// Console state. A `let` on its own ObservableObject, not @Published
@@ -991,6 +998,41 @@ final class AppModel: ObservableObject {
         } catch {
             // Preserve the last run history during reconnects.
         }
+        await refreshGraphLocalModels()
+    }
+
+    func refreshGraphLocalModels() async {
+        guard !isUITesting else { return }
+        do {
+            let response = try await backend.get(
+                "/api/langgraph/models",
+                as: GraphLocalModelsResponse.self
+            )
+            graphLocalModels = response.models
+            graphOllamaAvailable = response.available
+            graphOllamaError = response.error
+            if activeAccount == nil, response.available {
+                localModels = response.models
+            }
+        } catch {
+            graphOllamaAvailable = false
+            graphOllamaError = error.localizedDescription
+        }
+    }
+
+    func openModelLibrary(for issue: GraphPreflightIssue) {
+        modelLibraryInitialQuery = issue.model
+        modelLibraryPresented = true
+    }
+
+    func remapGraphModel(for issue: GraphPreflightIssue) {
+        graphStudioFocusWorkflowID = graphStudioFocusWorkflowID ?? selectedGraphWorkflow?.id
+        graphStudioFocusNodeID = issue.nodeID
+        graphStudioPresented = true
+    }
+
+    func clearGraphPreflightIssues() {
+        graphPreflightIssues = []
     }
 
     private func normalizeSelectedWorkflows() {
@@ -3625,6 +3667,7 @@ final class AppModel: ObservableObject {
             activeGraphStatus = "running"
             graphNodeActivities = []
             graphReviewRequest = nil
+            graphPreflightIssues = []
             isBusy = true
             if !justChatEnabled { selectInspectorTab(.workflows) }
 
@@ -3633,6 +3676,17 @@ final class AppModel: ObservableObject {
                   let accountIDs = event["account_ids"] as? [String]
             else { return }
             sendGraphCredentials(runID: runID, accountIDs: accountIDs)
+
+        case "graph_preflight_failed":
+            let rawIssues = event["issues"] as? [[String: Any]] ?? []
+            graphPreflightIssues = rawIssues.compactMap(GraphPreflightIssue.init(dictionary:))
+            graphErrorMessage = graphPreflightIssues.first?.message
+                ?? "A workflow model is unavailable."
+            if let workflowID = event["workflow_id"] as? String, !workflowID.isEmpty {
+                graphStudioFocusWorkflowID = workflowID
+            }
+            selectInspectorTab(.workflows)
+            showToast("Workflow needs a local model")
 
         case "graph_node_state":
             let nodeID = event["node_id"] as? String ?? "node"
@@ -3666,6 +3720,10 @@ final class AppModel: ObservableObject {
                     ?? graphNodeActivities[index].completionTokens
                 graphNodeActivities[index].contextLimit = event["context_limit"] as? Int
                     ?? graphNodeActivities[index].contextLimit
+                graphNodeActivities[index].modelSource = event["model_source"] as? String
+                    ?? graphNodeActivities[index].modelSource
+                graphNodeActivities[index].modelLabel = event["model_label"] as? String
+                    ?? graphNodeActivities[index].modelLabel
                 graphNodeActivities[index].isFinal = event["final_node"] as? Bool
                     ?? graphNodeActivities[index].isFinal
             } else {
@@ -3677,6 +3735,8 @@ final class AppModel: ObservableObject {
                     durationMilliseconds: nil,
                     error: nil,
                     model: event["model"] as? String,
+                    modelSource: event["model_source"] as? String,
+                    modelLabel: event["model_label"] as? String,
                     promptTokens: event["prompt_tokens"] as? Int,
                     completionTokens: event["completion_tokens"] as? Int,
                     contextLimit: event["context_limit"] as? Int,
@@ -4263,6 +4323,27 @@ final class AppModel: ObservableObject {
         // The picker reads the local list, which a live refresh would normally
         // fill in.
         localModels = models
+        graphLocalModels = models
+        graphOllamaAvailable = true
+        langGraphAvailable = true
+        langGraphVersion = "1.2.9"
+        let workflowFixture = #"""
+        {
+          "schema_version":1,"id":"single-agent","slug":"single-agent","name":"Single Agent",
+          "description":"One durable local agent.","supported_modes":["plan","build"],"revision":1,
+          "nodes":[
+            {"id":"input","type":"input","label":"Input","position":{"x":40,"y":120},"config":{}},
+            {"id":"final","type":"final","label":"Final Answer","position":{"x":360,"y":120},"config":{"prompt":"Answer the user."}}
+          ],
+          "edges":[{"id":"input-final","source":"input","source_port":"out","target":"final","target_port":"in"}],
+          "settings":{"max_steps":20,"failure_policy":"fail"},"scope":"builtin","valid":true,"trusted":true,
+          "capabilities":{"node_count":2,"edge_count":1,"parallel_width":1,"model_sources":["inherit"]}
+        }
+        """#
+        graphWorkflows = (try? JSONDecoder().decode(
+            [GraphWorkflow].self,
+            from: Data("[\(workflowFixture)]".utf8)
+        )) ?? []
         sessionInfo = SessionInfo(
             model: "qwen3:8b",
             host: "http://localhost:11434",

--- a/Locus/ComposerView.swift
+++ b/Locus/ComposerView.swift
@@ -447,9 +447,9 @@ struct ComposerView: View {
                             model.selectGraphWorkflow(workflow)
                         } label: {
                             if model.selectedGraphWorkflow?.id == workflow.id {
-                                Label(workflow.name, systemImage: "checkmark")
+                                Label("\(workflow.name) · \(workflow.modelRoutingLabel)", systemImage: "checkmark")
                             } else {
-                                Text(workflow.name)
+                                Text("\(workflow.name) · \(workflow.modelRoutingLabel)")
                             }
                         }
                     }
@@ -458,7 +458,9 @@ struct ComposerView: View {
                         model.graphStudioPresented = true
                     }
                 } label: {
-                    Text(model.selectedGraphWorkflow?.name ?? "Choose workflow")
+                    Text(model.selectedGraphWorkflow.map {
+                        "\($0.name) · \($0.modelRoutingLabel)"
+                    } ?? "Choose workflow")
                         .font(.system(size: 8, weight: .semibold))
                         .lineLimit(1)
                 }

--- a/Locus/InspectorWorkflowsTab.swift
+++ b/Locus/InspectorWorkflowsTab.swift
@@ -12,6 +12,7 @@ struct InspectorWorkflowsTab: View {
                 engineControls
                 if model.executionEngine == .langgraph {
                     workflowControls
+                    preflightFailures
                     activeRun
                     reviewRequest
                     recoverableRuns
@@ -93,7 +94,8 @@ struct InspectorWorkflowsTab: View {
                 }
             )) {
                 ForEach(model.compatibleGraphWorkflows) { workflow in
-                    Text(workflow.name + (workflow.trusted == false ? " · Trust required" : ""))
+                    Text(workflow.name + " · " + workflow.modelRoutingLabel
+                         + (workflow.trusted == false ? " · Trust required" : ""))
                         .tag(workflow.id)
                 }
             }
@@ -113,6 +115,7 @@ struct InspectorWorkflowsTab: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(LocusTheme.ink)
+                .accessibilityIdentifier("workflows.openStudio")
                 Button {
                     model.workflowRunPresented = true
                 } label: {
@@ -124,6 +127,51 @@ struct InspectorWorkflowsTab: View {
         .padding(11)
         .background(LocusTheme.paper)
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    @ViewBuilder
+    private var preflightFailures: some View {
+        if !model.graphPreflightIssues.isEmpty {
+            VStack(alignment: .leading, spacing: 9) {
+                HStack {
+                    Label("Local model required", systemImage: "exclamationmark.triangle.fill")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(LocusTheme.coral)
+                    Spacer()
+                    Button { model.clearGraphPreflightIssues() } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .buttonStyle(.plain)
+                }
+                ForEach(model.graphPreflightIssues) { issue in
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text(issue.nodeLabel)
+                            .font(.system(size: 9, weight: .semibold))
+                        Text(issue.message)
+                            .font(.system(size: 8))
+                            .foregroundStyle(LocusTheme.muted)
+                            .fixedSize(horizontal: false, vertical: true)
+                        HStack(spacing: 7) {
+                            Button("Refresh") {
+                                Task { await model.refreshGraphLocalModels() }
+                            }
+                            if issue.reason == "model_missing" {
+                                Button("Find model") { model.openModelLibrary(for: issue) }
+                            }
+                            Button("Remap") { model.remapGraphModel(for: issue) }
+                        }
+                        .font(.system(size: 8))
+                    }
+                    .padding(8)
+                    .background(LocusTheme.paper)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+            }
+            .padding(11)
+            .background(LocusTheme.coral.opacity(0.08))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(LocusTheme.coral.opacity(0.35)))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
     }
 
     @ViewBuilder
@@ -151,7 +199,10 @@ struct InspectorWorkflowsTab: View {
                         }
                         if let nodeModel = activity.model {
                             HStack(spacing: 8) {
-                                Label(nodeModel, systemImage: "cpu")
+                                Label(
+                                    [activity.modelLabel, nodeModel].compactMap { $0 }.joined(separator: " · "),
+                                    systemImage: activity.modelSource == "ollama" ? "desktopcomputer" : "cpu"
+                                )
                                 if let prompt = activity.promptTokens,
                                    let completion = activity.completionTokens {
                                     Text("\(prompt) in · \(completion) out")
@@ -291,6 +342,7 @@ struct InspectorWorkflowsTab: View {
         return HStack(spacing: 9) {
             Label("\(capabilities?.nodeCount ?? workflow.nodes.count) nodes", systemImage: "circle.grid.3x3")
             Label("\(capabilities?.parallelWidth ?? 1) parallel", systemImage: "arrow.triangle.branch")
+            Label(workflow.modelRoutingLabel, systemImage: "cpu")
             if capabilities?.mayMutate == true {
                 Label("May write", systemImage: "pencil")
                     .foregroundStyle(LocusTheme.coral)
@@ -416,6 +468,7 @@ struct GraphStudioView: View {
         .frame(minWidth: 980, idealWidth: 1180, minHeight: 680, idealHeight: 760)
         .background(LocusTheme.paper)
         .onAppear { selectInitialWorkflow() }
+        .task { await model.refreshGraphLocalModels() }
         .onChange(of: selectedWorkflowID) { _, newValue in loadWorkflow(newValue) }
         .accessibilityIdentifier("graphStudio.content")
     }
@@ -606,6 +659,8 @@ struct GraphStudioView: View {
         )
         .clipShape(RoundedRectangle(cornerRadius: 9))
         .contentShape(Rectangle())
+        .accessibilityIdentifier("graphStudio.node.\(node.id)")
+        .accessibilityAddTraits(.isButton)
         .onTapGesture { selectedNodeID = node.id }
         .gesture(
             DragGesture()
@@ -825,30 +880,7 @@ struct GraphStudioView: View {
             if [.model, .supervisor, .agent, .final].contains(node.wrappedValue.type) {
                 Divider()
                 Text("Model").font(.system(size: 8, weight: .semibold)).foregroundStyle(LocusTheme.muted)
-                Picker("Account", selection: Binding(
-                    get: { node.wrappedValue.config.modelBinding?.accountID ?? "" },
-                    set: { accountID in
-                        var binding = node.wrappedValue.config.modelBinding ?? GraphModelBinding()
-                        binding.accountID = accountID.isEmpty ? nil : accountID
-                        binding.displayHint = model.providerAccounts.first(where: {
-                            $0.id.uuidString == accountID
-                        })?.displayName
-                        node.wrappedValue.config.modelBinding = binding
-                    }
-                )) {
-                    Text("Inherit session model").tag("")
-                    ForEach(model.providerAccounts) { account in
-                        Text(account.displayName).tag(account.id.uuidString)
-                    }
-                }
-                TextField("Model override", text: Binding(
-                    get: { node.wrappedValue.config.modelBinding?.model ?? "" },
-                    set: { value in
-                        var binding = node.wrappedValue.config.modelBinding ?? GraphModelBinding()
-                        binding.model = value.isEmpty ? nil : value
-                        node.wrappedValue.config.modelBinding = binding
-                    }
-                ))
+                modelBindingEditor(node)
             }
             if [.agent, .toolSet].contains(node.wrappedValue.type) {
                 Divider()
@@ -881,6 +913,130 @@ struct GraphStudioView: View {
                 .foregroundStyle(LocusTheme.muted)
                 .textSelection(.enabled)
         }
+    }
+
+    @ViewBuilder
+    private func modelBindingEditor(_ node: Binding<GraphWorkflowNode>) -> some View {
+        let source = node.wrappedValue.config.modelBinding?.resolvedSource ?? .inheritSession
+        Picker("Source", selection: Binding(
+            get: { node.wrappedValue.config.modelBinding?.resolvedSource ?? .inheritSession },
+            set: { newSource in
+                switch newSource {
+                case .inheritSession:
+                    node.wrappedValue.config.modelBinding = GraphModelBinding(source: .inheritSession)
+                case .ollama:
+                    let existing = source == .ollama ? node.wrappedValue.config.modelBinding?.model : nil
+                    node.wrappedValue.config.modelBinding = GraphModelBinding(
+                        source: .ollama,
+                        model: existing ?? model.graphLocalModels.first?.name,
+                        displayHint: "Local Ollama"
+                    )
+                case .account:
+                    let account = model.providerAccounts.first
+                    node.wrappedValue.config.modelBinding = GraphModelBinding(
+                        source: .account,
+                        accountID: account?.id.uuidString,
+                        model: account?.preferredModel,
+                        displayHint: account?.displayName
+                    )
+                }
+            }
+        )) {
+            ForEach(GraphModelSource.allCases) { item in
+                Text(item.title).tag(item)
+            }
+        }
+        .accessibilityIdentifier("graphStudio.modelSource")
+
+        switch source {
+        case .inheritSession:
+            Text("Uses the model selected in the main composer when the run starts.")
+                .font(.system(size: 8))
+                .foregroundStyle(LocusTheme.muted)
+
+        case .ollama:
+            TextField("Ollama model", text: Binding(
+                get: { node.wrappedValue.config.modelBinding?.model ?? "" },
+                set: { value in setLocalModel(value, on: node) }
+            ))
+            .accessibilityIdentifier("graphStudio.localModel")
+            Menu("Installed models") {
+                if model.graphLocalModels.isEmpty {
+                    Text(model.graphOllamaAvailable ? "No Ollama models installed" : "Ollama unavailable")
+                } else {
+                    ForEach(model.graphLocalModels) { localModel in
+                        Button(localModel.name) { setLocalModel(localModel.name, on: node) }
+                    }
+                }
+            }
+            .accessibilityIdentifier("graphStudio.localModels")
+            if let selected = node.wrappedValue.config.modelBinding?.model,
+               !selected.isEmpty,
+               !model.graphLocalModels.contains(where: { $0.name == selected }) {
+                Label("Not currently installed", systemImage: "exclamationmark.triangle")
+                    .font(.system(size: 8))
+                    .foregroundStyle(LocusTheme.coral)
+            }
+            Button("Manage local models…") {
+                model.modelLibraryInitialQuery = node.wrappedValue.config.modelBinding?.model ?? ""
+                dismiss()
+                model.graphStudioPresented = false
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(180))
+                    model.modelLibraryPresented = true
+                }
+            }
+
+        case .account:
+            Picker("Account", selection: Binding(
+                get: { node.wrappedValue.config.modelBinding?.accountID ?? "" },
+                set: { accountID in
+                    let account = model.providerAccounts.first(where: { $0.id.uuidString == accountID })
+                    var binding = node.wrappedValue.config.modelBinding ?? GraphModelBinding(source: .account)
+                    binding.source = .account
+                    binding.accountID = accountID.isEmpty ? nil : accountID
+                    binding.model = account?.preferredModel ?? binding.model
+                    binding.displayHint = account?.displayName
+                    node.wrappedValue.config.modelBinding = binding
+                }
+            )) {
+                Text("Choose an account").tag("")
+                ForEach(model.providerAccounts) { account in
+                    Text(account.displayName).tag(account.id.uuidString)
+                }
+            }
+            TextField("Account model", text: Binding(
+                get: { node.wrappedValue.config.modelBinding?.model ?? "" },
+                set: { value in
+                    var binding = node.wrappedValue.config.modelBinding ?? GraphModelBinding(source: .account)
+                    binding.source = .account
+                    binding.model = value.isEmpty ? nil : value
+                    node.wrappedValue.config.modelBinding = binding
+                }
+            ))
+            if let rawID = node.wrappedValue.config.modelBinding?.accountID,
+               let id = UUID(uuidString: rawID),
+               let available = model.accountModels[id], !available.isEmpty {
+                Menu("Available models") {
+                    ForEach(available, id: \.self) { name in
+                        Button(name) {
+                            var binding = node.wrappedValue.config.modelBinding ?? GraphModelBinding(source: .account)
+                            binding.model = name
+                            node.wrappedValue.config.modelBinding = binding
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func setLocalModel(_ value: String, on node: Binding<GraphWorkflowNode>) {
+        var binding = node.wrappedValue.config.modelBinding ?? GraphModelBinding(source: .ollama)
+        binding.source = .ollama
+        binding.accountID = nil
+        binding.model = value.isEmpty ? nil : value
+        binding.displayHint = "Local Ollama"
+        node.wrappedValue.config.modelBinding = binding
     }
 
     private func routerEditor(_ node: Binding<GraphWorkflowNode>) -> some View {
@@ -994,6 +1150,18 @@ struct GraphStudioView: View {
         if draft.nodes.count > 64 { errors.append("Maximum 64 nodes") }
         if draft.edges.count > 256 { errors.append("Maximum 256 edges") }
         if draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { errors.append("Name is required") }
+        for node in draft.nodes where [.model, .supervisor, .agent, .final].contains(node.type) {
+            guard let binding = node.config.modelBinding else { continue }
+            switch binding.resolvedSource {
+            case .inheritSession:
+                if binding.accountID != nil { errors.append("\(node.label) cannot inherit an account") }
+            case .ollama:
+                if binding.model?.isEmpty != false { errors.append("\(node.label) needs an Ollama model") }
+                if binding.accountID != nil { errors.append("\(node.label) local binding cannot include an account") }
+            case .account:
+                if binding.accountID?.isEmpty != false { errors.append("\(node.label) needs a model account") }
+            }
+        }
         for edge in draft.edges {
             guard let source = draft.nodes.first(where: { $0.id == edge.source }),
                   let target = draft.nodes.first(where: { $0.id == edge.target }),
@@ -1011,11 +1179,18 @@ struct GraphStudioView: View {
     }
 
     private func selectInitialWorkflow() {
-        let preferred = model.selectedGraphWorkflow?.id
+        let preferred = model.graphStudioFocusWorkflowID
+            ?? model.selectedGraphWorkflow?.id
             ?? model.graphWorkflows.first?.id
             ?? ""
         selectedWorkflowID = preferred
         loadWorkflow(preferred)
+        if let focus = model.graphStudioFocusNodeID,
+           draft?.nodes.contains(where: { $0.id == focus }) == true {
+            selectedNodeID = focus
+        }
+        model.graphStudioFocusWorkflowID = nil
+        model.graphStudioFocusNodeID = nil
     }
 
     private func loadWorkflow(_ id: String) {

--- a/Locus/ModelLibraryView.swift
+++ b/Locus/ModelLibraryView.swift
@@ -189,7 +189,14 @@ struct ModelLibraryView: View {
         }
         .frame(width: 900, height: 620)
         .background(LocusTheme.panel)
-        .task { await library.loadInitial() }
+        .task {
+            let initialQuery = model.modelLibraryInitialQuery
+            if !initialQuery.isEmpty {
+                library.query = initialQuery
+                model.modelLibraryInitialQuery = ""
+            }
+            await library.loadInitial()
+        }
         .onDisappear { library.cancelDownload() }
         .onExitCommand {
             dismiss()

--- a/Locus/Models.swift
+++ b/Locus/Models.swift
@@ -1209,13 +1209,34 @@ struct GraphPosition: Codable, Hashable {
     var y: Double
 }
 
+enum GraphModelSource: String, Codable, CaseIterable, Identifiable {
+    case inheritSession = "inherit"
+    case ollama
+    case account
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .inheritSession: "Inherit session"
+        case .ollama: "Local Ollama"
+        case .account: "Remote account"
+        }
+    }
+}
+
 struct GraphModelBinding: Codable, Hashable {
+    var source: GraphModelSource? = nil
     var accountID: String? = nil
     var model: String? = nil
     var displayHint: String? = nil
 
+    var resolvedSource: GraphModelSource {
+        source ?? (accountID == nil ? .inheritSession : .account)
+    }
+
     enum CodingKeys: String, CodingKey {
-        case model
+        case source, model
         case accountID = "account_id"
         case displayHint = "display_hint"
     }
@@ -1409,12 +1430,16 @@ struct GraphWorkflowCapabilities: Codable, Hashable {
     let tools: [String]?
     let providerAccountIDs: [String]?
     let models: [String]?
+    let localModels: [String]?
+    let modelSources: [String]?
     let mayMutate: Bool?
     let promptCharacters: Int?
     let promptDigest: String?
 
     enum CodingKeys: String, CodingKey {
         case tools, models
+        case localModels = "local_models"
+        case modelSources = "model_sources"
         case nodeCount = "node_count"
         case edgeCount = "edge_count"
         case parallelWidth = "parallel_width"
@@ -1486,6 +1511,19 @@ struct GraphWorkflow: Codable, Hashable, Identifiable {
     }
 
     var isRunnable: Bool { valid != false && trusted != false }
+
+    var modelRoutingLabel: String {
+        let sources = Set(capabilities?.modelSources ?? nodes.compactMap {
+            guard [.model, .supervisor, .agent, .final].contains($0.type) else { return nil }
+            return $0.config.modelBinding?.resolvedSource.rawValue ?? GraphModelSource.inheritSession.rawValue
+        })
+        if sources.count > 1 { return "Mixed" }
+        switch sources.first {
+        case GraphModelSource.ollama.rawValue: return "Local"
+        case GraphModelSource.account.rawValue: return "Remote"
+        default: return "Inherited"
+        }
+    }
 }
 
 struct GraphWorkflowsResponse: Codable {
@@ -1586,10 +1624,41 @@ struct GraphNodeActivity: Identifiable, Hashable {
     var durationMilliseconds: Int?
     var error: String?
     var model: String? = nil
+    var modelSource: String? = nil
+    var modelLabel: String? = nil
     var promptTokens: Int? = nil
     var completionTokens: Int? = nil
     var contextLimit: Int? = nil
     var isFinal: Bool = false
+}
+
+struct GraphLocalModelsResponse: Codable, Hashable {
+    let available: Bool
+    let host: String
+    let models: [ModelInfo]
+    let error: String
+}
+
+struct GraphPreflightIssue: Identifiable, Hashable {
+    var id: String { "\(nodeID):\(reason):\(model)" }
+    let nodeID: String
+    let nodeLabel: String
+    let source: String
+    let model: String
+    let reason: String
+    let message: String
+
+    init?(dictionary: [String: Any]) {
+        guard let nodeID = dictionary["node_id"] as? String,
+              let reason = dictionary["reason"] as? String
+        else { return nil }
+        self.nodeID = nodeID
+        nodeLabel = dictionary["node_label"] as? String ?? nodeID
+        source = dictionary["source"] as? String ?? "ollama"
+        model = dictionary["model"] as? String ?? ""
+        self.reason = reason
+        message = dictionary["message"] as? String ?? "This workflow model is unavailable."
+    }
 }
 
 struct GraphReviewRequest: Identifiable, Hashable {

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -1570,6 +1570,8 @@ final class AppModelTests: XCTestCase {
             "agent": "Reviewer",
             "text": "private specialist output",
             "model": "specialist-model",
+            "model_source": "ollama",
+            "model_label": "Local Ollama",
             "prompt_tokens": 120,
             "completion_tokens": 30,
             "context_limit": 32768,
@@ -1592,9 +1594,38 @@ final class AppModelTests: XCTestCase {
         XCTAssertEqual(model.inspectorTab, .workflows)
         XCTAssertEqual(model.graphNodeActivities.first?.output, "private specialist output")
         XCTAssertEqual(model.graphNodeActivities.first?.promptTokens, 120)
+        XCTAssertEqual(model.graphNodeActivities.first?.modelSource, "ollama")
+        XCTAssertEqual(model.graphNodeActivities.first?.modelLabel, "Local Ollama")
         XCTAssertTrue(model.graphUsesMixedModels)
         XCTAssertEqual(model.graphContextModelLabel, "final-model · mixed-model run")
         XCTAssertEqual(model.blocks.count, initialBlocks, "specialist streams belong only in graph activity cards")
+    }
+
+    @MainActor
+    func testGraphPreflightFailureExposesRefreshPullAndRemapContext() {
+        let model = AppModel(startImmediately: false)
+        model.handleEventForTesting([
+            "type": "graph_preflight_failed",
+            "workflow_id": "builder-team",
+            "issues": [[
+                "node_id": "review",
+                "node_label": "Reviewer",
+                "source": "ollama",
+                "model": "qwen3:8b",
+                "reason": "model_missing",
+                "message": "Local model 'qwen3:8b' is not installed in Ollama.",
+            ]],
+        ])
+
+        XCTAssertEqual(model.inspectorTab, .workflows)
+        XCTAssertEqual(model.graphPreflightIssues.first?.nodeID, "review")
+        XCTAssertEqual(model.graphPreflightIssues.first?.model, "qwen3:8b")
+        XCTAssertEqual(model.graphStudioFocusWorkflowID, "builder-team")
+        XCTAssertEqual(model.graphErrorMessage, "Local model 'qwen3:8b' is not installed in Ollama.")
+
+        model.openModelLibrary(for: model.graphPreflightIssues[0])
+        XCTAssertTrue(model.modelLibraryPresented)
+        XCTAssertEqual(model.modelLibraryInitialQuery, "qwen3:8b")
     }
 
     @MainActor

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -29,6 +29,56 @@ final class FeatureLogicTests: XCTestCase {
 
     // MARK: - Slash commands
 
+    func testGraphModelBindingDecodesLegacySourcesAndEncodesExplicitOllama() throws {
+        let decoder = JSONDecoder()
+        let legacyAccount = try decoder.decode(
+            GraphModelBinding.self,
+            from: Data(#"{"account_id":"account-1","model":"remote-model"}"#.utf8)
+        )
+        XCTAssertNil(legacyAccount.source)
+        XCTAssertEqual(legacyAccount.resolvedSource, .account)
+
+        let legacyInherited = try decoder.decode(
+            GraphModelBinding.self,
+            from: Data(#"{"model":"session-override"}"#.utf8)
+        )
+        XCTAssertEqual(legacyInherited.resolvedSource, .inheritSession)
+
+        let local = GraphModelBinding(
+            source: .ollama,
+            model: "qwen3:8b",
+            displayHint: "Local Ollama"
+        )
+        let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(local)) as? [String: Any]
+        XCTAssertEqual(encoded?["source"] as? String, "ollama")
+        XCTAssertEqual(encoded?["model"] as? String, "qwen3:8b")
+        XCTAssertNil(encoded?["account_id"])
+    }
+
+    func testGraphWorkflowRoutingLabelDistinguishesLocalRemoteAndMixed() throws {
+        func workflow(sources: [String]) throws -> GraphWorkflow {
+            let data = try JSONSerialization.data(withJSONObject: [
+                "schema_version": 1,
+                "id": "w",
+                "slug": "w",
+                "name": "Workflow",
+                "description": "",
+                "supported_modes": ["build"],
+                "revision": 1,
+                "nodes": [],
+                "edges": [],
+                "settings": ["max_steps": 10, "failure_policy": "fail"],
+                "capabilities": ["model_sources": sources],
+            ])
+            return try JSONDecoder().decode(GraphWorkflow.self, from: data)
+        }
+
+        XCTAssertEqual(try workflow(sources: ["ollama"]).modelRoutingLabel, "Local")
+        XCTAssertEqual(try workflow(sources: ["account"]).modelRoutingLabel, "Remote")
+        XCTAssertEqual(try workflow(sources: ["inherit"]).modelRoutingLabel, "Inherited")
+        XCTAssertEqual(try workflow(sources: ["ollama", "account"]).modelRoutingLabel, "Mixed")
+    }
+
     func testSlashQueryDetection() {
         XCTAssertEqual(SlashCommand.query(from: "/"), "")
         XCTAssertEqual(SlashCommand.query(from: "/mod"), "mod")

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -349,6 +349,32 @@ final class LocusUITests: XCTestCase {
         XCTAssertFalse(anyElement("checkpointTab.content").exists)
     }
 
+    func testGraphStudioCanPinAnInstalledLocalOllamaModel() {
+        let engine = anyElement("composer.executionEngine")
+        XCTAssertTrue(engine.waitForExistence(timeout: 3))
+        engine.click()
+        XCTAssertTrue(app.menuItems["LangGraph"].waitForExistence(timeout: 2))
+        app.menuItems["LangGraph"].click()
+
+        app.typeKey("8", modifierFlags: .command)
+        let openStudio = anyElement("workflows.openStudio")
+        XCTAssertTrue(openStudio.waitForExistence(timeout: 3))
+        openStudio.click()
+
+        let finalNode = anyElement("graphStudio.node.final")
+        XCTAssertTrue(finalNode.waitForExistence(timeout: 3))
+        finalNode.click()
+
+        let source = anyElement("graphStudio.modelSource")
+        XCTAssertTrue(source.waitForExistence(timeout: 3))
+        source.click()
+        XCTAssertTrue(app.menuItems["Local Ollama"].waitForExistence(timeout: 2))
+        app.menuItems["Local Ollama"].click()
+
+        XCTAssertTrue(anyElement("graphStudio.localModel").waitForExistence(timeout: 2))
+        XCTAssertTrue(anyElement("graphStudio.localModels").exists)
+    }
+
     func testChangesTabShowsSeededWorkingTreeAndOpensADiff() {
         app.typeKey("2", modifierFlags: .command)
 

--- a/agent/PROTOCOL.md
+++ b/agent/PROTOCOL.md
@@ -236,6 +236,27 @@ The busy check is atomic and happens before any field is applied. Emits
 `session_info` on the WS when anything changed.
 `model` and `context_window` are persisted to `~/.ollama-code/config.json`.
 
+### LangGraph local models
+
+`GET /api/langgraph/models` always queries the configured Ollama host, even
+when the active session is routed through a remote account. It returns:
+
+```json
+{ "available": true, "host": "http://localhost:11434", "models": [], "error": "" }
+```
+
+Model-capable workflow nodes may include a version-1 additive binding:
+
+```json
+{ "model_binding": { "source": "ollama", "model": "qwen3:8b",
+  "display_hint": "Local Ollama" } }
+```
+
+`source` is `inherit`, `ollama`, or `account`. Legacy definitions without the
+field keep their previous meaning: an `account_id` selects an account and its
+absence inherits the session. Explicit Ollama bindings never persist a host or
+credentials; the engine uses the app's configured local endpoint.
+
 ---
 
 ## 2. WebSocket lifecycle
@@ -407,6 +428,17 @@ must not clear their busy state when this event arrives.
 ### `error`
 `{ "type": "error", "message": "..." }` — a failure inside the active agent
 turn. It is followed by `turn_done {reason: "error"}`.
+
+### `graph_preflight_failed`
+
+Emitted when an explicit local workflow binding cannot run. `issues` contains
+`node_id`, `node_label`, `source`, `model`, `reason`, and a user-facing
+`message`; reasons are `ollama_unreachable`, `model_missing`, or
+`tools_unsupported`. No run or transcript record is created. A terminal
+`turn_done {reason: "error"}` follows.
+
+Graph node token/usage events may also include `model_source` and
+`model_label`; older clients may ignore both fields.
 
 ### `slash_result`
 Ends a slash command (`/help`, `/model`, `/clear`, `/compact`, `/init`,

--- a/agent/ollama_code/langgraph_runtime.py
+++ b/agent/ollama_code/langgraph_runtime.py
@@ -18,11 +18,13 @@ import uuid
 from collections.abc import Callable, Iterable
 from contextlib import closing
 from copy import deepcopy
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Annotated, Any, TypedDict
 
-from .ollama import OllamaClient
+from .config import context_window, save_config
+from .ollama import DEFAULT_HOST, OllamaClient, OllamaError, effective_context_length
 from .paths import APP_DIR
 from .permissions import build_preview
 from .remote import RemoteClient
@@ -67,6 +69,8 @@ ACTIVE_STATUSES = {
 }
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,79}$")
 ROUTE_OPERATIONS = {"equals", "contains", "exists", "success", "failure"}
+MODEL_NODE_TYPES = {"model", "supervisor", "agent", "final"}
+MODEL_SOURCES = {"inherit", "ollama", "account"}
 
 NODE_PORTS: dict[str, tuple[list[dict[str, Any]], list[dict[str, Any]]]] = {
     "input": ([], [{"id": "out", "type": "state"}]),
@@ -94,6 +98,43 @@ NODE_PORTS: dict[str, tuple[list[dict[str, Any]], list[dict[str, Any]]]] = {
 
 class WorkflowError(ValueError):
     """A workflow definition, trust decision or run request is invalid."""
+
+
+class GraphPreflightError(WorkflowError):
+    """A run cannot start because one or more local model bindings are unavailable."""
+
+    def __init__(
+        self,
+        workflow_id: str,
+        issues: list[dict[str, str]],
+        *,
+        run_id: str = "",
+    ) -> None:
+        self.workflow_id = workflow_id
+        self.issues = issues
+        self.run_id = run_id
+        message = issues[0].get("message") if issues else "The workflow's local models are unavailable."
+        super().__init__(message)
+
+    def event(self) -> dict[str, Any]:
+        return {
+            "type": "graph_preflight_failed",
+            "workflow_id": self.workflow_id,
+            "issues": deepcopy(self.issues),
+            **({"run_id": self.run_id} if self.run_id else {}),
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedModelBinding:
+    """A workflow node's concrete provider without persisting credentials or hosts."""
+
+    client: Any
+    source: str
+    model: str
+    context_limit: int
+    options: dict[str, Any] | None
+    label: str
 
 
 def _utc_now() -> str:
@@ -440,6 +481,40 @@ class WorkflowRegistry:
                 pass
 
 
+def _normalized_model_binding(raw: Any, node_id: str, node_type: str) -> dict[str, str] | None:
+    if raw is None:
+        return None
+    if node_type not in MODEL_NODE_TYPES:
+        raise WorkflowError(f"node {node_id} cannot have a model binding")
+    if not isinstance(raw, dict):
+        raise WorkflowError(f"node {node_id} model_binding must be an object")
+    account_id = str(raw.get("account_id") or "").strip()[:200]
+    model = str(raw.get("model") or "").strip()[:500]
+    explicit_source = str(raw.get("source") or "").strip().lower()
+    source = explicit_source or ("account" if account_id else "inherit")
+    display_hint = str(raw.get("display_hint") or "").strip()[:200]
+    if source not in MODEL_SOURCES:
+        raise WorkflowError(f"node {node_id} has unsupported model source {source!r}")
+    if source == "ollama":
+        if not model:
+            raise WorkflowError(f"node {node_id} needs an Ollama model")
+        if account_id:
+            raise WorkflowError(f"node {node_id} Ollama binding may not include an account")
+    elif source == "account":
+        if not account_id:
+            raise WorkflowError(f"node {node_id} account binding needs an account_id")
+    elif account_id:
+        raise WorkflowError(f"node {node_id} inherited binding may not include an account")
+    return {
+        # Keep source absent on legacy definitions so their normalized digest
+        # and existing project trust remain stable. New editors always write it.
+        **({"source": source} if explicit_source else {}),
+        **({"account_id": account_id} if account_id else {}),
+        **({"model": model} if model else {}),
+        **({"display_hint": display_hint} if display_hint else {}),
+    }
+
+
 def validate_workflow(raw: dict[str, Any]) -> dict[str, Any]:
     """Return a normalized workflow or raise a user-facing validation error."""
     if not isinstance(raw, dict):
@@ -494,6 +569,9 @@ def validate_workflow(raw: dict[str, Any]) -> dict[str, Any]:
             raise WorkflowError(f"node {node_id} prompt exceeds {MAX_PROMPT_CHARS:,} characters")
         if any(key.lower() in {"api_key", "token", "password", "secret"} for key in config):
             raise WorkflowError(f"node {node_id} may not contain credentials")
+        model_binding = _normalized_model_binding(config.get("model_binding"), node_id, node_type)
+        if model_binding is not None:
+            config = {**config, "model_binding": model_binding}
         try:
             retry_count = int(config.get("retry_count") or 0)
         except (TypeError, ValueError) as exc:
@@ -683,6 +761,8 @@ def workflow_capabilities(definition: dict[str, Any]) -> dict[str, Any]:
     tools: set[str] = set()
     accounts: set[str] = set()
     models: set[str] = set()
+    local_models: set[str] = set()
+    model_sources: set[str] = set()
     prompts = 0
     prompt_material: list[dict[str, str]] = []
     for node in definition.get("nodes") or []:
@@ -691,10 +771,17 @@ def workflow_capabilities(definition: dict[str, Any]) -> dict[str, Any]:
         binding = config.get("model_binding") or {}
         account_id = str(binding.get("account_id") or "")
         model = str(binding.get("model") or "")
+        source = str(binding.get("source") or ("account" if account_id else "inherit"))
         if account_id:
             accounts.add(account_id)
-        if account_id or model:
-            models.add(f"{account_id or 'inherited'}:{model or 'default'}")
+        if node.get("type") in MODEL_NODE_TYPES:
+            model_sources.add(source)
+            if source == "ollama" and model:
+                local_models.add(model)
+            if source == "account":
+                models.add(f"account:{account_id}:{model or 'default'}")
+            else:
+                models.add(f"{source}:{model or 'default'}")
         prompt = str(config.get("prompt") or "")
         prompts += len(prompt)
         if prompt:
@@ -707,6 +794,8 @@ def workflow_capabilities(definition: dict[str, Any]) -> dict[str, Any]:
         "tools": sorted(tools),
         "provider_account_ids": sorted(accounts),
         "models": sorted(models),
+        "local_models": sorted(local_models),
+        "model_sources": sorted(model_sources),
         "may_mutate": not tools or bool(tools & mutation_names) or any(name.startswith("mcp__") for name in tools),
         "prompt_characters": prompts,
         "prompt_digest": _digest(prompt_material),
@@ -1112,6 +1201,7 @@ class LangGraphEngine:
         self.side_effects = SideEffectCoordinator()
         self._credentials: dict[str, dict[str, dict[str, Any]]] = {}
         self._pending_decisions: dict[str, dict[str, str]] = {}
+        self._ollama_clients: dict[str, OllamaClient] = {}
         self._active_run_id = ""
         self._guard = threading.RLock()
 
@@ -1153,6 +1243,155 @@ class LangGraphEngine:
     def required_accounts(self, workflow: dict[str, Any]) -> list[str]:
         return list(workflow_capabilities(workflow).get("provider_account_ids") or [])
 
+    def _ollama_host(self) -> str:
+        return str(self.core.config.get("host") or DEFAULT_HOST).rstrip("/")
+
+    def _ollama_client(self) -> OllamaClient:
+        host = self._ollama_host()
+        with self._guard:
+            client = self._ollama_clients.get(host)
+            if client is None:
+                client = OllamaClient(host)
+                self._ollama_clients[host] = client
+            return client
+
+    def _remembered_local_window(self, model: str) -> int:
+        windows = self.core.config.get("model_windows")
+        if not isinstance(windows, dict):
+            return 0
+        value = windows.get(f"{self._ollama_host()}|{model}")
+        return value if isinstance(value, int) and value > 0 else 0
+
+    def _remember_local_window(self, model: str, window: int) -> None:
+        if not model or window <= 0:
+            return
+        with self._guard:
+            current = self.core.config.get("model_windows")
+            windows = dict(current) if isinstance(current, dict) else {}
+            key = f"{self._ollama_host()}|{model}"
+            if windows.get(key) == window:
+                return
+            windows[key] = window
+            self.core.config["model_windows"] = windows
+            save_config(self.core.config)
+
+    def _local_context(
+        self,
+        client: OllamaClient,
+        model: str,
+    ) -> tuple[int, dict[str, Any] | None]:
+        configured = context_window(self.core.config.get("context_window"))
+        loaded = 0 if configured > 0 else client.loaded_context_length(model)
+        if loaded > 0:
+            self._remember_local_window(model, loaded)
+        trained = client.context_length(model)
+        limit = effective_context_length(loaded, trained, configured)
+        if limit <= 0:
+            limit = self._remembered_local_window(model)
+        options = {"num_ctx": limit} if configured > 0 and limit > 0 else None
+        return limit, options
+
+    def local_model_catalog(self) -> dict[str, Any]:
+        """Return the configured Ollama catalog even while the session uses a remote account."""
+        host = self._ollama_host()
+        client = self._ollama_client()
+        try:
+            raw = client.list_models()
+            resident: dict[str, int] = {}
+            try:
+                for entry in client.running_models():
+                    window = entry.get("context_length")
+                    if isinstance(window, int) and window > 0:
+                        for key in (entry.get("name"), entry.get("model")):
+                            if key:
+                                resident[str(key)] = window
+            except OllamaError:
+                pass
+            models: list[dict[str, Any]] = []
+            configured = context_window(self.core.config.get("context_window"))
+            for entry in raw:
+                name = str(entry.get("name") or entry.get("model") or "")
+                if not name:
+                    continue
+                trained = client.context_length(name)
+                window = effective_context_length(resident.get(name, 0), trained, configured)
+                if window <= 0:
+                    window = self._remembered_local_window(name)
+                details = entry.get("details") if isinstance(entry.get("details"), dict) else {}
+                models.append({
+                    "name": name,
+                    "size": entry.get("size") or 0,
+                    "parameter_size": details.get("parameter_size") or "",
+                    "context_length": window,
+                    "trained_context_length": trained,
+                })
+            return {"available": True, "host": host, "models": models, "error": ""}
+        except OllamaError as exc:
+            return {"available": False, "host": host, "models": [], "error": str(exc)[:1000]}
+
+    def local_preflight_issues(self, workflow: dict[str, Any]) -> list[dict[str, str]]:
+        local_nodes = [
+            node for node in workflow.get("nodes") or []
+            if str(((node.get("config") or {}).get("model_binding") or {}).get("source") or "") == "ollama"
+        ]
+        if not local_nodes:
+            return []
+        client = self._ollama_client()
+        issues: list[dict[str, str]] = []
+        try:
+            installed = {
+                str(item.get("name") or item.get("model") or "")
+                for item in client.list_models()
+            }
+        except OllamaError as exc:
+            for node in local_nodes:
+                binding = (node.get("config") or {}).get("model_binding") or {}
+                issues.append({
+                    "node_id": str(node.get("id") or ""),
+                    "node_label": str(node.get("label") or node.get("id") or "Model node"),
+                    "source": "ollama",
+                    "model": str(binding.get("model") or ""),
+                    "reason": "ollama_unreachable",
+                    "message": f"Ollama is unavailable at {self._ollama_host()}: {exc}",
+                })
+            return issues
+        for node in local_nodes:
+            config = node.get("config") or {}
+            binding = config.get("model_binding") or {}
+            model = str(binding.get("model") or "")
+            base = {
+                "node_id": str(node.get("id") or ""),
+                "node_label": str(node.get("label") or node.get("id") or "Model node"),
+                "source": "ollama",
+                "model": model,
+            }
+            if model not in installed:
+                issues.append({
+                    **base,
+                    "reason": "model_missing",
+                    "message": f"Local model {model!r} is not installed in Ollama.",
+                })
+            elif node.get("type") == "agent" and config.get("tools") and not client.supports_tools(model):
+                issues.append({
+                    **base,
+                    "reason": "tools_unsupported",
+                    "message": f"Local model {model!r} does not support the tools exposed by this Agent node.",
+                })
+        return issues
+
+    def preflight_local_models(
+        self,
+        workflow: dict[str, Any],
+        *,
+        run_id: str = "",
+    ) -> None:
+        issues = self.local_preflight_issues(workflow)
+        if not issues:
+            return
+        error = GraphPreflightError(str(workflow.get("id") or ""), issues, run_id=run_id)
+        self.core._emit(error.event())
+        raise error
+
     def start(
         self,
         goal: str,
@@ -1174,6 +1413,7 @@ class LangGraphEngine:
         if current and current.get("id") != existing_run_id:
             raise WorkflowError("another graph run is active")
         run_id = existing_run_id or uuid.uuid4().hex
+        self.preflight_local_models(workflow, run_id=existing_run_id)
         supplied = {
             str(item.get("account_id") or ""): self._sanitize_credential(item)
             for item in credentials or []
@@ -1293,6 +1533,7 @@ class LangGraphEngine:
         if unanswered:
             self._emit_interrupt(run_id, unanswered[0])
             return True, None
+        self.preflight_local_models(run["workflow"], run_id=run_id)
         self._prepare_run_context(run)
         result = self._execute(
             run_id, run["workflow"], run["goal"], run["mode"],
@@ -1314,6 +1555,7 @@ class LangGraphEngine:
             raise WorkflowError(
                 "this run has an uncertain external side effect; inspect it and explicitly discard or retry it"
             )
+        self.preflight_local_models(current, run_id=run_id)
         missing = [account for account in self.required_accounts(current) if account not in self._credentials.get(run_id, {})]
         if missing:
             self.runs.update(run_id, status="awaiting_credentials", state={**run["state"], "required_account_ids": missing})
@@ -1593,7 +1835,10 @@ class LangGraphEngine:
         node_id = str(node["id"])
         node_type = str(node["type"])
         config = dict(node.get("config") or {})
-        client, model, context_limit = self._provider_for(node, run_id)
+        provider = self._provider_for(node, run_id)
+        client = provider.client
+        model = provider.model
+        context_limit = provider.context_limit
         system = self.core.system_message().get("content", "")
         prompt = str(config.get("prompt") or "")
         if mode == "plan":
@@ -1618,6 +1863,7 @@ class LangGraphEngine:
             event = {
                 "run_id": run_id, "node_id": node_id, "agent": node["label"],
                 "text": token, "model": model, "context_limit": context_limit,
+                "model_source": provider.source, "model_label": provider.label,
                 "final_node": final_node,
             }
             if final_node:
@@ -1636,8 +1882,14 @@ class LangGraphEngine:
             on_token=on_token,
             should_stop=self.core._interrupt.is_set,
             on_thinking=on_thinking,
-            options=self.core.chat_options() if client is self.core.client else {},
+            options=provider.options or {},
         )
+        if provider.source == "ollama":
+            # A model that was cold at preflight now has an authoritative
+            # resident window. Remember it for recovery and future runs.
+            refreshed_limit, _ = self._local_context(client, model)
+            if refreshed_limit > 0:
+                context_limit = refreshed_limit
         if final_node:
             self.core._emit({"type": "message_end", "run_id": run_id, "node_id": node_id, "agent": node["label"]})
         content = response.content or "".join(content_parts)
@@ -1645,6 +1897,8 @@ class LangGraphEngine:
             "prompt_tokens": int(response.prompt_eval_count or 0),
             "completion_tokens": int(response.eval_count or 0),
             "model": model,
+            "model_source": provider.source,
+            "model_label": provider.label,
             "context_limit": context_limit,
         }
         self.core._emit({
@@ -1654,6 +1908,8 @@ class LangGraphEngine:
             "agent": node["label"],
             "text": "",
             "model": model,
+            "model_source": provider.source,
+            "model_label": provider.label,
             "context_limit": context_limit,
             "prompt_tokens": usage["prompt_tokens"],
             "completion_tokens": usage["completion_tokens"],
@@ -1817,12 +2073,32 @@ class LangGraphEngine:
 
         return self.side_effects.run(not initial_read_only, authorize_and_execute)
 
-    def _provider_for(self, node: dict[str, Any], run_id: str) -> tuple[Any, str, int]:
+    def _provider_for(self, node: dict[str, Any], run_id: str) -> ResolvedModelBinding:
         binding = (node.get("config") or {}).get("model_binding") or {}
         account_id = str(binding.get("account_id") or "")
         requested_model = str(binding.get("model") or "")
-        if not account_id:
-            return self.core.client, requested_model or self.core.model, self.core.context_limit
+        source = str(binding.get("source") or ("account" if account_id else "inherit"))
+        display_hint = str(binding.get("display_hint") or "")
+        if source == "inherit":
+            return ResolvedModelBinding(
+                client=self.core.client,
+                source="inherit",
+                model=requested_model or self.core.model,
+                context_limit=self.core.context_limit,
+                options=self.core.chat_options(),
+                label=display_hint or "Inherited session model",
+            )
+        if source == "ollama":
+            client = self._ollama_client()
+            context_limit, options = self._local_context(client, requested_model)
+            return ResolvedModelBinding(
+                client=client,
+                source="ollama",
+                model=requested_model,
+                context_limit=context_limit,
+                options=options,
+                label=display_hint or "Local Ollama",
+            )
         credential = self._credentials.get(run_id, {}).get(account_id)
         if credential is None:
             raise WorkflowError(f"provider credentials are missing for account {account_id}")
@@ -1830,7 +2106,15 @@ class LangGraphEngine:
         model = requested_model or str(credential.get("model") or "")
         context_limit = int(credential.get("context_window") or 0)
         if provider == "ollama":
-            return OllamaClient(str(credential.get("host") or self.core.host)), model, context_limit
+            client = OllamaClient(str(credential.get("host") or self._ollama_host()))
+            return ResolvedModelBinding(
+                client=client,
+                source="account",
+                model=model,
+                context_limit=context_limit,
+                options={"num_ctx": context_limit} if context_limit > 0 else None,
+                label=display_hint or str(credential.get("account_label") or "Model account"),
+            )
         client = RemoteClient(
             base_url=str(credential.get("base_url") or ""),
             api_key=str(credential.get("api_key") or ""),
@@ -1838,7 +2122,14 @@ class LangGraphEngine:
             auth_style=str(credential.get("auth_style") or ""),
             lists_models=bool(credential.get("lists_models", True)),
         )
-        return client, model, context_limit
+        return ResolvedModelBinding(
+            client=client,
+            source="account",
+            model=model,
+            context_limit=context_limit,
+            options=None,
+            label=display_hint or str(credential.get("account_label") or "Model account"),
+        )
 
     def _schemas_for(self, requested: list[str], mode: str, run_id: str) -> list[dict[str, Any]]:
         snapshot = (self.runs.get(run_id).get("state") or {}).get("tool_schema_snapshot") or {}

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -40,7 +40,12 @@ from .config import (
 )
 from .core import AgentCore
 from .extensions import ExtensionError
-from .langgraph_runtime import WorkflowError, validate_workflow, workflow_capabilities
+from .langgraph_runtime import (
+    GraphPreflightError,
+    WorkflowError,
+    validate_workflow,
+    workflow_capabilities,
+)
 from .ollama import OllamaError, effective_context_length
 from .sessions import (
     SessionMeta,
@@ -591,6 +596,11 @@ def _workflow_failure(exc: WorkflowError) -> HTTPException:
 @app.get("/api/langgraph")
 def get_langgraph() -> dict[str, Any]:
     return service().core.langgraph_engine.snapshot()
+
+
+@app.get("/api/langgraph/models")
+def get_langgraph_models() -> dict[str, Any]:
+    return service().core.langgraph_engine.local_model_catalog()
 
 
 @app.get("/api/langgraph/workflows")
@@ -1305,6 +1315,7 @@ def _run_independent_graph(
         workflow = svc.core.langgraph_engine.registry.get(workflow_id, require_trust=True)
         if mode not in workflow["supported_modes"]:
             raise WorkflowError(f"{workflow['name']} does not support {mode.title()} mode")
+        svc.core.langgraph_engine.preflight_local_models(workflow)
         svc.core.new_session(reason="workflow_run")
         svc.core.langgraph_engine.start(text, mode, workflow_id, svc.decide)
     except WorkflowError as exc:
@@ -1326,6 +1337,16 @@ def _run_graph_operation(
 
 
 def _report_graph_failure(svc: ChatService, error: Exception, run_id: str = "") -> None:
+    if isinstance(error, GraphPreflightError):
+        # The engine already emitted a structured, actionable failure. Avoid
+        # duplicating it as a generic chat error or manufacturing a failed run.
+        svc.core._emit({
+            "type": "turn_done",
+            "reason": "error",
+            "duration_ms": 0,
+            **({"run_id": run_id} if run_id else {}),
+        })
+        return
     message = svc.core.langgraph_engine._redact(str(error), run_id) if run_id else str(error)[:4000]
     svc.core._emit({"type": "error", "message": message, **({"run_id": run_id} if run_id else {})})
     if run_id:

--- a/agent/tests/test_langgraph.py
+++ b/agent/tests/test_langgraph.py
@@ -15,12 +15,14 @@ from ollama_code import extensions as extensions_mod
 from ollama_code import sessions as sessions_mod
 from ollama_code.core import AgentCore
 from ollama_code.langgraph_runtime import (
+    GraphPreflightError,
     GraphRunStore,
     SideEffectCoordinator,
     WorkflowError,
     WorkflowRegistry,
     builtin_templates,
     validate_workflow,
+    workflow_capabilities,
 )
 from ollama_code.ollama import ChatResponse
 
@@ -101,6 +103,37 @@ class WorkflowClient:
         return [{"name": "test-model"}]
 
 
+class LocalWorkflowClient(WorkflowClient):
+    def __init__(self, models=("local-model",), *, loaded=32_768):
+        super().__init__()
+        self.models = list(models)
+        self.loaded = loaded
+        self.host = "http://local-ollama:11434"
+        self.options: list[dict | None] = []
+
+    def list_models(self):
+        return [{"name": name, "details": {"parameter_size": "8B"}} for name in self.models]
+
+    def running_models(self):
+        return [
+            {"name": name, "model": name, "context_length": self.loaded}
+            for name in self.models if self.loaded > 0
+        ]
+
+    def context_length(self, name):
+        return 32_768
+
+    def loaded_context_length(self, name):
+        return self.loaded if name in self.models else 0
+
+    def supports_tools(self, name):
+        return name != "no-tools"
+
+    def chat_stream(self, *args, **kwargs):
+        self.options.append(kwargs.get("options"))
+        return super().chat_stream(*args, **kwargs)
+
+
 def graph_core(tmp_path: Path, *, delay: float = 0.0) -> tuple[AgentCore, WorkflowClient, list[dict]]:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
@@ -121,6 +154,125 @@ def test_builtin_templates_have_typed_ports_and_validate():
         assert len([node for node in workflow["nodes"] if node["type"] == "input"]) == 1
         assert any(node["type"] == "final" for node in workflow["nodes"])
         assert all("input_ports" in node and "output_ports" in node for node in workflow["nodes"])
+
+
+def test_model_binding_schema_is_additive_and_validates_sources():
+    legacy = builtin_templates()[0]
+    final = next(node for node in legacy["nodes"] if node["type"] == "final")
+    final["config"]["model_binding"] = {
+        "account_id": "remote-account",
+        "model": "remote-model",
+    }
+    normalized = validate_workflow(legacy)
+    binding = next(node for node in normalized["nodes"] if node["type"] == "final")["config"]["model_binding"]
+    assert "source" not in binding, "legacy workflow digests must remain stable"
+    capabilities = workflow_capabilities(normalized)
+    assert capabilities["model_sources"] == ["account", "inherit"]
+    assert "account:remote-account:remote-model" in capabilities["models"]
+
+    local = builtin_templates()[0]
+    final = next(node for node in local["nodes"] if node["type"] == "final")
+    final["config"]["model_binding"] = {"source": "ollama", "model": "qwen3:8b"}
+    capabilities = workflow_capabilities(validate_workflow(local))
+    assert capabilities["local_models"] == ["qwen3:8b"]
+    assert "ollama:qwen3:8b" in capabilities["models"]
+
+    invalid = builtin_templates()[0]
+    next(node for node in invalid["nodes"] if node["type"] == "final")["config"]["model_binding"] = {
+        "source": "ollama"
+    }
+    with pytest.raises(WorkflowError, match="needs an Ollama model"):
+        validate_workflow(invalid)
+
+    invalid = builtin_templates()[0]
+    next(node for node in invalid["nodes"] if node["type"] == "final")["config"]["model_binding"] = {
+        "source": "account"
+    }
+    with pytest.raises(WorkflowError, match="needs an account_id"):
+        validate_workflow(invalid)
+
+
+def test_explicit_ollama_nodes_ignore_active_remote_provider_and_send_local_options(tmp_path):
+    core, remote, events = graph_core(tmp_path)
+    core.provider = "remote"
+    core.host = "https://remote.example/v1"
+    core.config["provider"] = "remote"
+    core.config["host"] = "http://local-ollama:11434"
+    core.config["context_window"] = 16_384
+    local = LocalWorkflowClient(loaded=0)
+    core.langgraph_engine._ollama_clients["http://local-ollama:11434"] = local
+
+    workflow = builtin_templates()[0]
+    workflow["id"] = "local-workflow"
+    workflow["slug"] = "local-workflow"
+    for node in workflow["nodes"]:
+        if node["type"] in {"model", "supervisor", "agent", "final"}:
+            node["config"]["model_binding"] = {
+                "source": "ollama",
+                "model": "local-model",
+                "display_hint": "Local Ollama",
+            }
+    core.langgraph_engine.registry.save(workflow, "global")
+    result = core.langgraph_engine.start("Use my Mac", "build", "local-workflow")
+
+    assert result["status"] == "completed"
+    assert not remote.calls
+    assert local.calls
+    assert local.options and all(item == {"num_ctx": 16_384} for item in local.options)
+    usage = [event for event in events if event["type"] == "graph_node_token" and event.get("model")]
+    assert usage
+    assert all(event["model"] == "local-model" for event in usage)
+    assert all(event["model_source"] == "ollama" for event in usage)
+
+
+def test_missing_local_model_blocks_before_run_or_transcript_mutation(tmp_path):
+    core, _remote, events = graph_core(tmp_path)
+    core.config["host"] = "http://local-ollama:11434"
+    core.langgraph_engine._ollama_clients["http://local-ollama:11434"] = LocalWorkflowClient()
+    workflow = builtin_templates()[0]
+    workflow["id"] = "missing-local"
+    workflow["slug"] = "missing-local"
+    final = next(node for node in workflow["nodes"] if node["type"] == "final")
+    final["config"]["model_binding"] = {"source": "ollama", "model": "not-installed"}
+    core.langgraph_engine.registry.save(workflow, "global")
+    before = list(core.messages)
+
+    with pytest.raises(GraphPreflightError, match="not installed"):
+        core.langgraph_engine.start("Do not persist this", "build", "missing-local")
+
+    assert core.messages == before
+    assert core.langgraph_engine.runs.list() == []
+    assert core.langgraph_engine._credentials == {}
+    failure = next(event for event in events if event["type"] == "graph_preflight_failed")
+    assert failure["workflow_id"] == "missing-local"
+    assert failure["issues"][0]["reason"] == "model_missing"
+    assert not any(event["type"] in {"graph_run_started", "graph_credentials_required"} for event in events)
+
+
+def test_recovery_rechecks_local_model_without_changing_run_status(tmp_path):
+    core, _remote, events = graph_core(tmp_path)
+    core.config["host"] = "http://local-ollama:11434"
+    core.langgraph_engine._ollama_clients["http://local-ollama:11434"] = LocalWorkflowClient(models=())
+    workflow = builtin_templates()[0]
+    workflow["id"] = "recover-local"
+    workflow["slug"] = "recover-local"
+    final = next(node for node in workflow["nodes"] if node["type"] == "final")
+    final["config"]["model_binding"] = {"source": "ollama", "model": "removed-model"}
+    normalized = validate_workflow(workflow)
+    run = core.langgraph_engine.runs.create(
+        run_id="recover-run",
+        session_id=core.session.session_id,
+        workflow=normalized,
+        mode="build",
+        goal="Resume safely",
+        status="interrupted",
+    )
+
+    with pytest.raises(GraphPreflightError):
+        core.langgraph_engine.resume(run["id"])
+
+    assert core.langgraph_engine.runs.get(run["id"])["status"] == "interrupted"
+    assert next(event for event in events if event["type"] == "graph_preflight_failed")["run_id"] == run["id"]
 
 
 def test_validation_rejects_unsafe_routes_mismatched_ports_and_secrets():
@@ -167,11 +319,16 @@ def test_project_workflow_shadows_global_and_digest_change_revokes_trust(tmp_pat
     changed["description"] = "Changed after trust"
     changed["nodes"][2]["config"]["prompt"] = "Use the Linear MCP server"
     changed["nodes"][2]["config"]["tools"] = ["mcp__linear__update_issue"]
+    changed["nodes"][2]["config"]["model_binding"] = {
+        "source": "ollama",
+        "model": "qwen3:8b",
+    }
     path.write_text(json.dumps(changed))
     changed_item = registry.get("single-agent")
     assert changed_item["trusted"] is False
     assert changed_item["capability_diff"]["prompts_changed"] is True
     assert changed_item["capability_diff"]["tools_added"] == ["mcp__linear__update_issue"]
+    assert "ollama:qwen3:8b" in changed_item["capability_diff"]["models_added"]
     assert changed_item["capability_diff"]["mutation_after"] is True
     with pytest.raises(WorkflowError, match="trust"):
         registry.get("single-agent", require_trust=True)
@@ -419,11 +576,18 @@ def test_langgraph_rest_catalog_validation_and_uncertain_resolution(tmp_path):
     from ollama_code import server as server_mod
 
     core, _client, _events = graph_core(tmp_path)
+    core.config["host"] = "http://local-ollama:11434"
+    core.langgraph_engine._ollama_clients["http://local-ollama:11434"] = LocalWorkflowClient()
     server_mod.app.state.service = server_mod.ChatService(core)
     with TestClient(server_mod.app) as client:
         status = client.get("/api/langgraph")
         assert status.status_code == 200
         assert status.json()["version"] == "1.2.9"
+
+        local_models = client.get("/api/langgraph/models")
+        assert local_models.status_code == 200
+        assert local_models.json()["available"] is True
+        assert local_models.json()["models"][0]["name"] == "local-model"
 
         catalog = client.get("/api/langgraph/workflows")
         assert catalog.status_code == 200


### PR DESCRIPTION
## Summary
- add explicit inherit, local Ollama, and remote-account model bindings to every model-capable workflow node
- preflight local availability, installed models, and Agent tool support before creating or resuming a run
- expose the configured Ollama catalog independently of the active composer provider
- add Graph Studio routing controls, unavailable-model recovery actions, and live Local/Remote/Inherited/Mixed labels
- preserve schema-v1 workflows, remote credentials, Classic sessions, and Just Chat boundaries

## Verification
- 239 backend tests
- Ruff backend lint
- macOS application build
- 178 Swift unit tests
- 25 macOS UI tests
- focused LangGraph local-model backend and UI coverage