### PR TITLE
Prevent end-of-run UI freezes and restore interrupted runs

### DIFF
--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -6,6 +6,79 @@ import QuartzCore
 import UniformTypeIdentifiers
 import UserNotifications
 
+struct AppLifecycleRunSnapshot: Codable, Equatable {
+    let sessionID: String
+    let runID: String
+    let state: TeamRunState
+    let updatedAt: Date
+}
+
+struct AppLifecycleRecovery: Equatable {
+    let snapshot: AppLifecycleRunSnapshot?
+
+    var message: String {
+        guard let snapshot else {
+            return "Locus did not close normally. Your last session was restored."
+        }
+        switch snapshot.state {
+        case .completed:
+            return "Locus was force quit after the team run completed. Its results were restored."
+        case .failed, .cancelled, .discarded:
+            return "Locus did not close normally. The last team run finished as \(snapshot.state.title.lowercased())."
+        case .interrupted:
+            return "Locus closed unexpectedly. The interrupted team run is ready to resume."
+        case .queued, .dispatching, .running, .waitingPermission, .waitingComputer,
+             .waitingDispatchApproval, .reviewing, .paused:
+            return "Locus closed unexpectedly. The last team run can be inspected and resumed."
+        }
+    }
+}
+
+/// A deliberately tiny crash journal. The durable session/run database remains
+/// authoritative; these defaults only tell the next launch what to reopen and
+/// whether the previous process reached its ordinary termination hook.
+final class AppLifecycleJournal {
+    private let defaults: UserDefaults
+    private let cleanKey: String
+    private let snapshotKey: String
+
+    init(defaults: UserDefaults = .standard, keyPrefix: String = "Locus.lifecycle") {
+        self.defaults = defaults
+        cleanKey = "\(keyPrefix).clean"
+        snapshotKey = "\(keyPrefix).latestRun"
+    }
+
+    @discardableResult
+    func beginLaunch() -> AppLifecycleRecovery? {
+        let hadPreviousLaunch = defaults.object(forKey: cleanKey) != nil
+        let previousLaunchWasClean = defaults.bool(forKey: cleanKey)
+        let snapshot = defaults.data(forKey: snapshotKey)
+            .flatMap { try? JSONDecoder().decode(AppLifecycleRunSnapshot.self, from: $0) }
+        // Set this before any services are started. Force Quit cannot run a
+        // callback, so leaving this false is the abnormal-exit signal.
+        defaults.set(false, forKey: cleanKey)
+        guard hadPreviousLaunch, !previousLaunchWasClean else { return nil }
+        return AppLifecycleRecovery(snapshot: snapshot)
+    }
+
+    func record(sessionID: String, runID: String, state: TeamRunState, at date: Date = Date()) {
+        guard !sessionID.isEmpty, !runID.isEmpty else { return }
+        let snapshot = AppLifecycleRunSnapshot(
+            sessionID: sessionID,
+            runID: runID,
+            state: state,
+            updatedAt: date
+        )
+        if let data = try? JSONEncoder().encode(snapshot) {
+            defaults.set(data, forKey: snapshotKey)
+        }
+    }
+
+    func markCleanExit() {
+        defaults.set(true, forKey: cleanKey)
+    }
+}
+
 @MainActor
 final class AppModel: ObservableObject {
     @Published var agentRuntimePhase: RuntimePhase = .starting("Starting the local agent…")
@@ -180,6 +253,7 @@ final class AppModel: ObservableObject {
     @Published var streamRevision = 0
     @Published var toast: AppToast?
     var toastMessage: String? { toast?.message }
+    @Published private(set) var lifecycleRecoveryMessage: String?
     @Published var backendLogHint = ""
     @Published var contextNotice: String?
     @Published var isLoadingContext = false
@@ -293,6 +367,16 @@ final class AppModel: ObservableObject {
     private var commitDraftTask: Task<Void, Never>?
     private var filePreviewTask: Task<Void, Never>?
     private var agentInstructionsTask: Task<Void, Never>?
+    private var orchestrationRunsTasks: [String: (generation: Int, task: Task<OrchestrationRunsResponse, Error>)] = [:]
+    private var orchestrationDetailTasks: [String: Task<OrchestrationRun, Error>] = [:]
+    private var orchestrationEventTasks: [String: Task<OrchestrationEventsResponse, Error>] = [:]
+    private var orchestrationRunsGeneration = 0
+    private var orchestrationSelectionGeneration = 0
+    private var requestedOrchestrationRunID: String?
+    private var requestedOrchestrationLoadKey: String?
+    private var terminalRefreshRunIDs: Set<String> = []
+    private let lifecycleJournal: AppLifecycleJournal?
+    private var pendingLifecycleRecovery: AppLifecycleRecovery?
     private var indexedWorkspacePath: String?
     private var terminationObserver: NSObjectProtocol?
     private var activationObserver: NSObjectProtocol?
@@ -303,10 +387,17 @@ final class AppModel: ObservableObject {
     private let isUITesting: Bool
     private var isShuttingDown = false
 
-    init(startImmediately: Bool = true) {
+    init(
+        startImmediately: Bool = true,
+        backendOverride: BackendService? = nil,
+        lifecycleJournal: AppLifecycleJournal? = nil
+    ) {
         let isUITesting = ProcessInfo.processInfo.environment["LOCUS_UI_TESTING"] == "1"
         self.isUITesting = isUITesting
         persistenceEnabled = startImmediately && !isUITesting
+        let launchJournal = lifecycleJournal ?? AppLifecycleJournal()
+        self.lifecycleJournal = persistenceEnabled ? launchJournal : nil
+        pendingLifecycleRecovery = persistenceEnabled ? launchJournal.beginLaunch() : nil
         let defaults = UserDefaults.standard
         var loadedSettings: AppSettings
         // Gated on `persistenceEnabled` for the same reason the accounts below
@@ -460,7 +551,7 @@ final class AppModel: ObservableObject {
         sidebarCollapsed = loadedSettings.sidebarCollapsed
         inspectorTab = loadedSettings.resolvedInspectorTab
 
-        backend = BackendService(
+        backend = backendOverride ?? BackendService(
             baseURL: URL(string: loadedSettings.backendURL) ?? URL(string: "http://127.0.0.1:8791")!
         )
 
@@ -950,8 +1041,64 @@ final class AppModel: ObservableObject {
             immediate: true
         )
         await recovery?.value
+        await restoreAfterUncleanExitIfNeeded()
         requestNotificationAuthorization()
         startRuntimeMonitor()
+    }
+
+    private func restoreAfterUncleanExitIfNeeded() async {
+        guard let recovery = pendingLifecycleRecovery else { return }
+        pendingLifecycleRecovery = nil
+
+        if let snapshot = recovery.snapshot {
+            if currentSessionID != snapshot.sessionID,
+               let session = sessions.first(where: { $0.id == snapshot.sessionID })
+            {
+                resume(session)
+                // `resume` also serves ordinary UI actions and owns its Task.
+                // Wait briefly for that existing path instead of duplicating
+                // its transcript/workspace restoration logic here.
+                for _ in 0..<50 {
+                    guard currentSessionID != snapshot.sessionID else { break }
+                    try? await Task.sleep(for: .milliseconds(100))
+                }
+            }
+            if currentSessionID == snapshot.sessionID {
+                await refreshOrchestrationRuns(
+                    select: snapshot.runID,
+                    terminal: snapshot.state == .completed
+                        || snapshot.state == .failed
+                        || snapshot.state == .cancelled
+                        || snapshot.state == .discarded
+                        || snapshot.state == .interrupted
+                )
+            }
+        }
+
+        inspectorTab = .runs
+        inspectorCollapsed = false
+        settings.inspectorLastTab = InspectorTab.runs.rawValue
+        let message = lifecycleRecoveryExplanation(fallback: recovery)
+        lifecycleRecoveryMessage = message
+        showToast(message, duration: 8)
+    }
+
+    private func lifecycleRecoveryExplanation(fallback: AppLifecycleRecovery) -> String {
+        guard let run = selectedOrchestrationRun else { return fallback.message }
+        if run.state == TeamRunState.completed.rawValue {
+            return "Locus was force quit after the team run completed. Its results were restored."
+        }
+        if run.recoverable {
+            return "Locus closed unexpectedly. This team run can be resumed from its saved checkpoint."
+        }
+        if let state = TeamRunState(rawValue: run.state) {
+            return "Locus did not close normally. The restored team run is \(state.title.lowercased())."
+        }
+        return fallback.message
+    }
+
+    func dismissLifecycleRecoveryMessage() {
+        lifecycleRecoveryMessage = nil
     }
 
     @discardableResult
@@ -1133,6 +1280,7 @@ final class AppModel: ObservableObject {
 
     func shutdown() {
         isShuttingDown = true
+        lifecycleJournal?.markCleanExit()
         persistCurrentWorkspaceProfile()
         // Flush rather than cancel: a debounced settings write that is still
         // pending at quit would otherwise be dropped.
@@ -1147,6 +1295,12 @@ final class AppModel: ObservableObject {
         knowledgeReindexTask?.cancel()
         knowledgeWatcher.stop()
         agentInstructionsTask?.cancel()
+        orchestrationRunsTasks.values.forEach { $0.task.cancel() }
+        orchestrationDetailTasks.values.forEach { $0.cancel() }
+        orchestrationEventTasks.values.forEach { $0.cancel() }
+        orchestrationRunsTasks.removeAll()
+        orchestrationDetailTasks.removeAll()
+        orchestrationEventTasks.removeAll()
         backend.disconnect()
         backendProcess.stop()
         taskWorkers.values.forEach { $0.stop() }
@@ -2884,34 +3038,109 @@ final class AppModel: ObservableObject {
         return manifest
     }
 
-    func refreshOrchestrationRuns(select runID: String? = nil) async {
+    func refreshOrchestrationRuns(
+        select runID: String? = nil,
+        terminal: Bool = false
+    ) async {
+        let sessionID = currentSessionID
+        let requestKey = [sessionID, terminal ? "terminal:\(runID ?? "")" : "routine"]
+            .joined(separator: "|")
+        let request: (generation: Int, task: Task<OrchestrationRunsResponse, Error>)
+        if let existing = orchestrationRunsTasks[requestKey] {
+            request = existing
+        } else {
+            orchestrationRunsGeneration += 1
+            let generation = orchestrationRunsGeneration
+            let query = sessionID.isEmpty
+                ? []
+                : [URLQueryItem(name: "session_id", value: sessionID)]
+            let task = Task { [backend] in
+                try await backend.get(
+                    "/api/orchestrations",
+                    query: query,
+                    as: OrchestrationRunsResponse.self
+                )
+            }
+            request = (generation, task)
+            orchestrationRunsTasks[requestKey] = request
+        }
         do {
-            let response: OrchestrationRunsResponse = try await backend.get(
-                "/api/orchestrations",
-                query: currentSessionID.isEmpty ? [] : [URLQueryItem(name: "session_id", value: currentSessionID)],
-                as: OrchestrationRunsResponse.self
-            )
-            orchestrationRuns = response.runs
+            let response = try await request.task.value
+            if orchestrationRunsTasks[requestKey]?.generation == request.generation {
+                orchestrationRunsTasks.removeValue(forKey: requestKey)
+            }
+            guard request.generation == orchestrationRunsGeneration,
+                  currentSessionID == sessionID
+            else { return }
+            if orchestrationRuns != response.runs {
+                orchestrationRuns = response.runs
+            }
             let selectedID = runID ?? selectedOrchestrationRun?.id
                 ?? orchestrationRunID ?? response.runs.first?.id
-            if let selectedID { await loadOrchestrationRun(selectedID) }
+            if let selectedID {
+                await loadOrchestrationRun(selectedID, terminal: terminal)
+            }
         } catch {
+            if orchestrationRunsTasks[requestKey]?.generation == request.generation {
+                orchestrationRunsTasks.removeValue(forKey: requestKey)
+            }
+            guard !Task.isCancelled, request.generation == orchestrationRunsGeneration else { return }
             showToast("Could not load team runs: \(error.localizedDescription)")
         }
     }
 
-    func loadOrchestrationRun(_ runID: String) async {
+    func loadOrchestrationRun(_ runID: String, terminal: Bool = false) async {
+        let sameRun = selectedOrchestrationRun?.id == runID
+        let afterSequence = sameRun ? orchestrationEvents.map(\.sequence).max() ?? 0 : 0
+        let loadKey = "\(runID)|\(afterSequence)|\(terminal ? "terminal" : "routine")"
+        let generation: Int
+        if requestedOrchestrationLoadKey == loadKey {
+            generation = orchestrationSelectionGeneration
+        } else {
+            orchestrationSelectionGeneration += 1
+            generation = orchestrationSelectionGeneration
+            requestedOrchestrationLoadKey = loadKey
+            requestedOrchestrationRunID = runID
+        }
+        let detailKey = "\(runID)|\(terminal ? "terminal" : "routine")"
+        let eventsKey = "\(runID)|\(afterSequence)|\(terminal ? "terminal" : "routine")"
+        let detailTask = orchestrationDetailTask(runID: runID, key: detailKey)
+        let eventsTask = orchestrationEventsTask(
+            runID: runID,
+            afterSequence: afterSequence,
+            key: eventsKey
+        )
         do {
-            async let detail: OrchestrationRun = backend.get(
-                "/api/orchestrations/\(runID)", as: OrchestrationRun.self
-            )
-            async let events: OrchestrationEventsResponse = backend.get(
-                "/api/orchestrations/\(runID)/events", as: OrchestrationEventsResponse.self
-            )
-            selectedOrchestrationRun = try await detail
-            orchestrationEvents = try await events.events
-            orchestrationEventIDs = Set(orchestrationEvents.map(\.id))
+            let detail = try await detailTask.value
+            let response = try await eventsTask.value
+            if orchestrationDetailTasks[detailKey] != nil {
+                orchestrationDetailTasks.removeValue(forKey: detailKey)
+            }
+            if orchestrationEventTasks[eventsKey] != nil {
+                orchestrationEventTasks.removeValue(forKey: eventsKey)
+            }
+            guard generation == orchestrationSelectionGeneration,
+                  requestedOrchestrationRunID == runID
+            else { return }
+            let base = sameRun ? orchestrationEvents : []
+            let merged = Self.mergeOrchestrationEvents(base, with: response.events)
+            if selectedOrchestrationRun != detail {
+                selectedOrchestrationRun = detail
+            }
+            if orchestrationEvents != merged {
+                orchestrationEvents = merged
+            }
+            orchestrationEventIDs = Set(merged.map(\.id))
+            if orchestrationRunID == runID,
+               let state = TeamRunState(rawValue: detail.state),
+               orchestrationState != state
+            {
+                orchestrationState = state
+            }
         } catch {
+            orchestrationDetailTasks.removeValue(forKey: detailKey)
+            orchestrationEventTasks.removeValue(forKey: eventsKey)
+            guard !Task.isCancelled, generation == orchestrationSelectionGeneration else { return }
             showToast("Could not inspect that run: \(error.localizedDescription)")
         }
     }
@@ -2921,21 +3150,65 @@ final class AppModel: ObservableObject {
             .filter { $0.text("run_id") == runID }
             .map(\.sequence)
             .max() ?? 0
+        let key = "\(runID)|\(after)|routine"
+        let task = orchestrationEventsTask(runID: runID, afterSequence: after, key: key)
         do {
-            let response: OrchestrationEventsResponse = try await backend.get(
-                "/api/orchestrations/\(runID)/events",
-                query: [URLQueryItem(name: "after_seq", value: String(after))],
-                as: OrchestrationEventsResponse.self
-            )
-            for event in response.events where !orchestrationEventIDs.contains(event.id) {
-                orchestrationEventIDs.insert(event.id)
-                orchestrationEvents.append(event)
+            let response = try await task.value
+            orchestrationEventTasks.removeValue(forKey: key)
+            guard selectedOrchestrationRun?.id == runID || orchestrationRunID == runID else { return }
+            let merged = Self.mergeOrchestrationEvents(orchestrationEvents, with: response.events)
+            if merged != orchestrationEvents {
+                orchestrationEvents = merged
+                orchestrationEventIDs = Set(merged.map(\.id))
             }
-            orchestrationEvents.sort { $0.sequence < $1.sequence }
         } catch {
+            orchestrationEventTasks.removeValue(forKey: key)
             // The inspector can still reload the full run on demand. A failed
             // reconnect backfill must not disturb the active transcript.
         }
+    }
+
+    nonisolated static func mergeOrchestrationEvents(
+        _ existing: [OrchestrationEvent],
+        with incoming: [OrchestrationEvent]
+    ) -> [OrchestrationEvent] {
+        var byID: [String: OrchestrationEvent] = [:]
+        for event in existing where !event.isTransientStream { byID[event.id] = event }
+        for event in incoming where !event.isTransientStream { byID[event.id] = event }
+        return byID.values.sorted {
+            $0.sequence == $1.sequence ? $0.id < $1.id : $0.sequence < $1.sequence
+        }
+    }
+
+    private func orchestrationDetailTask(
+        runID: String,
+        key: String
+    ) -> Task<OrchestrationRun, Error> {
+        if let existing = orchestrationDetailTasks[key] { return existing }
+        let task = Task { [backend] in
+            try await backend.get(
+                "/api/orchestrations/\(runID)", as: OrchestrationRun.self
+            )
+        }
+        orchestrationDetailTasks[key] = task
+        return task
+    }
+
+    private func orchestrationEventsTask(
+        runID: String,
+        afterSequence: Int,
+        key: String
+    ) -> Task<OrchestrationEventsResponse, Error> {
+        if let existing = orchestrationEventTasks[key] { return existing }
+        let task = Task { [backend] in
+            try await backend.get(
+                "/api/orchestrations/\(runID)/events",
+                query: [URLQueryItem(name: "after_seq", value: String(afterSequence))],
+                as: OrchestrationEventsResponse.self
+            )
+        }
+        orchestrationEventTasks[key] = task
+        return task
     }
 
     func exportOrchestration(_ runID: String, includeContent: Bool) async {
@@ -3993,6 +4266,13 @@ final class AppModel: ObservableObject {
                         state: state,
                         updatedAt: Date()
                     )
+                    if let runID = response.orchestrationRunID {
+                        lifecycleJournal?.record(
+                            sessionID: response.sessionInfo.sessionID,
+                            runID: runID,
+                            state: state
+                        )
+                    }
                 }
                 touchWorkspaceProfile(response.sessionInfo.cwd)
                 showToast("Session resumed")
@@ -5418,7 +5698,7 @@ final class AppModel: ObservableObject {
             runtime.sessionInfo = runtime.sessionInfo?.replacingTask(record)
             state = record.state ?? state
         }
-        taskConversationStates[runtime.sessionID] = TaskConversationState(
+        let updated = TaskConversationState(
             sessionID: runtime.sessionID,
             taskID: taskID,
             teamID: (event["team_id"] as? String) ?? previous?.teamID,
@@ -5427,6 +5707,14 @@ final class AppModel: ObservableObject {
             state: state,
             updatedAt: Date()
         )
+        taskConversationStates[runtime.sessionID] = updated
+        if let runID = updated.runID {
+            lifecycleJournal?.record(
+                sessionID: runtime.sessionID,
+                runID: runID,
+                state: state
+            )
+        }
         if (type == "orchestration_started" || type == "turn_done"), persistenceEnabled {
             Task { await refreshMetadata() }
         }
@@ -5499,7 +5787,7 @@ final class AppModel: ObservableObject {
     ) {
         guard !currentSessionID.isEmpty else { return }
         let previous = taskConversationStates[currentSessionID]
-        taskConversationStates[currentSessionID] = TaskConversationState(
+        let updated = TaskConversationState(
             sessionID: currentSessionID,
             taskID: taskID ?? activeTaskRecord?.id ?? previous?.taskID,
             teamID: (event["team_id"] as? String) ?? previous?.teamID,
@@ -5508,6 +5796,18 @@ final class AppModel: ObservableObject {
             state: state,
             updatedAt: Date()
         )
+        if previous?.taskID == updated.taskID,
+           previous?.teamID == updated.teamID,
+           previous?.workerID == updated.workerID,
+           previous?.runID == updated.runID,
+           previous?.state == updated.state
+        {
+            return
+        }
+        taskConversationStates[currentSessionID] = updated
+        if let runID = updated.runID {
+            lifecycleJournal?.record(sessionID: currentSessionID, runID: runID, state: state)
+        }
     }
 
     private func handle(_ event: [String: Any]) {
@@ -5548,11 +5848,6 @@ final class AppModel: ObservableObject {
                 }
                 noteLocalHost(from: info)
                 applyWorkspaceProfileIfNeeded(for: info)
-                if !currentSessionID.isEmpty {
-                    Task { @MainActor [weak self] in
-                        await self?.refreshOrchestrationRuns()
-                    }
-                }
             }
 
         case "session_started":
@@ -5778,9 +6073,10 @@ final class AppModel: ObservableObject {
             }
 
         case "orchestration_state":
-            orchestrationState = (event["state"] as? String)
-                .flatMap(TeamRunState.init(rawValue:))
-            if let orchestrationState { updateTaskConversation(state: orchestrationState, event: event) }
+            if let state = (event["state"] as? String).flatMap(TeamRunState.init(rawValue:)) {
+                if orchestrationState != state { orchestrationState = state }
+                updateTaskConversation(state: state, event: event)
+            }
 
         case "dispatch_plan_ready":
             orchestrationState = .waitingDispatchApproval
@@ -5883,17 +6179,23 @@ final class AppModel: ObservableObject {
             }
 
         case "orchestration_completed":
-            orchestrationState = (event["state"] as? String)
+            let completedState = (event["state"] as? String)
                 .flatMap(TeamRunState.init(rawValue:)) ?? .completed
-            if let orchestrationState { updateTaskConversation(state: orchestrationState, event: event) }
+            if orchestrationState != completedState { orchestrationState = completedState }
+            updateTaskConversation(state: completedState, event: event)
             if let usage = event["usage"] as? [String: Any] {
                 teamModelCalls = usage["model_calls"] as? Int ?? teamModelCalls
                 teamMeteredTokens = usage["metered_tokens"] as? Int ?? teamMeteredTokens
             }
             if let runID = event["run_id"] as? String {
-                Task { @MainActor [weak self] in
-                    await self?.refreshOrchestrationRuns(select: runID)
-                    await self?.exportOrchestrationToOTLP(runID)
+                // Reconnects can replay this durable terminal event. Only the
+                // first copy should start the final metadata + incremental
+                // timeline fetch; the live event itself is already deduped.
+                if terminalRefreshRunIDs.insert(runID).inserted {
+                    Task { @MainActor [weak self] in
+                        await self?.refreshOrchestrationRuns(select: runID, terminal: true)
+                        await self?.exportOrchestrationToOTLP(runID)
+                    }
                 }
             }
 
@@ -6715,6 +7017,61 @@ final class AppModel: ObservableObject {
                     requestID: "req-ui-1"
                 )
             ))
+        }
+        seedUITestRunFixtureIfNeeded()
+    }
+
+    private func seedUITestRunFixtureIfNeeded() {
+        guard let fixture = ProcessInfo.processInfo.environment["LOCUS_UI_TESTING_RUN_FIXTURE"],
+              fixture == "completed" || fixture == "recoverable"
+        else { return }
+        let state: TeamRunState = fixture == "completed" ? .completed : .interrupted
+        let run = OrchestrationRun(
+            id: "seed-run",
+            sessionID: "seed-current",
+            teamID: "seed-team",
+            teamName: "Codex Team",
+            workerID: "seed-worker",
+            workspaceRoot: "/tmp",
+            executionPath: "/tmp",
+            taskID: nil,
+            state: state.rawValue,
+            request: "Build a Pokémon Center stock checker",
+            createdAt: Date().addingTimeInterval(-300).timeIntervalSince1970,
+            updatedAt: Date().timeIntervalSince1970,
+            completedAt: fixture == "completed" ? Date().timeIntervalSince1970 : nil,
+            lastSequence: 1_200,
+            pinned: false,
+            legacy: false,
+            recoverable: fixture == "recoverable",
+            recoveryReason: fixture == "recoverable" ? "Saved checkpoint available" : nil,
+            checkpoint: nil,
+            attempts: nil
+        )
+        orchestrationRuns = [run]
+        selectedOrchestrationRun = run
+        orchestrationRunID = run.id
+        orchestrationState = state
+        let rawEvents: [[String: Any]] = (1...1_200).map { sequence in
+            [
+                "event_id": "seed-event-\(sequence)",
+                "run_id": run.id,
+                "seq": sequence,
+                "type": sequence == 1_200 ? "orchestration_completed" : "agent_job_completed",
+                "summary": sequence == 1_200 ? "Team run completed" : "Durable result \(sequence)",
+                "detail": String(repeating: "Verified output. ", count: 12),
+            ]
+        }
+        orchestrationEvents = rawEvents.compactMap {
+            decode(OrchestrationEvent.self, from: $0)
+        }
+        orchestrationEventIDs = Set(orchestrationEvents.map(\.id))
+        inspectorTab = .runs
+        inspectorCollapsed = false
+        if ProcessInfo.processInfo.environment["LOCUS_UI_TESTING_UNCLEAN_RECOVERY"] == "1" {
+            lifecycleRecoveryMessage = fixture == "completed"
+                ? "Locus was force quit after the team run completed. Its results were restored."
+                : "Locus closed unexpectedly. This team run can be resumed from its saved checkpoint."
         }
     }
 

--- a/Locus/BackendService.swift
+++ b/Locus/BackendService.swift
@@ -17,11 +17,13 @@ final class BackendService {
     /// Pinned direct, over every proxy layer including the system's: the
     /// agent is a loopback child of this process, and no proxy configuration
     /// — however wrong — may ever sit between the app and it.
-    private let session: URLSession = {
+    private let session: URLSession
+
+    private static func makeSession() -> URLSession {
         let configuration = URLSessionConfiguration.default
         configuration.connectionProxyDictionary = [:]
         return URLSession(configuration: configuration)
-    }()
+    }
     private var socket: URLSessionWebSocketTask?
     private var baseURL: URL
     private var reconnectTask: Task<Void, Never>?
@@ -37,10 +39,12 @@ final class BackendService {
 
     init(
         baseURL: URL = URL(string: "http://127.0.0.1:8791")!,
-        authToken: String = BackendSecurity.launchToken
+        authToken: String = BackendSecurity.launchToken,
+        session: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.authToken = authToken
+        self.session = session ?? Self.makeSession()
     }
 
     func updateBaseURL(_ url: URL) {

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -223,6 +223,26 @@ struct InspectorRunsTab: View {
     var body: some View {
         VStack(spacing: 0) {
             header
+            if let message = model.lifecycleRecoveryMessage {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "arrow.counterclockwise.circle.fill")
+                        .foregroundStyle(LocusTheme.signalDeep)
+                    Text(message)
+                        .font(.system(size: 9))
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: 4)
+                    Button {
+                        model.dismissLifecycleRecoveryMessage()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Dismiss recovery explanation")
+                }
+                .padding(10)
+                .background(LocusTheme.signal.opacity(0.1))
+                .accessibilityIdentifier("runs.recoveryExplanation")
+            }
             if let plan = draftPlan, model.pendingDispatchPlan != nil {
                 dispatchEditor(plan)
             } else if let run = model.selectedOrchestrationRun {
@@ -236,7 +256,11 @@ struct InspectorRunsTab: View {
                 )
             }
         }
-        .task { await model.refreshOrchestrationRuns() }
+        .task {
+            if model.orchestrationRuns.isEmpty, model.selectedOrchestrationRun == nil {
+                await model.refreshOrchestrationRuns()
+            }
+        }
         .onChange(of: model.pendingDispatchPlan) { _, value in draftPlan = value }
         .onAppear { draftPlan = model.pendingDispatchPlan }
     }
@@ -295,6 +319,7 @@ struct InspectorRunsTab: View {
                     Text("\(run.state.replacingOccurrences(of: "_", with: " ")) · \(run.lastSequence) events")
                         .font(.system(size: 8, design: .monospaced))
                         .foregroundStyle(LocusTheme.muted)
+                        .accessibilityIdentifier("runs.state")
                 }
                 Spacer()
                 runActions(run)
@@ -376,6 +401,7 @@ struct InspectorRunsTab: View {
         VStack(spacing: 0) {
             TextField("Filter agent, event, state, or attempt", text: $filter)
                 .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("runs.filter")
                 .padding(.horizontal, 12)
                 .padding(.bottom, 7)
             ScrollView {

--- a/Locus/SessionSidebarView.swift
+++ b/Locus/SessionSidebarView.swift
@@ -611,38 +611,50 @@ private struct TeamProgressPopover: View {
     @EnvironmentObject private var model: AppModel
     let dismiss: () -> Void
 
+    @ViewBuilder
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 1)) { timeline in
-            VStack(alignment: .leading, spacing: 0) {
-                header
-                Divider()
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 12) {
-                        if let issue = model.selectedTeamRouteIssue {
-                            Label(issue, systemImage: "exclamationmark.triangle.fill")
-                                .font(.system(size: 9, weight: .medium))
-                                .foregroundStyle(LocusTheme.coral)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .padding(10)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .background(LocusTheme.coral.opacity(0.08))
-                                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                                .accessibilityIdentifier("teamProgress.routeIssue")
-                        }
-
-                        dispatcherSection(now: timeline.date)
-                        delegatedJobs
-                        modelRoster
-                    }
-                    .padding(14)
-                }
-                .frame(maxHeight: 430)
-                Divider()
-                footer
+        if runIsActive {
+            TimelineView(.periodic(from: .now, by: 1)) { timeline in
+                content(now: timeline.date)
             }
-            .frame(width: 370)
-            .background(LocusTheme.panel)
+        } else {
+            // A terminal run has no elapsed clock left to update. Keeping a
+            // periodic TimelineView alive here made the completed popover
+            // invalidate the entire sidebar once per second indefinitely.
+            content(now: Date())
         }
+    }
+
+    private func content(now: Date) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    if let issue = model.selectedTeamRouteIssue {
+                        Label(issue, systemImage: "exclamationmark.triangle.fill")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(LocusTheme.coral)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(10)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(LocusTheme.coral.opacity(0.08))
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                            .accessibilityIdentifier("teamProgress.routeIssue")
+                    }
+
+                    dispatcherSection(now: now)
+                    delegatedJobs
+                    modelRoster
+                }
+                .padding(14)
+            }
+            .frame(maxHeight: 430)
+            Divider()
+            footer
+        }
+        .frame(width: 370)
+        .background(LocusTheme.panel)
         .accessibilityIdentifier("teamProgress.popover")
     }
 
@@ -690,6 +702,7 @@ private struct TeamProgressPopover: View {
                     Text(dispatcherDetail(activity: activity))
                         .font(.system(size: 9))
                         .foregroundStyle(LocusTheme.inkSoft)
+                        .lineLimit(4)
                 }
                 Spacer(minLength: 6)
                 if startedAt != nil && runIsActive {

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -1,7 +1,203 @@
 import XCTest
 @testable import Locus
 
+private final class OrchestrationURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var recordedURLs: [URL] = []
+    static var responseDelay: (URL) -> TimeInterval = { _ in 0 }
+
+    static func reset() {
+        lock.lock()
+        recordedURLs = []
+        responseDelay = { _ in 0 }
+        lock.unlock()
+    }
+
+    static var requests: [URL] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedURLs
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url else { return }
+        Self.lock.lock()
+        Self.recordedURLs.append(url)
+        let delay = Self.responseDelay(url)
+        Self.lock.unlock()
+
+        let complete = { [weak self] in
+            guard let self else { return }
+            let data = Self.responseData(for: url)
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        }
+        if delay > 0 {
+            DispatchQueue.global().asyncAfter(deadline: .now() + delay, execute: complete)
+        } else {
+            complete()
+        }
+    }
+
+    override func stopLoading() {}
+
+    private static func responseData(for url: URL) -> Data {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let path = components?.path ?? url.path
+        let parts = path.split(separator: "/")
+        let runID = parts.count >= 3 ? String(parts[2]) : "run-1"
+        let run = runJSON(id: runID)
+        if path == "/api/orchestrations" {
+            return try! JSONSerialization.data(withJSONObject: [
+                "runs": [runJSON(id: "run-1")],
+                "read_only": false,
+            ])
+        }
+        if path.hasSuffix("/events") {
+            let after = Int(components?.queryItems?.first(where: { $0.name == "after_seq" })?.value ?? "0") ?? 0
+            let events: [[String: Any]] = after < 65 ? [
+                ["event_id": "event-65", "run_id": runID, "seq": 65, "type": "agent_job_completed", "state": "completed"],
+            ] : []
+            return try! JSONSerialization.data(withJSONObject: [
+                "run_id": runID,
+                "events": events,
+                "last_seq": max(after, 65),
+            ])
+        }
+        return try! JSONSerialization.data(withJSONObject: run)
+    }
+
+    private static func runJSON(id: String) -> [String: Any] {
+        [
+            "id": id,
+            "session_id": "session-1",
+            "team_id": "team-1",
+            "team_name": "Codex Team",
+            "worker_id": "worker-1",
+            "workspace_root": "/tmp",
+            "execution_path": "/tmp",
+            "state": "completed",
+            "request": "Check stock",
+            "created_at": 1.0,
+            "updated_at": 2.0,
+            "completed_at": 2.0,
+            "last_seq": 65,
+            "pinned": false,
+            "legacy": false,
+            "recoverable": false,
+        ]
+    }
+}
+
 final class AppModelTests: XCTestCase {
+    @MainActor
+    private func orchestrationModel() -> AppModel {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [OrchestrationURLProtocol.self]
+        let service = BackendService(
+            baseURL: URL(string: "http://locus.test")!,
+            authToken: "test",
+            session: URLSession(configuration: configuration)
+        )
+        let model = AppModel(startImmediately: false, backendOverride: service)
+        model.currentSessionID = "session-1"
+        return model
+    }
+
+    override func setUp() {
+        super.setUp()
+        OrchestrationURLProtocol.reset()
+    }
+
+    @MainActor
+    func testDuplicateSessionInfoAndCompletionPerformOneIncrementalRefresh() async throws {
+        let model = orchestrationModel()
+        await model.loadOrchestrationRun("run-1")
+        OrchestrationURLProtocol.reset()
+
+        var info = sessionInfo(id: "session-1")
+        info["type"] = "session_info"
+        model.handleEventForTesting(info)
+        model.handleEventForTesting(info)
+        let completed: [String: Any] = [
+            "type": "orchestration_completed",
+            "event_id": "event-66",
+            "seq": 66,
+            "run_id": "run-1",
+            "state": "completed",
+        ]
+        model.handleEventForTesting(completed)
+        model.handleEventForTesting(completed)
+
+        for _ in 0..<50 where OrchestrationURLProtocol.requests.count < 3 {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        let urls = OrchestrationURLProtocol.requests
+        XCTAssertEqual(urls.filter { $0.path == "/api/orchestrations" }.count, 1)
+        XCTAssertEqual(urls.filter { $0.path == "/api/orchestrations/run-1" }.count, 1)
+        let eventURLs = urls.filter { $0.path.hasSuffix("/events") }
+        XCTAssertEqual(eventURLs.count, 1)
+        XCTAssertEqual(
+            URLComponents(url: try XCTUnwrap(eventURLs.first), resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "after_seq" })?.value,
+            "66"
+        )
+    }
+
+    @MainActor
+    func testConcurrentRunRefreshesCoalesce() async {
+        let model = orchestrationModel()
+        let first = Task { await model.refreshOrchestrationRuns(select: "run-1") }
+        let second = Task { await model.refreshOrchestrationRuns(select: "run-1") }
+        await first.value
+        await second.value
+
+        let urls = OrchestrationURLProtocol.requests
+        XCTAssertEqual(urls.filter { $0.path == "/api/orchestrations" }.count, 1)
+        XCTAssertEqual(urls.filter { $0.path == "/api/orchestrations/run-1" }.count, 1)
+        XCTAssertEqual(urls.filter { $0.path.hasSuffix("/events") }.count, 1)
+    }
+
+    @MainActor
+    func testLateRunResponseCannotReplaceNewerSelection() async throws {
+        OrchestrationURLProtocol.responseDelay = { url in
+            url.path.contains("run-old") ? 0.2 : 0
+        }
+        let model = orchestrationModel()
+        let old = Task { await model.loadOrchestrationRun("run-old") }
+        try await Task.sleep(for: .milliseconds(20))
+        let new = Task { await model.loadOrchestrationRun("run-new") }
+        await new.value
+        await old.value
+
+        XCTAssertEqual(model.selectedOrchestrationRun?.id, "run-new")
+    }
+
+    func testIncrementalEventMergeDeduplicatesAndDropsTransientStreams() throws {
+        func event(_ json: String) throws -> OrchestrationEvent {
+            try JSONDecoder().decode(OrchestrationEvent.self, from: Data(json.utf8))
+        }
+        let one = try event(#"{"event_id":"one","seq":1,"type":"orchestration_started"}"#)
+        let duplicate = try event(#"{"event_id":"one","seq":1,"type":"orchestration_started"}"#)
+        let stream = try event(#"{"event_id":"stream","seq":2,"type":"agent_job_stream"}"#)
+        let three = try event(#"{"event_id":"three","seq":3,"type":"orchestration_completed"}"#)
+
+        XCTAssertEqual(
+            AppModel.mergeOrchestrationEvents([one], with: [duplicate, stream, three]).map(\.id),
+            ["one", "three"]
+        )
+    }
+
     @MainActor
     func testOrchestrationControlsResolveTheWorkerThatOwnsTheRun() {
         let oldRun = TaskConversationState(

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -109,6 +109,50 @@ final class FeatureLogicTests: XCTestCase {
         )
     }
 
+    func testLifecycleJournalDistinguishesCleanAndUncleanTermination() throws {
+        let suite = "LocusTests.lifecycle.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let journal = AppLifecycleJournal(defaults: defaults, keyPrefix: "test")
+
+        XCTAssertNil(journal.beginLaunch(), "the first launch is not a recovery")
+        journal.record(
+            sessionID: "session-1",
+            runID: "run-1",
+            state: .running,
+            at: Date(timeIntervalSince1970: 10)
+        )
+
+        let afterForcedQuit = AppLifecycleJournal(defaults: defaults, keyPrefix: "test")
+            .beginLaunch()
+        XCTAssertEqual(afterForcedQuit?.snapshot?.runID, "run-1")
+        XCTAssertEqual(afterForcedQuit?.snapshot?.state, .running)
+
+        journal.markCleanExit()
+        XCTAssertNil(
+            AppLifecycleJournal(defaults: defaults, keyPrefix: "test").beginLaunch(),
+            "normal termination must not show crash recovery"
+        )
+    }
+
+    func testLifecycleRecoveryExplainsCompletedAndRecoverableRuns() {
+        let completed = AppLifecycleRecovery(snapshot: AppLifecycleRunSnapshot(
+            sessionID: "session",
+            runID: "completed",
+            state: .completed,
+            updatedAt: Date()
+        ))
+        let active = AppLifecycleRecovery(snapshot: AppLifecycleRunSnapshot(
+            sessionID: "session",
+            runID: "active",
+            state: .waitingPermission,
+            updatedAt: Date()
+        ))
+
+        XCTAssertTrue(completed.message.contains("completed"))
+        XCTAssertTrue(active.message.contains("resumed"))
+    }
+
     // MARK: - Slash commands
 
     func testSlashQueryDetection() {

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -473,6 +473,50 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
     }
 
+    private func relaunchWithRunFixture(_ fixture: String, uncleanRecovery: Bool = false) {
+        app.terminate()
+        app.launchEnvironment["LOCUS_UI_TESTING_RUN_FIXTURE"] = fixture
+        app.launchEnvironment["LOCUS_UI_TESTING_UNCLEAN_RECOVERY"] = uncleanRecovery ? "1" : nil
+        app.launch()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+    }
+
+    func testCompletedRunWithLargeTimelineRemainsResponsiveAndRestoresAfterForceQuit() {
+        relaunchWithRunFixture("completed", uncleanRecovery: true)
+
+        let state = anyElement("runs.state")
+        XCTAssertTrue(state.waitForExistence(timeout: 3))
+        XCTAssertTrue((state.label + " \(state.value ?? "")").lowercased().contains("completed"))
+        XCTAssertTrue(anyElement("runs.recoveryExplanation").exists)
+        XCTAssertTrue(
+            app.staticTexts.matching(
+                NSPredicate(format: "value CONTAINS[c] %@ OR label CONTAINS[c] %@", "results were restored", "results were restored")
+            ).firstMatch.exists
+        )
+
+        let filter = app.textFields["runs.filter"]
+        filter.click()
+        filter.typeText("Team run completed")
+        XCTAssertEqual(filter.value as? String, "Team run completed")
+
+        // Exercise controls after the 1,200-event timeline has laid out.
+        app.typeKey("1", modifierFlags: .command)
+        XCTAssertTrue(anyElement("plan.create").waitForExistence(timeout: 3))
+        app.typeKey("7", modifierFlags: .command)
+        XCTAssertTrue(anyElement("runs.state").waitForExistence(timeout: 3))
+    }
+
+    func testForcedQuitRecoveryExplainsAResumableRun() {
+        relaunchWithRunFixture("recoverable", uncleanRecovery: true)
+
+        XCTAssertTrue(anyElement("runs.recoveryExplanation").waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            app.staticTexts.matching(
+                NSPredicate(format: "value CONTAINS[c] %@ OR label CONTAINS[c] %@", "can be resumed", "can be resumed")
+            ).firstMatch.exists
+        )
+    }
+
     func testPermissionPanelRepliesWithTheKeyboard() {
         relaunchWithPendingPermission()
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ like; macOS remembers the size you choose for later launches.
   costs, checkpoints, steering, pause/resume state, and recovery options in a
   local run store. Stop is routed to the worker that owns the run, waits for a
   terminal event, and leaves a cancelled run non-recoverable instead of
-  replaying its last approval after reconnecting.
+  replaying its last approval after reconnecting. Run updates are coalesced and
+  loaded incrementally so large timelines stay responsive at completion. After
+  an unexpected quit, Locus reopens the latest run and explains whether it
+  finished or can be resumed.
 - **Live Team Progress in the sidebar** shows the active dispatcher and its
   provider/model, elapsed time, delegated jobs, model calls, and hosted-token
   usage. Its Stop button remains available while a team is running.
@@ -564,7 +567,7 @@ xcodebuild \
 cd agent && .venv/bin/python -m pytest -q
 ```
 
-The repository currently contains 237 unit tests, 26 UI tests, and 372 backend
+The repository currently contains 244 unit tests, 29 UI tests, and 378 backend
 test cases.
 
 The unit suite covers work modes, lightweight context migration, session


### PR DESCRIPTION
## Summary
- coalesce orchestration refreshes, reject stale selections, and load only new durable events at completion
- stop terminal progress timers, bound dispatcher detail, and keep large Runs timelines responsive
- journal clean shutdowns and restore the last run with a completed or resumable explanation after forced quit
- document the 1.11 behavior and current test counts

## Verification
- 378 backend tests passed
- 244 native tests passed
- 29 macOS UI tests passed, including a forced-quit relaunch with a 1,200-event timeline
- acceptance build verified as io.sparktales.locus 1.11.0 (build 15)

## Live model note
The Kimi k3 + Qwen vLLM acceptance was not run because the vLLM endpoint was intentionally turned off before testing.