### PR TITLE
Fix stalled team runs and bounded progress

### DIFF
--- a/Locus/AgentTeams.swift
+++ b/Locus/AgentTeams.swift
@@ -611,6 +611,10 @@ struct OrchestrationEvent: Identifiable, Codable, Hashable {
     var id: String { text("event_id") ?? "event-\(sequence)" }
     var sequence: Int { values["seq"]?.integer ?? 0 }
     var type: String { text("type") ?? "event" }
+    /// Per-token specialist output is intentionally transient. The completed
+    /// attempt carries the bounded output, while hundreds of token rows make
+    /// the durable timeline and Accessibility tree needlessly expensive.
+    var isTransientStream: Bool { type == "agent_job_stream" }
     var jobID: String? { text("job_id") }
     var attemptID: String? { text("attempt_id") }
     var occurredAt: Date? {

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -5512,7 +5512,8 @@ final class AppModel: ObservableObject {
 
     private func handle(_ event: [String: Any]) {
         guard let type = event["type"] as? String else { return }
-        if event["event_id"] != nil,
+        if type != "agent_job_stream",
+           event["event_id"] != nil,
            let runEvent = decode(OrchestrationEvent.self, from: event),
            !orchestrationEventIDs.contains(runEvent.id),
            selectedOrchestrationRun?.id == (event["run_id"] as? String)

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -618,8 +618,9 @@ struct InspectorRunsTab: View {
 
     private var filteredEvents: [OrchestrationEvent] {
         let query = filter.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty else { return model.orchestrationEvents }
-        return model.orchestrationEvents.filter { event in
+        let durableEvents = model.orchestrationEvents.filter { !$0.isTransientStream }
+        guard !query.isEmpty else { return durableEvents }
+        return durableEvents.filter { event in
             [
                 event.type, event.title, event.jobID, event.attemptID,
                 event.text("agent_name"), event.text("agent_id"),

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -1763,6 +1763,20 @@ final class FeatureLogicTests: XCTestCase {
         XCTAssertEqual(activity.promptTokens + activity.completionTokens, 25)
     }
 
+    func testPerTokenTeamStreamsAreExcludedFromTheDurableTimeline() throws {
+        let stream = try JSONDecoder().decode(
+            OrchestrationEvent.self,
+            from: Data(#"{"type":"agent_job_stream","seq":4,"text":"token"}"#.utf8)
+        )
+        let completed = try JSONDecoder().decode(
+            OrchestrationEvent.self,
+            from: Data(#"{"type":"agent_job_completed","seq":5}"#.utf8)
+        )
+
+        XCTAssertTrue(stream.isTransientStream)
+        XCTAssertFalse(completed.isTransientStream)
+    }
+
     func testTaskConversationStateRoundTripsWithoutConversationContent() throws {
         let state = TaskConversationState(
             sessionID: "session",

--- a/agent/ollama_code/orchestration.py
+++ b/agent/ollama_code/orchestration.py
@@ -912,6 +912,18 @@ class TeamOrchestrator:
         )
 
     def synthesize(self, prepared: TeamPreparation, reviews: list[AgentResult], diff_text: str) -> str:
+        if self.remaining_model_calls(prepared.team.budget) <= 0:
+            message = (
+                "Team work completed within the configured model-call budget. "
+                "The final dispatcher summary call was skipped because implementation and review "
+                "used the available calls; the writer's verified handoff remains above."
+            )
+            self.emit({
+                "type": "note",
+                "run_id": prepared.run_id,
+                "text": message,
+            })
+            return message
         dispatcher = prepared.profiles[prepared.team.dispatcher_id]
         payload = {
             "request": prepared.original_request,

--- a/agent/ollama_code/runstore.py
+++ b/agent/ollama_code/runstore.py
@@ -534,7 +534,13 @@ class RunStore:
                 "SELECT COALESCE(MAX(attempt), 0) + 1 FROM job_attempts WHERE run_id=? AND job_id=?",
                 (run_id, job_id),
             ).fetchone()[0])
-            attempt_id = str(event.get("attempt_id") or f"{job_id}:{attempt}")
+            # ``attempt_id`` is globally unique in the schema, while job IDs
+            # such as ``writer`` are intentionally reused by every team run.
+            # Include the run boundary so the second team run cannot collide
+            # with the first run's ``writer:1`` record.
+            attempt_id = str(
+                event.get("attempt_id") or f"{run_id}:{job_id}:{attempt}"
+            )
             event["attempt_id"] = attempt_id
             event["attempt"] = attempt
             connection.execute(
@@ -561,7 +567,7 @@ class RunStore:
                 (run_id, job_id),
             ).fetchone()
             if row is None:
-                attempt, attempt_id = 1, f"{job_id}:1"
+                attempt, attempt_id = 1, f"{run_id}:{job_id}:1"
                 connection.execute(
                     """INSERT INTO job_attempts(
                         run_id, job_id, attempt, attempt_id, agent_id, agent_name,

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -14,8 +14,10 @@ import asyncio
 import base64
 import binascii
 import ipaddress
+import logging
 import os
 import signal
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -75,6 +77,8 @@ from .telemetry import TelemetryError, send_otlp
 from .terminal import TerminalManager, TerminalRejected
 from .worktrees import TaskCheckout, TaskCheckoutStore, WorktreeError
 
+logger = logging.getLogger(__name__)
+
 #: Tools whose success means files on disk may have changed.
 _MUTATING_TOOLS = {"write_file", "edit_file", "multi_edit", "bash"}
 MAX_HTTP_BODY_BYTES = 2 * 1024 * 1024
@@ -121,6 +125,7 @@ class ChatService:
         self.pending_dispatch_decisions: dict[str, Future[dict[str, Any]]] = {}
         self.pending_dispatch_plans: dict[str, dict[str, Any]] = {}
         self.turn_future: Any = None
+        self._terminal_events = 0
         self.active_orchestrator: TeamOrchestrator | None = None
         self.active_team: TeamPreparation | None = None
         self.active_run_id: str | None = None
@@ -172,6 +177,8 @@ class ChatService:
     # -- core event bridge (called from the worker thread) --
     def emit(self, event: dict[str, Any]) -> None:
         event_type = str(event.get("type") or "")
+        if event_type == "turn_done":
+            self._terminal_events += 1
         if event_type == "session_info":
             event = dict(event)
             event.setdefault("worker_id", self.worker_id)
@@ -187,15 +194,22 @@ class ChatService:
             "workspace_changed", "note", "error", "dispatch_plan",
             "orchestration_checkpoint", "dispatch_plan_ready",
         }
+        durable_agent_event = (
+            event_type.startswith("agent_job_") and event_type != "agent_job_stream"
+        )
         if run_id and (
             event_type in persisted_types
-            or event_type.startswith(("agent_job_", "orchestration_", "scheduler_lease", "mcp_task_"))
+            or durable_agent_event
+            or event_type.startswith(("orchestration_", "scheduler_lease", "mcp_task_"))
         ):
             event = dict(event)
             event.setdefault("run_id", run_id)
             try:
                 event = self.run_store.append_event(run_id, event)
-            except RunStoreError as exc:
+            except (RunStoreError, sqlite3.DatabaseError, OSError) as exc:
+                # Run history is observability, not execution authority. A
+                # damaged or temporarily locked history store must never stop
+                # an otherwise healthy agent turn.
                 event = {**event, "persistence_error": str(exc)}
         if event_type in {"agent_job_started", "agent_job_completed", "dispatch_plan"} \
                 or event_type.startswith("orchestration_") \
@@ -405,12 +419,38 @@ class ChatService:
                 # terminate immediately after a successful cancellation.
                 self.core._interrupt.clear()
                 self.core.begin_steerable_turn()
+            terminal_before = self._terminal_events
             try:
                 self.turn_future = loop.run_in_executor(None, call, *args)
             except Exception:
                 if steerable:
                     self.core.end_steerable_turn()
                 raise
+            def observe_completion(future: asyncio.Future[Any]) -> None:
+                if future.cancelled():
+                    return
+                exception = future.exception()
+                if exception is None:
+                    return
+                logger.error(
+                    "turn worker failed unexpectedly",
+                    exc_info=(type(exception), exception, exception.__traceback__),
+                )
+                # Most turn paths publish their own terminal boundary. This is
+                # the last-resort guard for errors outside those paths, so the
+                # UI cannot remain on Running after the worker has exited.
+                if self._terminal_events == terminal_before:
+                    self.core.end_steerable_turn()
+                    self.emit({
+                        "type": "error",
+                        "message": (
+                            "The run stopped because of an internal error. "
+                            "Nothing is still running; you can retry it."
+                        ),
+                    })
+                    self.emit({"type": "turn_done", "reason": "error", "duration_ms": 0})
+
+            self.turn_future.add_done_callback(observe_completion)
             return True
 
     def queue_event(self, event: dict[str, Any]) -> None:
@@ -2447,6 +2487,7 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
     run_id = str(manifest.get("run_id") or uuid.uuid4().hex)
     svc.active_run_id = run_id
     svc.pause_requested = False
+    stage = "validating the team setup"
     try:
         run_id, team, _, _ = parse_manifest(manifest)
         svc.run_store.start_run(
@@ -2486,6 +2527,7 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
             )
             svc.emit({"type": "task_ready", "task": task.as_dict(), "state": "running"})
 
+        stage = "preparing the dispatch plan"
         orchestrator = TeamOrchestrator(
             svc.emit,
             core._should_stop_stream,
@@ -2525,8 +2567,10 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
             "dispatch_complete", _team_checkpoint_state(prepared, "running", svc.current_task)
         )
 
+        stage = "starting the writer"
         route_snapshot = _install_writer_route(core, prepared)
         try:
+            stage = "running the writer"
             _run_team_writer(
                 svc,
                 orchestrator,
@@ -2537,6 +2581,7 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
                 ),
                 job_id="writer",
                 goal=prepared.original_request,
+                reserve_model_calls=2,
             )
             terminal_reason = str(core.last_turn_result.get("reason") or "complete")
             if terminal_reason not in {"complete", "max_iterations"}:
@@ -2545,10 +2590,14 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
                 "writer_complete", _team_checkpoint_state(prepared, "reviewing", svc.current_task)
             )
 
+            stage = "reviewing the changes"
             core.begin_steerable_turn()
             diff_text = _task_diff(svc, core.workspace_root, core.cwd)
+            test_evidence = _latest_assistant_output(core)
             try:
-                reviews = orchestrator.review(prepared, diff_text)
+                reviews = orchestrator.review(
+                    prepared, diff_text, test_evidence=test_evidence,
+                )
             except InterruptedError:
                 if core._interrupt.is_set() or not core._apply_pending_steers():
                     raise
@@ -2572,9 +2621,14 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
                     persisted_user_text="[Team steering update]",
                     job_id="writer-steered",
                     goal="Apply the user's steering update to the existing task changes",
+                    reserve_model_calls=2,
                 )
                 diff_text = _task_diff(svc, core.workspace_root, core.cwd)
-                reviews = orchestrator.review(prepared, diff_text)
+                reviews = orchestrator.review(
+                    prepared,
+                    diff_text,
+                    test_evidence=_latest_assistant_output(core),
+                )
             svc.checkpoint(
                 "review_complete",
                 _team_checkpoint_state(
@@ -2593,6 +2647,7 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
                     persisted_user_text="[Team review requested a revision]",
                     job_id="writer-revision",
                     goal="Resolve verified reviewer findings and rerun focused tests",
+                    reserve_model_calls=1,
                 )
                 terminal_reason = str(core.last_turn_result.get("reason") or "complete")
                 diff_text = _task_diff(svc, core.workspace_root, core.cwd)
@@ -2603,6 +2658,7 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
                     ),
                 )
 
+            stage = "preparing the final handoff"
             core.begin_steerable_turn()
             synthesis = orchestrator.synthesize(prepared, reviews, diff_text)
             if synthesis and not core._interrupt.is_set():
@@ -2694,6 +2750,23 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
             "state": "failed",
             "duration_ms": max(int((time.monotonic() - started) * 1_000), 0),
         })
+    except Exception as exc:  # noqa: BLE001 - terminal guard for worker failures
+        terminal_reason = "error"
+        logger.exception("team run failed unexpectedly while %s", stage)
+        svc.emit({
+            "type": "error",
+            "message": (
+                f"The team run stopped unexpectedly while {stage}. "
+                "Nothing is still running; you can retry it."
+            ),
+            "error_type": type(exc).__name__,
+        })
+        svc.emit({
+            "type": "orchestration_completed",
+            "run_id": run_id,
+            "state": "failed",
+            "duration_ms": max(int((time.monotonic() - started) * 1_000), 0),
+        })
     finally:
         if svc.current_task is not None:
             task_state = {
@@ -2762,12 +2835,14 @@ def _run_team_writer(
     persisted_user_text: str,
     job_id: str,
     goal: str,
+    reserve_model_calls: int = 0,
 ) -> None:
     """Run the only mutation-capable member under both permission and call budgets."""
     core = svc.core
     remaining = orchestrator.remaining_model_calls(prepared.team.budget)
     if remaining <= 0:
         raise OrchestrationError("team model-call budget exhausted before the writer ran")
+    model_call_limit = max(remaining - max(reserve_model_calls, 0), 1)
     started = time.monotonic()
     prompt_before = core.total_prompt_tokens
     completion_before = core.total_completion_tokens
@@ -2790,7 +2865,7 @@ def _run_team_writer(
             svc.decide,
             allow_tools=True,
             persisted_user_text=persisted_user_text,
-            model_call_limit=remaining,
+            model_call_limit=model_call_limit,
             persist_user_message=False,
         )
     prompt_tokens = max(core.total_prompt_tokens - prompt_before, 0)
@@ -2828,6 +2903,15 @@ def _run_team_writer(
         },
         "usage": orchestrator.usage(),
     })
+
+
+def _latest_assistant_output(core: AgentCore) -> str:
+    """Return bounded writer verification evidence for the read-only reviewer."""
+    assistant = next(
+        (message for message in reversed(core.messages) if message.get("role") == "assistant"),
+        {},
+    )
+    return str(assistant.get("content") or "")[:120_000]
 
 
 def _install_writer_route(core: AgentCore, prepared: TeamPreparation) -> dict[str, Any]:

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -13,7 +13,9 @@ import subprocess
 import threading
 import time
 from concurrent.futures import Future
+from contextlib import nullcontext
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -2875,6 +2877,121 @@ def test_starting_a_new_team_turn_clears_the_previous_interrupt(tmp_path):
         assert observed == [False]
 
     asyncio.run(scenario())
+
+
+def test_uncaught_turn_worker_error_publishes_a_terminal_event(tmp_path):
+    async def scenario():
+        core = _core(tmp_path, [])
+        service = server_mod.ChatService(core)
+        service.loop = asyncio.get_running_loop()
+
+        def broken_turn():
+            raise RuntimeError("private diagnostic detail")
+
+        assert service.start_turn(service.loop, broken_turn)
+        with pytest.raises(RuntimeError, match="private diagnostic detail"):
+            await service.turn_future
+        await asyncio.sleep(0)
+
+        events = []
+        while not service.queue.empty():
+            events.append(service.queue.get_nowait())
+        error = next(event for event in events if event["type"] == "error")
+        terminal = next(event for event in events if event["type"] == "turn_done")
+        assert "internal error" in error["message"]
+        assert "private diagnostic detail" not in error["message"]
+        assert terminal["reason"] == "error"
+
+    asyncio.run(scenario())
+
+
+def test_team_turn_unexpected_error_is_persisted_as_failed(tmp_path, monkeypatch):
+    core = _core(tmp_path, [])
+    service = server_mod.ChatService(core)
+
+    def broken_manifest(_manifest):
+        raise RuntimeError("unexpected parser failure")
+
+    monkeypatch.setattr(server_mod, "parse_manifest", broken_manifest)
+    server_mod._run_team_turn(service, "do the work", {"run_id": "failed-team-run"})
+
+    record = service.run_store.run("failed-team-run", include_events=True)
+    assert record is not None
+    assert record["state"] == "failed"
+    assert any(
+        event["type"] == "orchestration_completed" and event["state"] == "failed"
+        for event in record["events"]
+    )
+    assert service.active_run_id is None
+
+
+def test_specialist_token_streams_do_not_flood_durable_run_history(tmp_path):
+    core = _core(tmp_path, [])
+    service = server_mod.ChatService(core)
+    service.run_store.start_run("stream-run", request="work")
+    service.active_run_id = "stream-run"
+
+    for token in ("one", "two", "three"):
+        service.emit({
+            "type": "agent_job_stream", "run_id": "stream-run",
+            "job_id": "review", "text": token,
+        })
+
+    assert service.run_store.events("stream-run") == []
+
+
+def test_team_writer_reserves_calls_for_review_and_synthesis():
+    observed = {}
+    core = SimpleNamespace(
+        total_prompt_tokens=0,
+        total_completion_tokens=0,
+        last_turn_result={"model_calls": 0},
+        messages=[{"role": "assistant", "content": "verified"}],
+    )
+
+    def run_turn(_prompt, _decider, **kwargs):
+        observed["model_call_limit"] = kwargs["model_call_limit"]
+        core.last_turn_result = {"model_calls": 2, "reason": "complete"}
+
+    core.run_turn = run_turn
+    writer = SimpleNamespace(
+        id="writer", name="Writer", role="implementer", model="k3",
+        route={"provider": "remote", "account_label": "Kimi"},
+    )
+    prepared = SimpleNamespace(
+        run_id="run", writer=writer,
+        team=SimpleNamespace(budget=SimpleNamespace()),
+    )
+
+    class Orchestrator:
+        def remaining_model_calls(self, _budget):
+            return 5
+
+        def writer_slot(self, _run_id, _writer):
+            return nullcontext()
+
+        def account_writer_usage(self, *_args):
+            return None
+
+        def usage(self):
+            return {"model_calls": 2}
+
+    events = []
+    service = SimpleNamespace(core=core, emit=events.append, decide=lambda *_args: "always")
+    server_mod._run_team_writer(
+        service,
+        Orchestrator(),
+        prepared,
+        "write",
+        persisted_user_text="request",
+        job_id="writer",
+        goal="implement",
+        reserve_model_calls=2,
+    )
+
+    assert observed["model_call_limit"] == 3
+    assert events[0]["type"] == "agent_job_started"
+    assert events[-1]["type"] == "agent_job_completed"
 
 
 def test_tool_call_runs_and_reports(tmp_path):

--- a/agent/tests/test_orchestration.py
+++ b/agent/tests/test_orchestration.py
@@ -13,6 +13,7 @@ from ollama_code.orchestration import (
     ModelCallScheduler,
     OrchestrationError,
     TeamOrchestrator,
+    TeamPreparation,
     orchestration_fingerprint,
     parse_manifest,
     validate_dispatch_plan,
@@ -191,6 +192,32 @@ def test_maximum_estimated_cost_is_a_hard_run_budget() -> None:
         orchestrator.account_writer_usage(
             profiles["writer"], team.budget, 1, 1_000, 0,
         )
+
+
+def test_synthesis_uses_a_deterministic_handoff_when_budget_is_spent() -> None:
+    events = []
+    _, team, profiles, _ = parse_manifest(_manifest())
+    plan = validate_dispatch_plan(_valid_plan(), team, profiles)
+    prepared = TeamPreparation(
+        run_id="run-1",
+        team=team,
+        profiles=profiles,
+        plan=plan,
+        results=[],
+        writer=profiles[team.default_writer_id],
+        writer_prompt="write",
+        original_request="Build it",
+        workspace="/tmp/workspace",
+    )
+    orchestrator = TeamOrchestrator(events.append, lambda: False)
+    orchestrator.account_writer_usage(
+        prepared.writer, team.budget, team.budget.max_model_calls, 0, 0,
+    )
+
+    result = orchestrator.synthesize(prepared, [], "")
+
+    assert "final dispatcher summary call was skipped" in result
+    assert [event["type"] for event in events] == ["note"]
 
 
 def test_scorecard_uses_bounded_evaluations_and_deterministic_ties(tmp_path) -> None:

--- a/agent/tests/test_runstore.py
+++ b/agent/tests/test_runstore.py
@@ -29,6 +29,27 @@ def test_run_store_orders_events_and_rebuilds_attempts(tmp_path) -> None:
     assert detail["attempts"][0]["result"]["output"] == "done"
 
 
+def test_run_store_attempt_ids_are_scoped_to_each_run(tmp_path) -> None:
+    store = RunStore(tmp_path / "runs.sqlite3")
+    attempt_ids = []
+
+    for run_id in ("first-run", "second-run"):
+        store.start_run(run_id, session_id="session", team_id="team", request="work")
+        started = store.append_event(run_id, {
+            "type": "agent_job_started", "job_id": "writer",
+            "agent_id": "writer-agent", "agent_name": "Writer",
+            "role": "implementer", "goal": "implement",
+        })
+        completed = store.append_event(run_id, {
+            "type": "agent_job_completed", "state": "completed",
+            "result": {"job_id": "writer", "output": "done"},
+        })
+        assert started["attempt_id"] == completed["attempt_id"]
+        attempt_ids.append(started["attempt_id"])
+
+    assert attempt_ids == ["first-run:writer:1", "second-run:writer:1"]
+
+
 def test_run_store_checkpoint_and_redacted_export(tmp_path) -> None:
     store = RunStore(tmp_path / "runs.sqlite3")
     store.start_run("run-1", request="secret request")


### PR DESCRIPTION
## Summary
- scope team attempt IDs to each run so repeated writer jobs cannot collide
- guarantee terminal failure events and keep run-history persistence from stopping active work
- reserve model calls for review/synthesis, with a deterministic budget-exhausted handoff
- keep per-token specialist streams out of durable history and the inspector timeline

## Verification
- 378 backend tests passed
- 265 macOS/native and UI tests passed
- live Codex Team run completed with Kimi k3 and Qwen vLLM in 10/12 calls
- generated Pokémon Center checker: 28/28 offline tests passed
