### PR TITLE
Add live team progress and reliable cancellation

### DIFF
--- a/Locus/AgentTeams.swift
+++ b/Locus/AgentTeams.swift
@@ -308,7 +308,12 @@ struct AgentTeam: Identifiable, Codable, Hashable {
 
     mutating func clamp() {
         name = String(name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(64))
-        memberIDs = Array(Set(memberIDs)).prefix(32).map { $0 }
+        // Preserve the editor's order (dispatcher first in the common case)
+        // while removing duplicates. Converting through Set made the team
+        // model picker reshuffle on every save.
+        var seenMemberIDs: Set<UUID> = []
+        memberIDs = memberIDs.filter { seenMemberIDs.insert($0).inserted }
+        memberIDs = Array(memberIDs.prefix(32))
         budget.clamp()
         if routingMode == .scorecard, routingWeights == nil { routingWeights = .init() }
         routingWeights?.normalize()
@@ -366,6 +371,37 @@ enum AgentTeamValidation {
         }
         for profile in team.memberIDs.compactMap({ byID[$0] }) where !profile.isConfigured {
             errors.append("Configure a model for \(profile.name.isEmpty ? "an agent" : profile.name).")
+        }
+        return Array(Set(errors)).sorted()
+    }
+
+    /// Validate saved agent models against catalogs the provider has actually
+    /// reported. An account's display name is intentionally not evidence that
+    /// its endpoint serves a similarly named model.
+    static func routeErrors(
+        team: AgentTeam,
+        profiles: [AgentProfile],
+        accounts: [ProviderAccount],
+        accountModels: [UUID: [String]]
+    ) -> [String] {
+        let byID = Dictionary(uniqueKeysWithValues: profiles.map { ($0.id, $0) })
+        let accountsByID = Dictionary(uniqueKeysWithValues: accounts.map { ($0.id, $0) })
+        var errors: [String] = []
+
+        for profile in team.memberIDs.compactMap({ byID[$0] }) {
+            guard case .providerAccount(let accountID) = profile.route,
+                  let account = accountsByID[accountID],
+                  account.kind.listsModels,
+                  let reported = accountModels[accountID],
+                  !reported.isEmpty,
+                  !reported.contains(where: {
+                      $0.caseInsensitiveCompare(profile.model) == .orderedSame
+                  })
+            else { continue }
+
+            errors.append(
+                "\(profile.name) is set to \(profile.model), but \(account.displayName) does not report that model. Choose one from the model picker."
+            )
         }
         return Array(Set(errors)).sorted()
     }

--- a/Locus/AgentTeamsSettingsView.swift
+++ b/Locus/AgentTeamsSettingsView.swift
@@ -474,7 +474,53 @@ private struct AgentProfileEditor: View {
                     Text(account.displayName).tag(AgentRoute.providerAccount(account.id))
                 }
             }
-            TextField("Exact model", text: $draft.model)
+            LabeledContent("Model") {
+                HStack(spacing: 7) {
+                    if modelChoices.isEmpty {
+                        TextField("Exact model ID", text: $draft.model)
+                            .textFieldStyle(.roundedBorder)
+                            .accessibilityIdentifier("agent.model.manual")
+                    } else {
+                        Picker("Model", selection: $draft.model) {
+                            if modelSelectionUnavailable {
+                                Text("\(draft.model) — unavailable")
+                                    .tag(draft.model)
+                            }
+                            Text("Choose a model…").tag("")
+                            ForEach(modelChoices, id: \.self) { name in
+                                Text(name).tag(name)
+                            }
+                        }
+                        .labelsHidden()
+                        .accessibilityIdentifier("agent.model.picker")
+                    }
+                    Button {
+                        Task { await refreshModels() }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Refresh models from this provider")
+                    .accessibilityLabel("Refresh provider models")
+                    .accessibilityIdentifier("agent.model.refresh")
+                }
+            }
+            if modelSelectionUnavailable {
+                Label(
+                    "This provider does not report \(draft.model). Choose a model from the menu before saving.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.system(size: 9))
+                .foregroundStyle(LocusTheme.coral)
+            } else if modelChoices.isEmpty {
+                Text("This provider cannot list models, so enter its exact API model ID.")
+                    .font(.system(size: 8))
+                    .foregroundStyle(LocusTheme.muted)
+            } else {
+                Text("Only models reported by the selected provider are shown.")
+                    .font(.system(size: 8))
+                    .foregroundStyle(LocusTheme.muted)
+            }
             Picker("Access ceiling", selection: $draft.accessCeiling) {
                 ForEach(AgentAccessCeiling.allCases) { Text($0.title).tag($0) }
             }
@@ -540,10 +586,60 @@ private struct AgentProfileEditor: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(LocusTheme.ink)
+                .disabled(
+                    draft.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        || modelSelectionUnavailable
+                )
             }
         }
         .padding(20)
         .frame(width: 600, height: 720)
+        .task { await refreshModels() }
+        .onChange(of: draft.route) { _, _ in
+            draft.model = ""
+            connectionResult = nil
+            Task { await refreshModels() }
+        }
+    }
+
+    private var modelChoices: [String] {
+        let values: [String]
+        switch draft.route {
+        case .localOllama:
+            values = model.localModels.map(\.name)
+        case .providerAccount(let id):
+            guard let account = model.providerAccounts.first(where: { $0.id == id }) else {
+                return []
+            }
+            if account.kind.listsModels,
+               let reported = model.accountModels[id],
+               !reported.isEmpty
+            {
+                values = reported
+            } else {
+                values = [account.preferredModel] + account.kind.curatedModels
+            }
+        }
+        var seen: Set<String> = []
+        return values.filter { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !trimmed.isEmpty && seen.insert(trimmed.lowercased()).inserted
+        }
+    }
+
+    private var modelSelectionUnavailable: Bool {
+        !draft.model.isEmpty && !modelChoices.isEmpty && !modelChoices.contains(where: {
+            $0.caseInsensitiveCompare(draft.model) == .orderedSame
+        })
+    }
+
+    private func refreshModels() async {
+        switch draft.route {
+        case .localOllama:
+            await model.refreshMetadata()
+        case .providerAccount:
+            await model.refreshAccountCatalogs(force: true)
+        }
     }
 
     private func csv(_ value: String) -> [String] {
@@ -571,88 +667,99 @@ private struct AgentTeamEditor: View {
     }
 
     var body: some View {
-        Form {
-            TextField("Team name", text: $draft.name)
-            Section("Members") {
-                ForEach(model.agentProfiles) { profile in
-                    Toggle(isOn: Binding(
-                        get: { draft.memberIDs.contains(profile.id) },
-                        set: { included in
-                            if included { draft.memberIDs.append(profile.id) }
-                            else { draft.memberIDs.removeAll { $0 == profile.id } }
+        let errors = AgentTeamValidation.errors(team: draft, profiles: model.agentProfiles)
+        VStack(spacing: 0) {
+            ScrollView {
+                Form {
+                    TextField("Team name", text: $draft.name)
+                    Section("Members") {
+                        ForEach(model.agentProfiles) { profile in
+                            Toggle(isOn: Binding(
+                                get: { draft.memberIDs.contains(profile.id) },
+                                set: { included in
+                                    if included { draft.memberIDs.append(profile.id) }
+                                    else { draft.memberIDs.removeAll { $0 == profile.id } }
+                                }
+                            )) {
+                                Text("\(profile.name) · \(profile.role.title)")
+                            }
                         }
-                    )) {
-                        Text("\(profile.name) · \(profile.role.title)")
+                    }
+                    Picker("Dispatcher", selection: $draft.dispatcherID) {
+                        Text("Choose…").tag(nil as UUID?)
+                        ForEach(memberProfiles.filter { $0.role == .dispatcher }) {
+                            Text($0.name).tag($0.id as UUID?)
+                        }
+                    }
+                    Picker("Fallback dispatcher", selection: $draft.fallbackDispatcherID) {
+                        Text("None").tag(nil as UUID?)
+                        ForEach(memberProfiles.filter { $0.role == .dispatcher }) {
+                            Text($0.name).tag($0.id as UUID?)
+                        }
+                    }
+                    Picker("Default writer", selection: $draft.defaultWriterID) {
+                        Text("Choose…").tag(nil as UUID?)
+                        ForEach(memberProfiles.filter { $0.accessCeiling.canWrite }) {
+                            Text($0.name).tag($0.id as UUID?)
+                        }
+                    }
+                    Toggle("Use isolated managed worktree for new Git tasks", isOn: $draft.useManagedWorktree)
+                    Section("Dispatch and routing") {
+                        Picker("Plan approval", selection: Binding(
+                            get: { draft.resolvedDispatchApprovalMode },
+                            set: { draft.dispatchApprovalMode = $0 }
+                        )) {
+                            ForEach(DispatchApprovalMode.allCases) { Text($0.title).tag($0) }
+                        }
+                        Picker("Specialist routing", selection: Binding(
+                            get: { draft.resolvedRoutingMode },
+                            set: { draft.routingMode = $0 }
+                        )) {
+                            ForEach(AgentRoutingMode.allCases) { Text($0.title).tag($0) }
+                        }
+                        TextField("Evaluation tags", text: $evaluationTags, prompt: Text("swift, security, tests"))
+                        TextField(
+                            "Maximum estimated cost",
+                            value: $draft.maximumEstimatedCost,
+                            format: .currency(code: "USD")
+                        )
+                        if draft.resolvedRoutingMode == .scorecard {
+                            scoreWeight("Quality", \.quality)
+                            scoreWeight("Reliability", \.reliability)
+                            scoreWeight("Privacy/locality", \.privacy)
+                            scoreWeight("Latency", \.latency)
+                            scoreWeight("Cost", \.cost)
+                            Text("Weights are normalized to 100% when saved. Limited data is shown until five comparable evaluations exist.")
+                                .font(.system(size: 8))
+                                .foregroundStyle(LocusTheme.muted)
+                        }
+                    }
+                    Section("Hard budgets") {
+                        Stepper("Delegated jobs: \(draft.budget.maxJobs)", value: $draft.budget.maxJobs, in: 1...16)
+                        Stepper("Orchestration rounds: \(draft.budget.maxRounds)", value: $draft.budget.maxRounds, in: 1...8)
+                        Stepper("Model calls: \(draft.budget.maxModelCalls)", value: $draft.budget.maxModelCalls, in: 1...48)
+                        Stepper("Concurrent calls: \(draft.budget.maxConcurrentCalls)", value: $draft.budget.maxConcurrentCalls, in: 1...8)
+                        Stepper("Metered tokens: \(draft.budget.maxMeteredTokens.formatted())", value: $draft.budget.maxMeteredTokens, in: 1_000...2_000_000, step: 10_000)
+                    }
+                    if !errors.isEmpty {
+                        ForEach(errors, id: \.self) { error in
+                            Label(error, systemImage: "exclamationmark.triangle.fill")
+                                .foregroundStyle(LocusTheme.coral)
+                                .font(.system(size: 9))
+                        }
                     }
                 }
+                .padding(20)
+                .fixedSize(horizontal: false, vertical: true)
             }
-            Picker("Dispatcher", selection: $draft.dispatcherID) {
-                Text("Choose…").tag(nil as UUID?)
-                ForEach(memberProfiles.filter { $0.role == .dispatcher }) {
-                    Text($0.name).tag($0.id as UUID?)
-                }
-            }
-            Picker("Fallback dispatcher", selection: $draft.fallbackDispatcherID) {
-                Text("None").tag(nil as UUID?)
-                ForEach(memberProfiles.filter { $0.role == .dispatcher }) {
-                    Text($0.name).tag($0.id as UUID?)
-                }
-            }
-            Picker("Default writer", selection: $draft.defaultWriterID) {
-                Text("Choose…").tag(nil as UUID?)
-                ForEach(memberProfiles.filter { $0.accessCeiling.canWrite }) {
-                    Text($0.name).tag($0.id as UUID?)
-                }
-            }
-            Toggle("Use isolated managed worktree for new Git tasks", isOn: $draft.useManagedWorktree)
-            Section("Dispatch and routing") {
-                Picker("Plan approval", selection: Binding(
-                    get: { draft.resolvedDispatchApprovalMode },
-                    set: { draft.dispatchApprovalMode = $0 }
-                )) {
-                    ForEach(DispatchApprovalMode.allCases) { Text($0.title).tag($0) }
-                }
-                Picker("Specialist routing", selection: Binding(
-                    get: { draft.resolvedRoutingMode },
-                    set: { draft.routingMode = $0 }
-                )) {
-                    ForEach(AgentRoutingMode.allCases) { Text($0.title).tag($0) }
-                }
-                TextField("Evaluation tags", text: $evaluationTags, prompt: Text("swift, security, tests"))
-                TextField(
-                    "Maximum estimated cost",
-                    value: $draft.maximumEstimatedCost,
-                    format: .currency(code: "USD")
-                )
-                if draft.resolvedRoutingMode == .scorecard {
-                    scoreWeight("Quality", \.quality)
-                    scoreWeight("Reliability", \.reliability)
-                    scoreWeight("Privacy/locality", \.privacy)
-                    scoreWeight("Latency", \.latency)
-                    scoreWeight("Cost", \.cost)
-                    Text("Weights are normalized to 100% when saved. Limited data is shown until five comparable evaluations exist.")
-                        .font(.system(size: 8))
-                        .foregroundStyle(LocusTheme.muted)
-                }
-            }
-            Section("Hard budgets") {
-                Stepper("Delegated jobs: \(draft.budget.maxJobs)", value: $draft.budget.maxJobs, in: 1...16)
-                Stepper("Orchestration rounds: \(draft.budget.maxRounds)", value: $draft.budget.maxRounds, in: 1...8)
-                Stepper("Model calls: \(draft.budget.maxModelCalls)", value: $draft.budget.maxModelCalls, in: 1...48)
-                Stepper("Concurrent calls: \(draft.budget.maxConcurrentCalls)", value: $draft.budget.maxConcurrentCalls, in: 1...8)
-                Stepper("Metered tokens: \(draft.budget.maxMeteredTokens.formatted())", value: $draft.budget.maxMeteredTokens, in: 1_000...2_000_000, step: 10_000)
-            }
-            let errors = AgentTeamValidation.errors(team: draft, profiles: model.agentProfiles)
-            if !errors.isEmpty {
-                ForEach(errors, id: \.self) { error in
-                    Label(error, systemImage: "exclamationmark.triangle.fill")
-                        .foregroundStyle(LocusTheme.coral)
-                        .font(.system(size: 9))
-                }
-            }
+            .accessibilityIdentifier("teamEditor.scroll")
+
+            Divider()
+
             HStack {
                 Spacer()
                 Button("Cancel") { dismiss() }
+                    .accessibilityIdentifier("teamEditor.cancel")
                 Button("Save") {
                     draft.evaluationTags = evaluationTags.split(separator: ",").map(String.init)
                     draft.clamp()
@@ -661,10 +768,13 @@ private struct AgentTeamEditor: View {
                     .buttonStyle(.borderedProminent)
                     .tint(LocusTheme.ink)
                     .disabled(!errors.isEmpty)
+                    .accessibilityIdentifier("teamEditor.save")
             }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 14)
+            .background(LocusTheme.paper)
         }
-        .padding(20)
-        .frame(width: 620, height: 760)
+        .frame(width: 620, height: 680)
     }
 
     private var memberProfiles: [AgentProfile] {

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -45,6 +45,7 @@ final class AppModel: ObservableObject {
     @Published private(set) var orchestrationState: TeamRunState?
     @Published private(set) var activeWorkerID: String?
     @Published private(set) var taskConversationStates: [String: TaskConversationState] = [:]
+    @Published private(set) var dispatcherActivity: AgentActivity?
     @Published private(set) var agentActivities: [AgentActivity] = []
     @Published private(set) var teamModelCalls = 0
     @Published private(set) var teamMeteredTokens = 0
@@ -199,6 +200,30 @@ final class AppModel: ObservableObject {
     private var taskWorkers: [String: TaskWorkerRuntime] = [:]
     private var conversationBackend: BackendService {
         taskWorkers[currentSessionID]?.service ?? backend
+    }
+
+    /// Team chats execute in dedicated worker processes. Run controls must go
+    /// back to the worker that owns the run; sending them to the main control
+    /// service can update the shared run database without interrupting the
+    /// model call, which makes a cancelled approval reappear on reconnect.
+    private func orchestrationBackend(for runID: String) -> BackendService {
+        guard let sessionID = Self.orchestrationOwnerSessionID(
+            for: runID,
+            currentSessionID: currentSessionID,
+            currentRunID: orchestrationRunID,
+            states: taskConversationStates
+        ) else { return backend }
+        return taskWorkers[sessionID]?.service ?? backend
+    }
+
+    static func orchestrationOwnerSessionID(
+        for runID: String,
+        currentSessionID: String,
+        currentRunID: String?,
+        states: [String: TaskConversationState]
+    ) -> String? {
+        if currentRunID == runID { return currentSessionID }
+        return states.first(where: { $0.value.runID == runID })?.key
     }
     private let ollamaRuntime = OllamaRuntime()
     private let mcpAuthCoordinator = MCPAuthCoordinator()
@@ -557,10 +582,35 @@ final class AppModel: ObservableObject {
     /// The closed picker's label. With an account it leads with the account's
     /// short name, because the model name alone no longer says where it runs.
     var modelPickerLabel: String {
+        if let team = selectedAgentTeam {
+            let count = selectedTeamModelNames.count
+            return "\(team.name) · \(count) \(count == 1 ? "model" : "models")"
+        }
         guard let account = activeAccount else {
             return localModels.isEmpty && models.isEmpty ? "Auto" : selectedModel
         }
         return "\(account.shortName) · \(selectedModel)"
+    }
+
+    var selectedTeamModelNames: [String] {
+        guard let team = selectedAgentTeam else { return [] }
+        var seen: Set<String> = []
+        return team.memberIDs.compactMap { id in
+            guard let profile = agentProfiles.first(where: { $0.id == id }) else { return nil }
+            let key = profile.model.lowercased()
+            guard seen.insert(key).inserted else { return nil }
+            return profile.model
+        }
+    }
+
+    var selectedTeamRouteIssue: String? {
+        guard let team = selectedAgentTeam else { return nil }
+        return AgentTeamValidation.routeErrors(
+            team: team,
+            profiles: agentProfiles,
+            accounts: providerAccounts,
+            accountModels: accountModels
+        ).first
     }
 
     var modelPickerSections: [ModelPickerSection] {
@@ -2093,7 +2143,11 @@ final class AppModel: ObservableObject {
 
     func submitDraft() {
         if isBusy {
-            steerDraft()
+            if steeringState?.hasPrefix("Stopping") == true {
+                queueDraft()
+            } else {
+                steerDraft()
+            }
         } else {
             send(draftText)
         }
@@ -2104,7 +2158,11 @@ final class AppModel: ObservableObject {
     /// and continues the same turn without an intermediate `turn_done`.
     func steerDraft() {
         let text = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard isBusy, !hasPendingPermission, !text.isEmpty else { return }
+        guard isBusy,
+              steeringState?.hasPrefix("Stopping") != true,
+              !hasPendingPermission,
+              !text.isEmpty
+        else { return }
         guard conversationBackend.send(["type": "steer", "text": text]) else {
             showToast("Reconnect the local agent — the direction was not sent")
             return
@@ -2250,16 +2308,16 @@ final class AppModel: ObservableObject {
             return
         }
         computerControl.cancelPendingActions()
-        isBusy = false
         pendingRetry = false
+        steeringState = "Stopping the current run…"
         showToast("Stopping the current run")
     }
 
     var hasRunningWorkForQuit: Bool {
         isBusy || hasPendingPermission || orchestrationState.map {
-            ![.completed, .failed, .interrupted].contains($0)
+            ![.completed, .failed, .interrupted, .cancelled, .discarded].contains($0)
         } == true || taskConversationStates.values.contains {
-            ![.completed, .failed, .interrupted].contains($0.state)
+            ![.completed, .failed, .interrupted, .cancelled, .discarded].contains($0.state)
         }
     }
 
@@ -2722,6 +2780,16 @@ final class AppModel: ObservableObject {
             showToast(errors[0])
             return nil
         }
+        let routeErrors = AgentTeamValidation.routeErrors(
+            team: team,
+            profiles: agentProfiles,
+            accounts: providerAccounts,
+            accountModels: accountModels
+        )
+        guard routeErrors.isEmpty else {
+            showToast(routeErrors[0])
+            return nil
+        }
         let members = team.memberIDs.compactMap { id in agentProfiles.first(where: { $0.id == id }) }
         for profile in members {
             guard let accountID = profile.route.accountID else { continue }
@@ -2927,7 +2995,31 @@ final class AppModel: ObservableObject {
     }
 
     func cancelOrchestration(_ runID: String) {
-        orchestrationAction(path: "/api/orchestrations/\(runID)/cancel", runID: runID)
+        let transport = orchestrationBackend(for: runID)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let _: SimpleActionResponse = try await transport.post(
+                    "/api/orchestrations/\(runID)/cancel",
+                    body: [:],
+                    timeout: 30,
+                    as: SimpleActionResponse.self
+                )
+                if orchestrationRunID == runID {
+                    pendingDispatchPlan = nil
+                    orchestrationState = .cancelled
+                    steeringState = "Stopping the team run…"
+                    updateTaskConversation(
+                        state: .cancelled,
+                        event: ["run_id": runID]
+                    )
+                }
+                showToast("Stopping the team run")
+                await refreshOrchestrationRuns(select: runID)
+            } catch {
+                showToast("Could not stop the team run: \(error.localizedDescription)")
+            }
+        }
     }
 
     func discardOrchestration(_ runID: String) {
@@ -3082,9 +3174,13 @@ final class AppModel: ObservableObject {
 
     func decideDispatch(_ action: String, editedPlan: DispatchPlan? = nil) {
         guard let runID = orchestrationRunID else { return }
+        if action == "cancel" {
+            cancelOrchestration(runID)
+            return
+        }
         var payload: [String: Any] = ["type": "dispatch_decision", "run_id": runID, "action": action]
         if let editedPlan, let value = encodedJSONObject(editedPlan) { payload["plan"] = value }
-        guard backend.send(payload) else {
+        guard orchestrationBackend(for: runID).send(payload) else {
             showToast("The dispatch decision could not be delivered")
             return
         }
@@ -3172,10 +3268,11 @@ final class AppModel: ObservableObject {
         body: [String: Any] = [:],
         runID: String?
     ) {
+        let transport = runID.map(orchestrationBackend(for:)) ?? backend
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let _: SimpleActionResponse = try await backend.post(
+                let _: SimpleActionResponse = try await transport.post(
                     path, body: body, timeout: 30, as: SimpleActionResponse.self
                 )
                 await refreshOrchestrationRuns(select: runID)
@@ -3881,6 +3978,7 @@ final class AppModel: ObservableObject {
                 blocks = Self.blocks(from: response.messages)
                 sessionInfo = response.sessionInfo
                 currentSessionID = response.sessionInfo.sessionID
+                dispatcherActivity = nil
                 agentActivities = response.agentActivities
                 orchestrationState = response.orchestrationState
                 orchestrationRunID = response.orchestrationRunID
@@ -3913,6 +4011,7 @@ final class AppModel: ObservableObject {
         streamingReply.resetTurn()
         isBusy = false
         orchestrationState = nil
+        dispatcherActivity = nil
         agentActivities = []
         activeTaskRecord = nil
         taskHasChanges = false
@@ -5625,6 +5724,7 @@ final class AppModel: ObservableObject {
             orchestrationRunID = event["run_id"] as? String
             orchestrationState = .dispatching
             activeWorkerID = event["worker_id"] as? String ?? activeWorkerID
+            dispatcherActivity = nil
             agentActivities = []
             teamModelCalls = 0
             teamMeteredTokens = 0
@@ -5639,6 +5739,42 @@ final class AppModel: ObservableObject {
             }
             updateTaskConversation(state: .dispatching, event: event)
             if persistenceEnabled { Task { await refreshMetadata() } }
+
+        case "dispatcher_started":
+            let runID = event["run_id"] as? String ?? orchestrationRunID ?? "current"
+            dispatcherActivity = AgentActivity(
+                id: "dispatcher-\(runID)",
+                agentName: event["agent_name"] as? String ?? "Dispatcher",
+                role: AgentRole.dispatcher.rawValue,
+                provider: event["provider"] as? String ?? "",
+                model: event["model"] as? String ?? "",
+                goal: event["goal"] as? String ?? "Creating the team plan",
+                state: .running,
+                output: "",
+                reasoningText: nil,
+                tool: nil,
+                evidence: [],
+                startedAt: Date(),
+                elapsedMilliseconds: 0,
+                promptTokens: 0,
+                completionTokens: 0
+            )
+
+        case "dispatcher_completed":
+            let state = (event["state"] as? String) == TeamRunState.failed.rawValue
+                ? TeamRunState.failed : .completed
+            if var activity = dispatcherActivity {
+                activity.state = state
+                activity.output = event["message"] as? String ?? "Dispatch plan ready"
+                activity.elapsedMilliseconds = event["elapsed_ms"] as? Int ?? 0
+                activity.promptTokens = event["prompt_tokens"] as? Int ?? 0
+                activity.completionTokens = event["completion_tokens"] as? Int ?? 0
+                dispatcherActivity = activity
+            }
+            if let usage = event["usage"] as? [String: Any] {
+                teamModelCalls = usage["model_calls"] as? Int ?? teamModelCalls
+                teamMeteredTokens = usage["metered_tokens"] as? Int ?? teamMeteredTokens
+            }
 
         case "orchestration_state":
             orchestrationState = (event["state"] as? String)
@@ -6062,6 +6198,7 @@ final class AppModel: ObservableObject {
             orchestrationRunID = nil
             orchestrationState = nil
             activeWorkerID = nil
+            dispatcherActivity = nil
             agentActivities = []
             teamModelCalls = 0
             teamMeteredTokens = 0

--- a/Locus/SessionSidebarView.swift
+++ b/Locus/SessionSidebarView.swift
@@ -19,6 +19,7 @@ struct SessionSidebarView: View {
     @EnvironmentObject private var model: AppModel
     @State private var sessionToRename: SessionSummary?
     @State private var renameText = ""
+    @State private var teamProgressPresented = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -173,6 +174,10 @@ struct SessionSidebarView: View {
                 model.settingsPresented = true
             }
 
+            if model.selectedAgentTeam != nil {
+                teamProgressRow
+            }
+
             navigationRow(
                 symbol: "shippingbox",
                 title: "Hugging Face",
@@ -185,6 +190,62 @@ struct SessionSidebarView: View {
         }
         .padding(.horizontal, SidebarMetrics.gutter)
         .padding(.bottom, 10)
+    }
+
+    private var teamProgressRow: some View {
+        Button {
+            teamProgressPresented.toggle()
+        } label: {
+            HStack(spacing: SidebarMetrics.iconGap) {
+                Image(systemName: "waveform.path.ecg")
+                    .font(.system(size: 12, weight: .medium))
+                    .frame(width: SidebarMetrics.iconColumn)
+                Text("Team progress")
+                    .font(.system(size: 10, weight: .semibold))
+                Spacer(minLength: 4)
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(teamProgressColor)
+                        .frame(width: 6, height: 6)
+                    Text(teamProgressTitle)
+                        .font(.system(size: 8, weight: .semibold))
+                        .lineLimit(1)
+                }
+            }
+            .foregroundStyle(LocusTheme.inkSoft)
+            .padding(.horizontal, SidebarMetrics.rowInset)
+            .frame(height: 30)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(teamProgressPresented ? LocusTheme.signal.opacity(0.12) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .help("Show the active team's dispatcher, jobs, models, and usage")
+        .accessibilityLabel("Team progress, \(teamProgressTitle)")
+        .accessibilityIdentifier("sidebar.teamProgress")
+        .popover(isPresented: $teamProgressPresented, arrowEdge: .leading) {
+            TeamProgressPopover {
+                teamProgressPresented = false
+            }
+            .environmentObject(model)
+        }
+    }
+
+    private var teamProgressTitle: String {
+        if model.selectedTeamRouteIssue != nil { return "Needs setup" }
+        return model.orchestrationState?.title ?? "Ready"
+    }
+
+    private var teamProgressColor: Color {
+        if model.selectedTeamRouteIssue != nil { return LocusTheme.coral }
+        switch model.orchestrationState {
+        case .completed: return LocusTheme.success
+        case .failed, .interrupted, .cancelled, .discarded: return LocusTheme.coral
+        case .waitingPermission, .waitingComputer, .waitingDispatchApproval, .paused:
+            return LocusTheme.warning
+        case .queued, .dispatching, .running, .reviewing: return LocusTheme.signalDeep
+        case nil: return LocusTheme.success
+        }
     }
 
     /// One row of the nav stack. They share an icon column with the New chat,
@@ -543,6 +604,306 @@ struct SessionSidebarView: View {
         case .online: LocusTheme.success
         case .unavailable: LocusTheme.coral
         }
+    }
+}
+
+private struct TeamProgressPopover: View {
+    @EnvironmentObject private var model: AppModel
+    let dismiss: () -> Void
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { timeline in
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                Divider()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        if let issue = model.selectedTeamRouteIssue {
+                            Label(issue, systemImage: "exclamationmark.triangle.fill")
+                                .font(.system(size: 9, weight: .medium))
+                                .foregroundStyle(LocusTheme.coral)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .padding(10)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(LocusTheme.coral.opacity(0.08))
+                                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                                .accessibilityIdentifier("teamProgress.routeIssue")
+                        }
+
+                        dispatcherSection(now: timeline.date)
+                        delegatedJobs
+                        modelRoster
+                    }
+                    .padding(14)
+                }
+                .frame(maxHeight: 430)
+                Divider()
+                footer
+            }
+            .frame(width: 370)
+            .background(LocusTheme.panel)
+        }
+        .accessibilityIdentifier("teamProgress.popover")
+    }
+
+    private var header: some View {
+        HStack(spacing: 9) {
+            Image(systemName: "person.3.sequence.fill")
+                .foregroundStyle(LocusTheme.signalDeep)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.selectedAgentTeam?.name ?? "Team")
+                    .font(.system(size: 12, weight: .bold))
+                Text(progressStateTitle)
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundStyle(progressStateColor)
+            }
+            Spacer()
+            if runIsActive {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel("Team run in progress")
+            }
+        }
+        .padding(14)
+    }
+
+    @ViewBuilder
+    private func dispatcherSection(now: Date) -> some View {
+        let activity = model.dispatcherActivity
+        let dispatcher = selectedDispatcher
+        let startedAt = activity?.startedAt ?? model.activeWorkStartedAt
+        let elapsed = startedAt.map { max(now.timeIntervalSince($0), 0) } ?? 0
+
+        VStack(alignment: .leading, spacing: 7) {
+            sectionLabel("DISPATCHER")
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: dispatcherSymbol(activity?.state))
+                    .foregroundStyle(dispatcherColor(activity?.state))
+                    .frame(width: 14)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(activity?.agentName ?? dispatcher?.name ?? "Dispatcher")
+                        .font(.system(size: 10, weight: .semibold))
+                    Text(dispatcherRouteLine(activity: activity, profile: dispatcher))
+                        .font(.system(size: 8, design: .monospaced))
+                        .foregroundStyle(LocusTheme.muted)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(dispatcherDetail(activity: activity))
+                        .font(.system(size: 9))
+                        .foregroundStyle(LocusTheme.inkSoft)
+                }
+                Spacer(minLength: 6)
+                if startedAt != nil && runIsActive {
+                    Text(duration(elapsed))
+                        .font(.system(size: 8, design: .monospaced))
+                        .foregroundStyle(LocusTheme.muted)
+                }
+            }
+            if model.orchestrationState == .dispatching,
+               elapsed >= 30,
+               model.agentActivities.isEmpty
+            {
+                Label(
+                    "Still waiting for the dispatcher. No plan or delegated jobs have started.",
+                    systemImage: "clock.badge.exclamationmark"
+                )
+                .font(.system(size: 8, weight: .medium))
+                .foregroundStyle(LocusTheme.warning)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("teamProgress.dispatcherSlow")
+            }
+        }
+        .padding(10)
+        .background(LocusTheme.white.opacity(0.75))
+        .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .stroke(LocusTheme.line, lineWidth: 1)
+        }
+        .accessibilityIdentifier("teamProgress.dispatcher")
+    }
+
+    private var delegatedJobs: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack {
+                sectionLabel("DELEGATED JOBS")
+                Spacer()
+                Text("\(completedJobs)/\(model.agentActivities.count)")
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundStyle(LocusTheme.muted)
+            }
+            if model.agentActivities.isEmpty {
+                Text(model.orchestrationState == nil
+                    ? "No run yet. Send a task with this team selected."
+                    : "Jobs appear here after the dispatcher returns a plan.")
+                    .font(.system(size: 9))
+                    .foregroundStyle(LocusTheme.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                ForEach(model.agentActivities) { activity in
+                    HStack(spacing: 7) {
+                        Image(systemName: dispatcherSymbol(activity.state))
+                            .foregroundStyle(dispatcherColor(activity.state))
+                            .frame(width: 13)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("\(activity.agentName) · \(activity.role.capitalized)")
+                                .font(.system(size: 9, weight: .semibold))
+                            Text("\(activity.provider) · \(activity.model)")
+                                .font(.system(size: 8, design: .monospaced))
+                                .foregroundStyle(LocusTheme.muted)
+                                .lineLimit(1)
+                        }
+                        Spacer()
+                        Text(activity.state.title)
+                            .font(.system(size: 8))
+                            .foregroundStyle(LocusTheme.muted)
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("teamProgress.jobs")
+    }
+
+    private var modelRoster: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            sectionLabel("TEAM MODELS")
+            ForEach(teamProfiles) { profile in
+                HStack(alignment: .firstTextBaseline, spacing: 7) {
+                    Text(profile.role.title)
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundStyle(LocusTheme.muted)
+                        .frame(width: 72, alignment: .leading)
+                    Text(profile.model)
+                        .font(.system(size: 8, design: .monospaced))
+                        .lineLimit(2)
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .accessibilityIdentifier("teamProgress.models")
+    }
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            Text("\(model.teamModelCalls.formatted()) calls")
+            Text("\(model.teamMeteredTokens.formatted()) hosted tokens")
+            Spacer()
+            if runIsActive, let runID = model.orchestrationRunID {
+                Button("Stop", role: .destructive) {
+                    model.cancelOrchestration(runID)
+                }
+                .buttonStyle(.borderless)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(LocusTheme.coral)
+                .accessibilityIdentifier("teamProgress.stop")
+            }
+            Button("Open Runs") {
+                model.selectInspectorTab(.runs)
+                dismiss()
+            }
+            .buttonStyle(.borderless)
+            .font(.system(size: 9, weight: .semibold))
+            .accessibilityIdentifier("teamProgress.openRuns")
+        }
+        .font(.system(size: 8, design: .monospaced))
+        .foregroundStyle(LocusTheme.muted)
+        .padding(12)
+    }
+
+    private var selectedDispatcher: AgentProfile? {
+        guard let id = model.selectedAgentTeam?.dispatcherID else { return nil }
+        return model.agentProfiles.first(where: { $0.id == id })
+    }
+
+    private var teamProfiles: [AgentProfile] {
+        guard let team = model.selectedAgentTeam else { return [] }
+        return team.memberIDs.compactMap { id in model.agentProfiles.first(where: { $0.id == id }) }
+    }
+
+    private var completedJobs: Int {
+        model.agentActivities.filter { $0.state == .completed }.count
+    }
+
+    private var runIsActive: Bool {
+        switch model.orchestrationState {
+        case .queued, .dispatching, .running, .waitingPermission, .waitingComputer,
+             .waitingDispatchApproval, .reviewing, .paused:
+            return true
+        case .completed, .failed, .interrupted, .cancelled, .discarded, nil:
+            return false
+        }
+    }
+
+    private var progressStateTitle: String {
+        if model.selectedTeamRouteIssue != nil { return "Needs model setup" }
+        return model.orchestrationState?.title ?? "Ready"
+    }
+
+    private var progressStateColor: Color {
+        if model.selectedTeamRouteIssue != nil { return LocusTheme.coral }
+        return dispatcherColor(model.orchestrationState)
+    }
+
+    private func dispatcherRouteLine(activity: AgentActivity?, profile: AgentProfile?) -> String {
+        if let activity, !activity.model.isEmpty {
+            return [activity.provider, activity.model].filter { !$0.isEmpty }.joined(separator: " · ")
+        }
+        guard let profile else { return "Model not configured" }
+        let provider: String
+        switch profile.route {
+        case .localOllama:
+            provider = "Local Ollama"
+        case .providerAccount(let id):
+            provider = model.providerAccounts.first(where: { $0.id == id })?.displayName
+                ?? "Unavailable provider"
+        }
+        return "\(provider) · \(profile.model)"
+    }
+
+    private func dispatcherDetail(activity: AgentActivity?) -> String {
+        if let activity, !activity.output.isEmpty { return activity.output }
+        switch model.orchestrationState {
+        case .dispatching: return "Creating and validating the job plan…"
+        case .waitingDispatchApproval: return "The plan is ready and waiting for approval."
+        case .running, .reviewing: return "Plan complete; team work is underway."
+        case .completed: return "The team run completed."
+        case .failed: return "The dispatcher or team run failed."
+        default: return "Ready to route the next task."
+        }
+    }
+
+    private func sectionLabel(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 8, weight: .bold))
+            .tracking(0.7)
+            .foregroundStyle(LocusTheme.muted)
+    }
+
+    private func dispatcherSymbol(_ state: TeamRunState?) -> String {
+        switch state {
+        case .completed: "checkmark.circle.fill"
+        case .failed, .interrupted, .cancelled, .discarded: "xmark.circle.fill"
+        case .waitingPermission, .waitingComputer, .waitingDispatchApproval, .paused:
+            "pause.circle.fill"
+        case .queued, .dispatching, .running, .reviewing: "circle.dotted"
+        case nil: "circle"
+        }
+    }
+
+    private func dispatcherColor(_ state: TeamRunState?) -> Color {
+        switch state {
+        case .completed: LocusTheme.success
+        case .failed, .interrupted, .cancelled, .discarded: LocusTheme.coral
+        case .waitingPermission, .waitingComputer, .waitingDispatchApproval, .paused:
+            LocusTheme.warning
+        case .queued, .dispatching, .running, .reviewing: LocusTheme.signalDeep
+        case nil: LocusTheme.muted
+        }
+    }
+
+    private func duration(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        if total < 60 { return "\(total)s" }
+        return "\(total / 60)m \(total % 60)s"
     }
 }
 

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -88,13 +88,29 @@ struct WorkspaceView: View {
                 .environmentObject(model)
 
             Menu {
+                if let team = model.selectedAgentTeam {
+                    Section("Active team") {
+                        ForEach(model.selectedTeamModelNames, id: \.self) { name in
+                            Label(name, systemImage: "cpu")
+                        }
+                        Button("Manage \(team.name)…") {
+                            model.settingsPage = .agents
+                            model.settingsPresented = true
+                        }
+                        Button("Switch to Solo") {
+                            model.selectAgentTeam(nil)
+                        }
+                    }
+                    Divider()
+                }
                 ForEach(model.modelPickerSections) { section in
-                    Section(section.title) {
+                    Section(model.teamModeEnabled ? "Solo · \(section.title)" : section.title) {
                         if let message = section.emptyMessage {
                             Text(message)
                         }
                         ForEach(section.models, id: \.self) { name in
                             Button {
+                                if model.teamModeEnabled { model.selectAgentTeam(nil) }
                                 model.selectModel(account: section.account, model: name)
                             } label: {
                                 // The checkmark answers "which one am I using",
@@ -127,7 +143,9 @@ struct WorkspaceView: View {
                 .accessibilityIdentifier("workspace.modelPicker.manageAccounts")
             } label: {
                 HStack(spacing: 7) {
-                    Image(systemName: model.activeAccount == nil ? "bolt.fill" : "cloud.fill")
+                    Image(systemName: model.teamModeEnabled
+                        ? "person.3.sequence.fill"
+                        : (model.activeAccount == nil ? "bolt.fill" : "cloud.fill"))
                         .font(.system(size: 11))
                         .foregroundStyle(LocusTheme.signalDeep)
                     Text(model.modelPickerLabel)
@@ -149,7 +167,12 @@ struct WorkspaceView: View {
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
-            .accessibilityLabel("Select Ollama model")
+            .help(model.teamModeEnabled
+                ? "Active team: \(model.selectedTeamModelNames.joined(separator: ", "))"
+                : "Select model")
+            .accessibilityLabel(model.teamModeEnabled
+                ? "Active team, \(model.modelPickerLabel)"
+                : "Select model")
             .accessibilityIdentifier("workspace.modelPicker")
 
             Button {

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -3,6 +3,51 @@ import XCTest
 
 final class AppModelTests: XCTestCase {
     @MainActor
+    func testOrchestrationControlsResolveTheWorkerThatOwnsTheRun() {
+        let oldRun = TaskConversationState(
+            sessionID: "old-session",
+            taskID: nil,
+            teamID: "team",
+            workerID: "worker-old",
+            runID: "run-old",
+            state: .waitingDispatchApproval,
+            updatedAt: Date()
+        )
+        let currentRun = TaskConversationState(
+            sessionID: "current-session",
+            taskID: nil,
+            teamID: "team",
+            workerID: "worker-current",
+            runID: "run-current",
+            state: .dispatching,
+            updatedAt: Date()
+        )
+        let states = [
+            oldRun.sessionID: oldRun,
+            currentRun.sessionID: currentRun,
+        ]
+
+        XCTAssertEqual(
+            AppModel.orchestrationOwnerSessionID(
+                for: "run-old",
+                currentSessionID: "current-session",
+                currentRunID: "run-current",
+                states: states
+            ),
+            "old-session"
+        )
+        XCTAssertEqual(
+            AppModel.orchestrationOwnerSessionID(
+                for: "run-current",
+                currentSessionID: "current-session",
+                currentRunID: "run-current",
+                states: [:]
+            ),
+            "current-session"
+        )
+    }
+
+    @MainActor
     func testGlobalAgentConcurrencyStaysWithinApplicationCeiling() {
         let model = AppModel(startImmediately: false)
         model.globalAgentConcurrency = 99
@@ -541,6 +586,38 @@ final class AppModelTests: XCTestCase {
         XCTAssertFalse(model.isCurrentRoute(account: personal, model: "claude-sonnet-4-5"))
         XCTAssertFalse(model.isCurrentRoute(account: nil, model: "claude-sonnet-4-5"))
         XCTAssertEqual(model.modelPickerLabel, "Work · claude-sonnet-4-5")
+    }
+
+    @MainActor
+    func testModelPickerLabelShowsTheSelectedTeamAndDistinctModelCount() {
+        let model = AppModel(startImmediately: false)
+        let dispatcher = AgentProfile(
+            name: "Dispatcher",
+            model: "qwen",
+            role: .dispatcher
+        )
+        let planner = AgentProfile(name: "Planner", model: "qwen", role: .planner)
+        let writer = AgentProfile(
+            name: "Writer",
+            model: "kimi",
+            role: .implementer,
+            accessCeiling: .workspaceWrite
+        )
+        model.saveAgentProfile(dispatcher)
+        model.saveAgentProfile(planner)
+        model.saveAgentProfile(writer)
+        let team = AgentTeam(
+            name: "Codex Team",
+            dispatcherID: dispatcher.id,
+            fallbackDispatcherID: nil,
+            memberIDs: [dispatcher.id, planner.id, writer.id],
+            defaultWriterID: writer.id
+        )
+        model.saveAgentTeam(team)
+        model.selectAgentTeam(team.id)
+
+        XCTAssertEqual(model.selectedTeamModelNames, ["qwen", "kimi"])
+        XCTAssertEqual(model.modelPickerLabel, "Codex Team · 2 models")
     }
 
     @MainActor

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -1628,6 +1628,51 @@ final class FeatureLogicTests: XCTestCase {
         )
     }
 
+    func testAgentTeamRejectsAModelTheSelectedProviderDoesNotReport() {
+        let account = ProviderAccount(
+            kind: .custom,
+            name: "Hosted Qwen",
+            preferredModel: "served-model"
+        )
+        let dispatcher = AgentProfile(
+            name: "Dispatcher",
+            route: .providerAccount(account.id),
+            model: "friendly-but-invalid-name",
+            role: .dispatcher
+        )
+        let writer = AgentProfile(
+            name: "Writer",
+            model: "local-writer",
+            role: .implementer,
+            accessCeiling: .workspaceWrite
+        )
+        let team = AgentTeam(
+            name: "Validated routes",
+            dispatcherID: dispatcher.id,
+            fallbackDispatcherID: nil,
+            memberIDs: [dispatcher.id, writer.id],
+            defaultWriterID: writer.id
+        )
+
+        let errors = AgentTeamValidation.routeErrors(
+            team: team,
+            profiles: [dispatcher, writer],
+            accounts: [account],
+            accountModels: [account.id: ["served-model"]]
+        )
+
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertTrue(errors[0].contains("does not report that model"))
+        XCTAssertTrue(
+            AgentTeamValidation.routeErrors(
+                team: team,
+                profiles: [dispatcher, writer],
+                accounts: [account],
+                accountModels: [account.id: [dispatcher.model]]
+            ).isEmpty
+        )
+    }
+
     func testTeamMentionsResolveAgentsAndTeamsWithoutMatchingOrdinaryText() {
         let agent = AgentProfile(name: "CodeReviewer", model: "local", role: .reviewer)
         let team = AgentTeam(

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ like; macOS remembers the size you choose for later launches.
   in a private managed worktree.
 - **Durable, inspectable runs** record timelines, evidence, routing decisions,
   costs, checkpoints, steering, pause/resume state, and recovery options in a
-  local run store.
+  local run store. Stop is routed to the worker that owns the run, waits for a
+  terminal event, and leaves a cancelled run non-recoverable instead of
+  replaying its last approval after reconnecting.
+- **Live Team Progress in the sidebar** shows the active dispatcher and its
+  provider/model, elapsed time, delegated jobs, model calls, and hosted-token
+  usage. Its Stop button remains available while a team is running.
+- **Team-aware model controls** label the workspace with the selected team and
+  distinct model count, list the exact team models in the header menu, and use
+  provider-backed model dropdowns when editing agent profiles.
 - **Evaluation suites and transparent scorecard routing** compare Solo and team
   configurations against immutable fixtures, then explain why an eligible agent
   was selected.
@@ -39,10 +47,11 @@ for setup, examples, permission boundaries, recovery, and troubleshooting.
 ## Designed for real project work
 
 - **One calm sidebar** holds the conversation list: rows for Plugins & MCP,
-  Manage Accounts and Hugging Face, then New chat, search, recents, and a footer
-  with the workspace selector, connection status, and the rest of the app's
-  actions. It starts open, collapses with `⌘0` or the header button when you
-  want the room, and remembers its state across launches.
+  Manage Accounts, Agents & Teams, live Team Progress, and Hugging Face, then
+  New chat, search, recents, and a footer with the workspace selector,
+  connection status, and the rest of the app's actions. It starts open,
+  collapses with `⌘0` or the header button when you want the room, and remembers
+  its state across launches.
 - **Workspaces** open from a folder picker that can create folders, or with
   **New Workspace…**, which names a folder, creates it, and opens it.
 - **Local or rented GPU.** Point Locus at local Ollama, or at any
@@ -97,6 +106,8 @@ for setup, examples, permission boundaries, recovery, and troubleshooting.
   match count, `↵`/`⇧↵` navigation, and scroll-to-match highlighting.
 - **Message queueing** keeps you typing while a run is active — queued
   messages send automatically when the turn finishes, and Esc stops a run.
+  Anything submitted while the UI says **Stopping…** is queued for the next
+  turn rather than steered into the run being cancelled.
 - **Rewind** any earlier user message: the conversation returns to that point
   with the message back in the composer for editing.
 - **Session organizer** adds names, pins, soft archives, filtering, and Markdown
@@ -272,6 +283,12 @@ A model name is remembered per account rather than globally, so switching to a
 different provider never arrives carrying the last one's model — that is how a
 Kimi model name ends up pointed at Anthropic and fails with an error that names
 neither problem.
+
+When a team is selected, the header menu shows the team name and distinct model
+count rather than the solo session's provider. Open it to see each exact model,
+switch back to Solo, or manage the team. Agent profiles use a model dropdown
+filled from their selected provider; the refresh and **Test Connection** actions
+can wake a scaled-to-zero vLLM endpoint before its model catalog is available.
 
 **Test Connection** confirms the account answers before you send a message,
 and reports the actual reason when it does not — a rejected key, a wrong URL,
@@ -545,8 +562,8 @@ xcodebuild \
 cd agent && .venv/bin/python -m pytest -q
 ```
 
-The repository currently contains 234 unit tests, 26 UI tests, and 367 backend
-tests.
+The repository currently contains 237 unit tests, 26 UI tests, and 372 backend
+test cases.
 
 The unit suite covers work modes, lightweight context migration, session
 acknowledgements and retry branches, recoverable session clearing, Hugging Face

--- a/agent/ollama_code/ollama.py
+++ b/agent/ollama_code/ollama.py
@@ -436,6 +436,12 @@ class OllamaClient:
                 resp.done_reason = "interrupted"
                 return resp
             raise OllamaError(f"chat request failed: {e}") from e
+        except Exception:
+            if should_stop is not None and should_stop():
+                resp.done = True
+                resp.done_reason = "interrupted"
+                return resp
+            raise
         finally:
             watcher_done.set()
             if watcher is not None:

--- a/agent/ollama_code/orchestration.py
+++ b/agent/ollama_code/orchestration.py
@@ -618,7 +618,9 @@ class TeamOrchestrator:
         })
         dispatcher = profiles[team.dispatcher_id]
         try:
-            plan = self._dispatch(request, workspace, team, profiles, dispatcher, forced_agent)
+            plan = self._dispatch_with_status(
+                run_id, request, workspace, team, profiles, dispatcher, forced_agent,
+            )
         except OllamaError:
             fallback_id = team.fallback_dispatcher_id
             if not fallback_id or fallback_id == dispatcher.id:
@@ -630,7 +632,9 @@ class TeamOrchestrator:
                 "state": "dispatching",
                 "message": f"Primary dispatcher unavailable; trying {dispatcher.name}",
             })
-            plan = self._dispatch(request, workspace, team, profiles, dispatcher, forced_agent)
+            plan = self._dispatch_with_status(
+                run_id, request, workspace, team, profiles, dispatcher, forced_agent,
+            )
         plan = self._resolve_scorecard(run_id, plan, team, profiles, forced_agent)
         if team.dispatch_approval_mode == "preview":
             if self.approve_dispatch is None:
@@ -646,8 +650,8 @@ class TeamOrchestrator:
                 if action == "cancel":
                     raise InterruptedError("dispatch cancelled")
                 if action == "redispatch":
-                    plan = self._dispatch(
-                        request, workspace, team, profiles, dispatcher, forced_agent,
+                    plan = self._dispatch_with_status(
+                        run_id, request, workspace, team, profiles, dispatcher, forced_agent,
                     )
                     plan = self._resolve_scorecard(run_id, plan, team, profiles, forced_agent)
                     continue
@@ -976,6 +980,53 @@ class TeamOrchestrator:
             "prompt_tokens": result.prompt_tokens,
             "completion_tokens": result.completion_tokens,
         }
+
+    def _dispatch_with_status(
+        self,
+        run_id: str,
+        request: str,
+        workspace: str,
+        team: AgentTeam,
+        profiles: dict[str, AgentProfile],
+        dispatcher: AgentProfile,
+        forced_agent: str | None,
+    ) -> DispatchPlan:
+        started = time.monotonic()
+        self.emit({
+            "type": "dispatcher_started",
+            "run_id": run_id,
+            "agent_id": dispatcher.id,
+            "agent_name": dispatcher.name,
+            "provider": _route_label(dispatcher.route),
+            "model": dispatcher.model,
+            "goal": "Creating the team plan",
+            "state": "running",
+        })
+        try:
+            plan = self._dispatch(
+                request, workspace, team, profiles, dispatcher, forced_agent,
+            )
+        except Exception as exc:
+            self.emit({
+                "type": "dispatcher_completed",
+                "run_id": run_id,
+                "agent_id": dispatcher.id,
+                "state": "failed",
+                "message": str(exc)[:2_000],
+                "elapsed_ms": max(int((time.monotonic() - started) * 1_000), 0),
+                "usage": self.usage(),
+            })
+            raise
+        self.emit({
+            "type": "dispatcher_completed",
+            "run_id": run_id,
+            "agent_id": dispatcher.id,
+            "state": "completed",
+            "message": "Dispatch plan ready",
+            "elapsed_ms": max(int((time.monotonic() - started) * 1_000), 0),
+            "usage": self.usage(),
+        })
+        return plan
 
     def _dispatch(
         self,

--- a/agent/ollama_code/remote.py
+++ b/agent/ollama_code/remote.py
@@ -573,6 +573,18 @@ class RemoteClient:
                 resp.done_reason = "interrupted"
                 return resp
             raise OllamaError(proxy.redact(f"chat request failed: {e}")) from e
+        except Exception:
+            # Closing a requests/urllib3 response from the stop watcher can
+            # surface an implementation error such as
+            # ``AttributeError: 'NoneType' object has no attribute 'read'``
+            # instead of RequestException. Once Stop is set, that exception is
+            # the expected wake-up path and must not trigger dispatcher repair
+            # or fallback work.
+            if should_stop is not None and should_stop():
+                resp.done = True
+                resp.done_reason = "interrupted"
+                return resp
+            raise
         finally:
             watcher_done.set()
             if watcher is not None:
@@ -667,6 +679,12 @@ class RemoteClient:
                 resp.done_reason = "interrupted"
                 return resp
             raise OllamaError(proxy.redact(f"chat request failed: {e}")) from e
+        except Exception:
+            if should_stop is not None and should_stop():
+                resp.done = True
+                resp.done_reason = "interrupted"
+                return resp
+            raise
         finally:
             watcher_done.set()
             if watcher is not None:

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -124,6 +124,7 @@ class ChatService:
         self.active_orchestrator: TeamOrchestrator | None = None
         self.active_team: TeamPreparation | None = None
         self.active_run_id: str | None = None
+        self.cancel_requested_runs: set[str] = set()
         self.pause_requested = False
         self.active_evaluation_id: str | None = None
         self.active_evaluation_core: AgentCore | None = None
@@ -398,6 +399,11 @@ class ChatService:
             name = str(getattr(call, "__name__", ""))
             steerable = name in {"_run_user_turn", "_run_team_turn", "retry_last_response"}
             if steerable:
+                # Stop belongs to the turn it interrupted. Team dispatch uses
+                # the flag before AgentCore.run_turn (which clears it for solo
+                # turns), so carrying it forward makes the next team request
+                # terminate immediately after a successful cancellation.
+                self.core._interrupt.clear()
                 self.core.begin_steerable_turn()
             try:
                 self.turn_future = loop.run_in_executor(None, call, *args)
@@ -1532,17 +1538,25 @@ def orchestration_pause(run_id: str) -> dict[str, Any]:
 def orchestration_cancel(run_id: str) -> dict[str, Any]:
     _require_capability("recovery_controls")
     svc = service()
-    if svc.active_run_id == run_id and svc.busy:
-        svc.pause_requested = False
-        svc.core.interrupt()
-        svc.deny_all_pending()
-        svc.cancel_all_computer_actions()
-        svc.cancel_dispatch_decisions()
-        svc.core.mcp.cancel_pending_inputs()
-    try:
-        svc.run_store.set_state(run_id, "cancelled", recoverable=False)
-    except RunStoreError as exc:
-        raise HTTPException(404, str(exc)) from exc
+    record = svc.run_store.run(run_id)
+    if record is None:
+        raise HTTPException(404, f"orchestration not found: {run_id}")
+    terminal_states = {"cancelled", "completed", "failed", "interrupted", "discarded"}
+    if str(record.get("state") or "") in terminal_states:
+        return {"ok": True, "run_id": run_id, "state": str(record["state"])}
+    if svc.active_run_id != run_id or not svc.busy:
+        owner = str(record.get("worker_id") or "")
+        if owner and owner != svc.worker_id:
+            raise HTTPException(409, "that orchestration is active in another worker")
+        raise HTTPException(409, "that orchestration is not actively running")
+    svc.pause_requested = False
+    svc.cancel_requested_runs.add(run_id)
+    svc.core.interrupt()
+    svc.deny_all_pending()
+    svc.cancel_all_computer_actions()
+    svc.cancel_dispatch_decisions()
+    svc.core.mcp.cancel_pending_inputs()
+    svc.run_store.set_state(run_id, "cancelled", recoverable=False)
     return {"ok": True, "run_id": run_id, "state": "cancelled"}
 
 
@@ -2622,7 +2636,8 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
             "usage": orchestrator.usage(),
         })
     except InterruptedError:
-        terminal_reason = "interrupted"
+        cancelled = run_id in svc.cancel_requested_runs
+        terminal_reason = "cancelled" if cancelled else "interrupted"
         paused = svc.pause_requested
         if paused and prepared is not None:
             svc.checkpoint(
@@ -2651,14 +2666,24 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
         svc.emit({
             "type": "orchestration_completed",
             "run_id": str(manifest.get("run_id") or ""),
-            "state": "paused" if paused else "interrupted",
+            "state": "paused" if paused else terminal_reason,
             "duration_ms": max(int((time.monotonic() - started) * 1_000), 0),
         })
         svc.run_store.set_state(
             run_id,
-            "paused" if paused else "interrupted",
-            recoverable=paused or svc.run_store.latest_checkpoint(run_id) is not None,
-            reason=("Paused by the user." if paused else "The run was interrupted."),
+            "paused" if paused else terminal_reason,
+            # A user cancellation is final even when the run reached a
+            # checkpoint before Stop was pressed. Advertising that checkpoint
+            # as recoverable is what allowed the cancelled approval to be
+            # offered again after reconnecting.
+            recoverable=paused or (
+                not cancelled and svc.run_store.latest_checkpoint(run_id) is not None
+            ),
+            reason=(
+                "Paused by the user." if paused
+                else "Cancelled by the user." if cancelled
+                else "The run was interrupted."
+            ),
         )
     except (OrchestrationError, WorktreeError, OllamaError, ValueError) as exc:
         terminal_reason = "error"
@@ -2675,6 +2700,7 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
                 "complete": "completed",
                 "max_iterations": "completed",
                 "interrupted": "interrupted",
+                "cancelled": "cancelled",
             }.get(terminal_reason, "failed")
             svc.current_task.state = task_state
             svc.current_task.save()
@@ -2699,6 +2725,7 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
         })
         core._emit_info()
         svc.active_run_id = None
+        svc.cancel_requested_runs.discard(run_id)
         svc.pause_requested = False
 
 

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -12,6 +12,7 @@ import os
 import subprocess
 import threading
 import time
+from concurrent.futures import Future
 from pathlib import Path
 
 import pytest
@@ -1156,7 +1157,10 @@ def test_remote_stream_interrupt_closes_a_stalled_response(monkeypatch):
 
         def iter_lines(self, decode_unicode=True):
             self.closed.wait(2)
-            return iter(())
+            # urllib3 may dereference its cleared file handle after another
+            # thread closes the response. Cancellation still has to be
+            # reported as interrupted rather than entering provider fallback.
+            raise AttributeError("'NoneType' object has no attribute 'read'")
 
         def close(self):
             self.closed.set()
@@ -1897,6 +1901,66 @@ def test_health_and_models(client):
     assert models["models"][0]["name"] == "test-model"
     assert models["models"][0]["context_length"] == 32768
     assert models["current"] == "test-model"
+
+
+def test_cancel_rejects_a_run_owned_by_another_worker(client, tmp_path):
+    svc = client.app.state.service
+    svc.run_store.start_run(
+        "foreign-run",
+        session_id=svc.core.session.session_id,
+        team_id="team-1",
+        team_name="Team",
+        worker_id="worker-in-another-process",
+        workspace_root=str(tmp_path),
+        execution_path=str(tmp_path),
+        task_id="",
+        request="Build something",
+        manifest={},
+        state="dispatching",
+    )
+
+    response = client.post("/api/orchestrations/foreign-run/cancel")
+
+    assert response.status_code == 409
+    assert "another worker" in response.json()["detail"]
+    assert svc.run_store.run("foreign-run")["state"] == "dispatching"
+
+
+def test_cancel_interrupts_the_worker_that_owns_the_run(client, tmp_path):
+    svc = client.app.state.service
+    run_id = "local-run"
+    svc.run_store.start_run(
+        run_id,
+        session_id=svc.core.session.session_id,
+        team_id="team-1",
+        team_name="Team",
+        worker_id=svc.worker_id,
+        workspace_root=str(tmp_path),
+        execution_path=str(tmp_path),
+        task_id="",
+        request="Build something",
+        manifest={},
+        state="waiting_dispatch_approval",
+    )
+    turn: Future[None] = Future()
+    svc.turn_future = turn
+    svc.active_run_id = run_id
+    try:
+        response = client.post(f"/api/orchestrations/{run_id}/cancel")
+
+        assert response.status_code == 200
+        assert response.json()["state"] == "cancelled"
+        assert svc.core._interrupt.is_set()
+        assert run_id in svc.cancel_requested_runs
+        record = svc.run_store.run(run_id)
+        assert record["state"] == "cancelled"
+        assert record["recoverable"] is False
+    finally:
+        turn.set_result(None)
+        svc.turn_future = None
+        svc.active_run_id = None
+        svc.cancel_requested_runs.discard(run_id)
+        svc.core._interrupt.clear()
 
 
 def test_models_report_the_window_a_model_is_really_running_in(client, monkeypatch):
@@ -2789,6 +2853,26 @@ def test_terminal_event_is_not_sent_until_turn_slot_is_idle(tmp_path):
         await asyncio.sleep(0)
         assert socket.events == [{"type": "turn_done", "reason": "interrupted"}]
         pump.cancel()
+
+    asyncio.run(scenario())
+
+
+def test_starting_a_new_team_turn_clears_the_previous_interrupt(tmp_path):
+    async def scenario():
+        core = _core(tmp_path, [])
+        service = server_mod.ChatService(core)
+        service.loop = asyncio.get_running_loop()
+        core.interrupt()
+        observed = []
+
+        def next_team_turn():
+            observed.append(core._interrupt.is_set())
+
+        next_team_turn.__name__ = "_run_team_turn"
+        assert service.start_turn(service.loop, next_team_turn)
+        await service.turn_future
+
+        assert observed == [False]
 
     asyncio.run(scenario())
 

--- a/agent/tests/test_orchestration.py
+++ b/agent/tests/test_orchestration.py
@@ -112,6 +112,55 @@ def test_manifest_and_dispatch_plan_enforce_one_writer_and_known_members():
         validate_dispatch_plan(no_writer, team, profiles)
 
 
+def test_dispatcher_progress_names_the_model_and_reports_completion(monkeypatch):
+    events = []
+    _, team, profiles, forced = parse_manifest(_manifest())
+    orchestrator = TeamOrchestrator(events.append, lambda: False)
+    expected = validate_dispatch_plan(_valid_plan(), team, profiles)
+    monkeypatch.setattr(orchestrator, "_dispatch", lambda *_args: expected)
+
+    actual = orchestrator._dispatch_with_status(
+        "run-1", "Build it", "/tmp/workspace", team, profiles,
+        profiles[team.dispatcher_id], forced,
+    )
+
+    assert actual == expected
+    assert events[0] == {
+        "type": "dispatcher_started",
+        "run_id": "run-1",
+        "agent_id": "dispatcher",
+        "agent_name": "Dispatcher",
+        "provider": "Local Ollama",
+        "model": "test-model",
+        "goal": "Creating the team plan",
+        "state": "running",
+    }
+    assert events[-1]["type"] == "dispatcher_completed"
+    assert events[-1]["state"] == "completed"
+    assert events[-1]["message"] == "Dispatch plan ready"
+
+
+def test_dispatch_cancel_does_not_start_repair_or_fallback_calls(monkeypatch):
+    events = []
+    _, team, profiles, forced = parse_manifest(_manifest())
+    orchestrator = TeamOrchestrator(events.append, lambda: True)
+    calls = []
+
+    def interrupted_call(*_args, **_kwargs):
+        calls.append("call")
+        raise InterruptedError("orchestration cancelled")
+
+    monkeypatch.setattr(orchestrator, "_raw_call", interrupted_call)
+
+    with pytest.raises(InterruptedError, match="cancelled"):
+        orchestrator._dispatch(
+            "Build it", "/tmp/workspace", team, profiles,
+            profiles[team.dispatcher_id], forced,
+        )
+
+    assert calls == ["call"]
+
+
 def test_orchestration_fingerprint_ignores_credentials_but_tracks_models():
     first = _manifest()
     _, team, profiles, _ = parse_manifest(first)


### PR DESCRIPTION
## What changed

- adds a live Team Progress sidebar popover with dispatcher, model, job, usage, and Stop state
- makes the workspace model menu team-aware and gives agent profiles provider-backed model dropdowns
- keeps large team editors scrollable and preserves deterministic member/model order
- routes dispatch decisions and cancellation to the session worker that owns the run
- makes user cancellation terminal and non-recoverable, aborts stalled provider reads, and clears the old interrupt before the next team turn
- documents the 1.11 behavior and adds regression coverage

## Root cause

Team chats run in dedicated worker processes, but cancellation and dispatch decisions were sent to the shared control service. The shared run database could say `cancelled` while the owning worker remained blocked in dispatcher approval or a provider stream. Reconnect then surfaced the old checkpoint again, and the stale interrupt could terminate the next prompt.

## User impact

Stop now reaches the active Qwen/vLLM or Kimi worker, settles the composer back to Ready, cannot replay the cancelled checkpoint, and allows a distinct next request to start normally.

## Validation

- 372 backend tests passed
- complete `LocusTests` target passed
- signed self-contained macOS build verified end to end: run A → Cancelled/Ready → distinct run B dispatching → Cancelled/Ready
