### PR TITLE
Prevent long model names from hanging picker

### DIFF
--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -6567,6 +6567,18 @@ final class AppModel: ObservableObject {
         // The picker reads the local list, which a live refresh would normally
         // fill in.
         localModels = models
+        if ProcessInfo.processInfo.environment["LOCUS_UI_TESTING_LONG_MODEL"] == "1" {
+            let account = ProviderAccount(
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000401")!,
+                kind: .custom,
+                name: "Long vLLM route",
+                baseURLOverride: "https://example.invalid/v1",
+                preferredModel: "/repository/Qwen3.6-27B-Fable-Fusion-711-Uncensored-Heretic-NM-DAU-NEO-MAX-NEO-MTP-Q8_0.gguf"
+            )
+            providerAccounts = [account]
+            accountModels[account.id] = [account.preferredModel]
+            accountStatus[account.id] = .connected(models: 1)
+        }
         sessionInfo = SessionInfo(
             model: "qwen3:8b",
             host: "http://localhost:11434",

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct WorkspaceView: View {
     @EnvironmentObject private var model: AppModel
+    @State private var modelPickerPresented = false
 
     private var sessionTitle: String {
         model.sessions.first(where: { $0.id == model.currentSessionID })?.displayTitle
@@ -87,60 +88,8 @@ struct WorkspaceView: View {
             ContextUsageChip()
                 .environmentObject(model)
 
-            Menu {
-                if let team = model.selectedAgentTeam {
-                    Section("Active team") {
-                        ForEach(model.selectedTeamModelNames, id: \.self) { name in
-                            Label(name, systemImage: "cpu")
-                        }
-                        Button("Manage \(team.name)…") {
-                            model.settingsPage = .agents
-                            model.settingsPresented = true
-                        }
-                        Button("Switch to Solo") {
-                            model.selectAgentTeam(nil)
-                        }
-                    }
-                    Divider()
-                }
-                ForEach(model.modelPickerSections) { section in
-                    Section(model.teamModeEnabled ? "Solo · \(section.title)" : section.title) {
-                        if let message = section.emptyMessage {
-                            Text(message)
-                        }
-                        ForEach(section.models, id: \.self) { name in
-                            Button {
-                                if model.teamModeEnabled { model.selectAgentTeam(nil) }
-                                model.selectModel(account: section.account, model: name)
-                            } label: {
-                                // The checkmark answers "which one am I using",
-                                // and the same model name can appear under two
-                                // accounts — so the account has to match too.
-                                if model.isCurrentRoute(account: section.account, model: name) {
-                                    Label(name, systemImage: "checkmark")
-                                } else {
-                                    Text(name)
-                                }
-                            }
-                        }
-                    }
-                }
-                Divider()
-                Button("Browse Hugging Face Models…") {
-                    model.modelLibraryPresented = true
-                }
-                .accessibilityIdentifier("workspace.modelPicker.browseHuggingFace")
-                Button("Refresh Models") {
-                    Task {
-                        await model.refreshMetadata()
-                        await model.refreshAccountCatalogs(force: true)
-                    }
-                }
-                Button("Manage Accounts…") {
-                    model.settingsPage = .accounts
-                    model.settingsPresented = true
-                }
-                .accessibilityIdentifier("workspace.modelPicker.manageAccounts")
+            Button {
+                modelPickerPresented.toggle()
             } label: {
                 HStack(spacing: 7) {
                     Image(systemName: model.teamModeEnabled
@@ -165,8 +114,7 @@ struct WorkspaceView: View {
                 }
                 .frame(maxWidth: 190)
             }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
+            .buttonStyle(.plain)
             .help(model.teamModeEnabled
                 ? "Active team: \(model.selectedTeamModelNames.joined(separator: ", "))"
                 : "Select model")
@@ -174,6 +122,12 @@ struct WorkspaceView: View {
                 ? "Active team, \(model.modelPickerLabel)"
                 : "Select model")
             .accessibilityIdentifier("workspace.modelPicker")
+            .popover(isPresented: $modelPickerPresented, arrowEdge: .top) {
+                ModelPickerPopover {
+                    modelPickerPresented = false
+                }
+                .environmentObject(model)
+            }
 
             Button {
                 model.commandPalettePresented = true
@@ -287,6 +241,186 @@ struct WorkspaceView: View {
                 .fill((recovering ? LocusTheme.warning : LocusTheme.coral).opacity(0.25))
                 .frame(height: 1)
         }
+    }
+}
+
+/// A bounded picker instead of a native `Menu`. Provider model identifiers can
+/// be hundreds of characters long (especially vLLM repository paths); AppKit's
+/// menu adaptor repeatedly recomputed the window layout for those strings and
+/// could pin the main thread at 100% CPU. This popover owns its width and lets
+/// its contents scroll, so a long route can never resize the app or its menu.
+private struct ModelPickerPopover: View {
+    @EnvironmentObject private var model: AppModel
+    let dismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Model")
+                    .font(.system(size: 12, weight: .bold))
+                    .accessibilityIdentifier("workspace.modelPicker.popover")
+                Spacer()
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .bold))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close model picker")
+                .accessibilityIdentifier("workspace.modelPicker.close")
+            }
+            .padding(14)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    if let team = model.selectedAgentTeam {
+                        teamSection(team)
+                        Divider()
+                    }
+
+                    ForEach(model.modelPickerSections) { section in
+                        routeSection(section)
+                    }
+                }
+                .padding(14)
+            }
+            .frame(maxHeight: 440)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 4) {
+                pickerAction(
+                    "Browse Hugging Face Models…",
+                    symbol: "shippingbox",
+                    identifier: "workspace.modelPicker.browseHuggingFace"
+                ) {
+                    dismiss()
+                    model.modelLibraryPresented = true
+                }
+                pickerAction(
+                    "Refresh Models",
+                    symbol: "arrow.clockwise",
+                    identifier: "workspace.modelPicker.refresh"
+                ) {
+                    Task {
+                        await model.refreshMetadata()
+                        await model.refreshAccountCatalogs(force: true)
+                    }
+                }
+                pickerAction(
+                    "Manage Accounts…",
+                    symbol: "person.crop.circle",
+                    identifier: "workspace.modelPicker.manageAccounts"
+                ) {
+                    dismiss()
+                    model.settingsPage = .accounts
+                    model.settingsPresented = true
+                }
+            }
+            .padding(10)
+        }
+        .frame(width: 380)
+        .background(LocusTheme.panel)
+    }
+
+    private func teamSection(_ team: AgentTeam) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionLabel("ACTIVE TEAM")
+            Text(team.name)
+                .font(.system(size: 11, weight: .bold))
+            ForEach(model.selectedTeamModelNames, id: \.self) { name in
+                HStack(alignment: .top, spacing: 7) {
+                    Image(systemName: "cpu")
+                        .font(.system(size: 9))
+                        .foregroundStyle(LocusTheme.signalDeep)
+                        .frame(width: 13)
+                    Text(name)
+                        .font(.system(size: 8, design: .monospaced))
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                }
+                .accessibilityElement(children: .combine)
+            }
+            HStack(spacing: 14) {
+                Button("Manage \(team.name)…") {
+                    dismiss()
+                    model.settingsPage = .agents
+                    model.settingsPresented = true
+                }
+                .accessibilityIdentifier("workspace.modelPicker.manageTeam")
+                Button("Switch to Solo") {
+                    model.selectAgentTeam(nil)
+                }
+                .accessibilityIdentifier("workspace.modelPicker.switchToSolo")
+            }
+            .buttonStyle(.borderless)
+            .font(.system(size: 9, weight: .semibold))
+        }
+    }
+
+    private func routeSection(_ section: ModelPickerSection) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionLabel(model.teamModeEnabled ? "SOLO · \(section.title)" : section.title.uppercased())
+            if let message = section.emptyMessage {
+                Text(message)
+                    .font(.system(size: 9))
+                    .foregroundStyle(LocusTheme.muted)
+            }
+            ForEach(section.models, id: \.self) { name in
+                Button {
+                    if model.teamModeEnabled { model.selectAgentTeam(nil) }
+                    model.selectModel(account: section.account, model: name)
+                    dismiss()
+                } label: {
+                    HStack(alignment: .top, spacing: 7) {
+                        Image(systemName: model.isCurrentRoute(account: section.account, model: name)
+                            ? "checkmark.circle.fill"
+                            : "circle")
+                            .font(.system(size: 9))
+                            .foregroundStyle(model.isCurrentRoute(account: section.account, model: name)
+                                ? LocusTheme.signalDeep
+                                : LocusTheme.muted)
+                            .frame(width: 13)
+                        Text(name)
+                            .font(.system(size: 9, design: .monospaced))
+                            .lineLimit(2)
+                            .truncationMode(.middle)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Use \(name) from \(section.title)")
+            }
+        }
+    }
+
+    private func pickerAction(
+        _ title: String,
+        symbol: String,
+        identifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: symbol)
+                .font(.system(size: 9, weight: .medium))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 4)
+        .frame(height: 26)
+        .accessibilityIdentifier(identifier)
+    }
+
+    private func sectionLabel(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 8, weight: .bold))
+            .tracking(0.7)
+            .foregroundStyle(LocusTheme.muted)
     }
 }
 

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -15,10 +15,9 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
     }
 
-    /// SwiftUI `Menu` controls surface as MenuButton (not Button) on current
-    /// macOS, so menu anchors are matched by identifier on any element type.
-    /// Identifiers can propagate to nested elements, so take the first match —
-    /// interactions on an ambiguous query fail outright.
+    /// SwiftUI controls do not expose a stable element type across macOS
+    /// releases. Match anchors by identifier on any element type and take the
+    /// first result, because interactions on an ambiguous query fail outright.
     private func anyElement(_ identifier: String) -> XCUIElement {
         app.descendants(matching: .any)[identifier].firstMatch
     }
@@ -176,7 +175,7 @@ final class LocusUITests: XCTestCase {
 
     func testExtensionsSettingsExposesAllExtensionCenters() {
         anyElement("workspace.modelPicker").click()
-        app.menuItems["Manage Accounts…"].click()
+        app.buttons["Manage Accounts…"].click()
 
         let extensionsPage = anyElement("settings.page.extensions")
         XCTAssertTrue(extensionsPage.waitForExistence(timeout: 3))
@@ -192,7 +191,7 @@ final class LocusUITests: XCTestCase {
 
     func testNetworkSettingsRevealManualProxyFieldsAndGateSave() {
         anyElement("workspace.modelPicker").click()
-        app.menuItems["Manage Accounts…"].click()
+        app.buttons["Manage Accounts…"].click()
 
         let networkPage = anyElement("settings.page.network")
         XCTAssertTrue(networkPage.waitForExistence(timeout: 3))
@@ -218,7 +217,7 @@ final class LocusUITests: XCTestCase {
 
     func testRuntimeSettingsShowAutomaticOnlineServices() {
         anyElement("workspace.modelPicker").click()
-        app.menuItems["Manage Accounts…"].click()
+        app.buttons["Manage Accounts…"].click()
 
         // Manage Accounts lands on the Accounts tab; the runtime readout lives
         // on General.
@@ -239,12 +238,36 @@ final class LocusUITests: XCTestCase {
         let picker = anyElement("workspace.modelPicker")
         XCTAssertTrue(picker.waitForExistence(timeout: 3))
         picker.click()
-        app.menuItems["Browse Hugging Face Models…"].click()
+        app.buttons["Browse Hugging Face Models…"].click()
 
         XCTAssertTrue(app.textFields["modelLibrary.search"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.buttons["modelLibrary.searchButton"].exists)
         XCTAssertTrue(app.buttons["modelLibrary.close"].exists)
         app.buttons["modelLibrary.close"].click()
+    }
+
+    func testModelPickerStaysResponsiveWithLongVLLMModelName() {
+        app.terminate()
+        app.launchEnvironment["LOCUS_UI_TESTING_LONG_MODEL"] = "1"
+        app.launch()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+
+        let originalFrame = app.windows.firstMatch.frame
+        anyElement("workspace.modelPicker").click()
+
+        XCTAssertTrue(anyElement("workspace.modelPicker.popover").waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            app.buttons.matching(
+                NSPredicate(format: "label CONTAINS %@", "Qwen3.6-27B-Fable-Fusion")
+            ).firstMatch.exists
+        )
+        XCTAssertTrue(anyElement("workspace.modelPicker.manageAccounts").exists)
+        XCTAssertEqual(app.windows.firstMatch.frame, originalFrame)
+
+        anyElement("workspace.modelPicker.close").click()
+        XCTAssertTrue(anyElement("workspace.commandPalette").waitForExistence(timeout: 3))
+        anyElement("workspace.commandPalette").click()
+        XCTAssertTrue(app.textFields["palette.search"].waitForExistence(timeout: 3))
     }
 
     func testSlashCommandPopupListsCommands() {
@@ -363,8 +386,8 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(anyElement("checkpointTab.content").waitForExistence(timeout: 3))
         XCTAssertTrue(anyElement("checkpointTab.create").exists)
 
-        // ⌘7 — AGENTS.md, with an explanation and the workspace editor.
-        app.typeKey("7", modifierFlags: .command)
+        // ⌘8 — AGENTS.md, with an explanation and the workspace editor.
+        app.typeKey("8", modifierFlags: .command)
         XCTAssertTrue(anyElement("agents.content").waitForExistence(timeout: 3))
         XCTAssertTrue(anyElement("agents.editor").exists)
         XCTAssertTrue(anyElement("agents.save").exists)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ like; macOS remembers the size you choose for later launches.
   provider/model, elapsed time, delegated jobs, model calls, and hosted-token
   usage. Its Stop button remains available while a team is running.
 - **Team-aware model controls** label the workspace with the selected team and
-  distinct model count, list the exact team models in the header menu, and use
-  provider-backed model dropdowns when editing agent profiles.
+  distinct model count, list the exact team models in a bounded, scrollable
+  header picker, and use provider-backed model dropdowns when editing agent
+  profiles. Long vLLM repository identifiers wrap inside the picker instead of
+  resizing or stalling the app.
 - **Evaluation suites and transparent scorecard routing** compare Solo and team
   configurations against immutable fixtures, then explain why an eligible agent
   was selected.


### PR DESCRIPTION
## Summary
- replace the native model menu with a bounded, scrollable picker popover
- preserve team-aware exact model details and provider routing controls
- add a long-vLLM-name regression launch and refresh picker/settings UI coverage
- document the 1.11 picker behavior

## Verification
- 237 Locus unit tests passed
- 27 Locus UI tests passed
- 372 backend tests passed
- 26 generated Pokemon Center checker tests passed
- signed Debug app verified and exercised with the real Codex Team routes
- long-name picker remained responsive; command palette opened immediately after dismissal