### PR TITLE
Streamline team dispatch approval and recovery

### DIFF
--- a/Docs/AGENT_TEAMS_FEATURE_GUIDE.md
+++ b/Docs/AGENT_TEAMS_FEATURE_GUIDE.md
@@ -250,7 +250,14 @@ Example: if Wi-Fi drops during a reviewer job, reopen the same chat. Locus asks 
 
 While a team works, a compact status bar appears below the transcript. It shows the current phase and completed job count without expanding a large activity panel into the conversation.
 
-Click **Inspect Run** to open the full Run Inspector.
+The Team Progress button immediately left of the header's context meter opens
+the dispatcher, delegated-job, model, and usage summary. Click **Inspect Run**
+or **Open Runs** to open the full Run Inspector.
+
+While the dispatcher creates the plan, the composer becomes a progress card.
+It names the dispatcher route, elapsed time, request, observable stage, and any
+bounded validation correction. Raw model output and hidden reasoning are not
+shown.
 
 ### Run Inspector: Timeline view
 
@@ -259,6 +266,12 @@ The Timeline view shows the run in exact event order. It includes dispatching, a
 Use the filter box to search by agent, event type, job state, or attempt.
 
 Example: search for `fallback` to see whether the primary dispatcher failed and which fallback route Locus used.
+
+If a dispatcher returns a plan that Locus cannot validate, Team Progress first
+shows **Correcting dispatcher plan…**. The Timeline records the bounded reason.
+If the corrected plan is still invalid, Locus continues safely with the team's
+designated writer and states why specialists were skipped; raw provider output
+and credentials are not written to run history.
 
 ### Run Inspector: Dependencies view
 
@@ -456,14 +469,21 @@ Successful, unpinned evaluation checkouts are eligible for automatic cleanup aft
 
 ## 9. Editable dispatch plans
 
-### Automatic or preview dispatch
+### One approval for the complete plan
 
-Each team has a **Dispatch approval** setting:
+Every native Locus team pauses once after the dispatcher returns a validated
+plan and before any jobs begin. The plan appears in the composer with its jobs,
+assignments, dependencies, and budget.
 
-- **Automatic** starts a validated plan immediately.
-- **Preview** pauses before any jobs start and opens the dispatch editor.
+- **Run Plan** approves the entire dependency graph. Locus does not ask again
+  for each model, agent, job, or step.
+- **Re-dispatch** rejects that candidate and asks the dispatcher for a
+  replacement, which is shown for approval when ready.
+- **Cancel** stops the run before any jobs begin.
 
-Example: enable Preview for an expensive hosted team so you can inspect its plan before it spends tokens.
+Security-sensitive tool permission prompts remain separate and continue to
+follow the selected permission mode. Older teams saved as Automatic are moved
+to this one-time plan review behavior when Locus loads them.
 
 ### Dispatch graph editor
 
@@ -485,7 +505,7 @@ Example: the dispatcher proposes Research → Writer → Review. Add a parallel 
 - **Re-dispatch** asks the dispatcher for a new plan within the remaining budget.
 - **Cancel** returns without starting the plan.
 
-The pending approval survives reconnects.
+The pending one-time approval survives reconnects.
 
 Example: select Re-dispatch when the proposed plan spends three specialist jobs on documentation but the task is primarily a test failure.
 
@@ -729,7 +749,7 @@ The platform keeps these boundaries regardless of team or permission settings:
 Suppose you want a team to fix a Swift concurrency bug safely:
 
 1. In **Agents & Teams**, create a local Dispatcher, a read-only Researcher, one workspace-write Implementer, and a read-only Reviewer.
-2. Create `Swift Team`, enable dispatch Preview, choose scorecard routing, and set a `$3` estimated-cost ceiling.
+2. Create `Swift Team`, choose scorecard routing, and set a `$3` estimated-cost ceiling.
 3. In the composer, select Team and `Swift Team`, then send: `Investigate and fix the actor-isolation warnings. Add regression tests.`
 4. Review the proposed dependency graph. Add a parallel test-design job if needed, then choose **Run Plan**.
 5. Click **Inspect Run** to watch routing explanations, evidence, tokens, and checkpoints.

--- a/Locus/AgentTeams.swift
+++ b/Locus/AgentTeams.swift
@@ -308,6 +308,10 @@ struct AgentTeam: Identifiable, Codable, Hashable {
 
     mutating func clamp() {
         name = String(name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(64))
+        // Locus presents one review boundary for the complete dispatch plan.
+        // Keep decoding `automatic` for older stores and other protocol
+        // clients, but every team saved by the native app uses one-time review.
+        dispatchApprovalMode = .preview
         // Preserve the editor's order (dispatcher first in the common case)
         // while removing duplicates. Converting through Set made the team
         // model picker reshuffle on every save.
@@ -323,7 +327,7 @@ struct AgentTeam: Identifiable, Codable, Hashable {
         maximumEstimatedCost = min(max(maximumEstimatedCost ?? 0, 0), 100_000)
     }
 
-    var resolvedDispatchApprovalMode: DispatchApprovalMode { dispatchApprovalMode ?? .automatic }
+    var resolvedDispatchApprovalMode: DispatchApprovalMode { .preview }
     var resolvedRoutingMode: AgentRoutingMode { routingMode ?? .manual }
     var resolvedRoutingWeights: AgentScoreWeights { routingWeights ?? .init() }
 }
@@ -422,6 +426,18 @@ enum AgentTeamStore {
         decodeElements(AgentTeam.self, data: defaults.data(forKey: teamsKey))
     }
 
+    static func migrateToOneTimeApproval(_ teams: [AgentTeam]) -> (teams: [AgentTeam], changed: Bool) {
+        let changed = teams.contains { $0.dispatchApprovalMode != .preview }
+        return (
+            teams.map { stored in
+                var team = stored
+                team.dispatchApprovalMode = .preview
+                return team
+            },
+            changed
+        )
+    }
+
     static func save(profiles: [AgentProfile], teams: [AgentTeam], to defaults: UserDefaults = .standard) {
         if let data = try? JSONEncoder().encode(profiles) { defaults.set(data, forKey: profilesKey) }
         if let data = try? JSONEncoder().encode(teams) { defaults.set(data, forKey: teamsKey) }
@@ -458,6 +474,15 @@ enum TeamRunState: String, Codable, CaseIterable, Hashable {
     case interrupted
     case cancelled
     case discarded
+
+    var isTerminal: Bool {
+        switch self {
+        case .completed, .failed, .interrupted, .cancelled, .discarded:
+            true
+        default:
+            false
+        }
+    }
 
     var title: String {
         switch self {

--- a/Locus/AgentTeamsSettingsView.swift
+++ b/Locus/AgentTeamsSettingsView.swift
@@ -151,7 +151,7 @@ struct AgentTeamsSettingsView: View {
                 fallbackDispatcherID: nil,
                 memberIDs: members,
                 defaultWriterID: writer?.id,
-                dispatchApprovalMode: .automatic,
+                dispatchApprovalMode: .preview,
                 routingMode: .scorecard,
                 routingWeights: .init()
             )
@@ -705,12 +705,16 @@ private struct AgentTeamEditor: View {
                     }
                     Toggle("Use isolated managed worktree for new Git tasks", isOn: $draft.useManagedWorktree)
                     Section("Dispatch and routing") {
-                        Picker("Plan approval", selection: Binding(
-                            get: { draft.resolvedDispatchApprovalMode },
-                            set: { draft.dispatchApprovalMode = $0 }
-                        )) {
-                            ForEach(DispatchApprovalMode.allCases) { Text($0.title).tag($0) }
-                        }
+                        Label(
+                            "Review each team plan once before any agent begins",
+                            systemImage: "checkmark.shield"
+                        )
+                        .font(.system(size: 9, weight: .medium))
+                        Text("Run Plan approves the complete plan. Locus will not ask again for each model, agent, job, or step; security-sensitive tool permissions remain separate.")
+                            .font(.system(size: 8))
+                            .foregroundStyle(LocusTheme.muted)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .accessibilityIdentifier("teamEditor.oneTimeApproval")
                         Picker("Specialist routing", selection: Binding(
                             get: { draft.resolvedRoutingMode },
                             set: { draft.routingMode = $0 }

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -119,6 +119,7 @@ final class AppModel: ObservableObject {
     @Published private(set) var activeWorkerID: String?
     @Published private(set) var taskConversationStates: [String: TaskConversationState] = [:]
     @Published private(set) var dispatcherActivity: AgentActivity?
+    @Published private(set) var dispatcherValidationReason: String?
     @Published private(set) var agentActivities: [AgentActivity] = []
     @Published private(set) var teamModelCalls = 0
     @Published private(set) var teamMeteredTokens = 0
@@ -483,11 +484,16 @@ final class AppModel: ObservableObject {
         }
         if !isUITesting, persistenceEnabled {
             let loadedProfiles = AgentTeamStore.loadProfiles(from: defaults)
-            let loadedTeams = AgentTeamStore.loadTeams(from: defaults)
+            let storedTeams = AgentTeamStore.loadTeams(from: defaults)
+            let approvalMigration = AgentTeamStore.migrateToOneTimeApproval(storedTeams)
+            let loadedTeams = approvalMigration.teams
             let loadedSelection = defaults.string(forKey: AgentTeamStore.selectionKey)
                 .flatMap(UUID.init(uuidString:))
             agentProfiles = loadedProfiles
             agentTeams = loadedTeams
+            if approvalMigration.changed {
+                AgentTeamStore.save(profiles: loadedProfiles, teams: loadedTeams, to: defaults)
+            }
             teamRoutingConsentAccountIDs = AgentTeamStore.loadConsent(from: defaults)
             let storedConcurrency = defaults.integer(forKey: AgentTeamStore.globalConcurrencyKey)
             globalAgentConcurrency = storedConcurrency == 0 ? 3 : min(max(storedConcurrency, 1), 8)
@@ -2468,10 +2474,49 @@ final class AppModel: ObservableObject {
     }
 
     var hasRunningWorkForQuit: Bool {
-        isBusy || hasPendingPermission || orchestrationState.map {
-            ![.completed, .failed, .interrupted, .cancelled, .discarded].contains($0)
-        } == true || taskConversationStates.values.contains {
-            ![.completed, .failed, .interrupted, .cancelled, .discarded].contains($0.state)
+        Self.shouldWarnBeforeQuit(
+            isBusy: isBusy,
+            hasPendingPermission: hasPendingPermission,
+            currentSessionID: currentSessionID,
+            orchestrationState: orchestrationState,
+            taskConversationStates: taskConversationStates,
+            liveWorkerSessionIDs: Set(
+                taskWorkers.values.compactMap { runtime in
+                    runtime.process.isRunning ? runtime.sessionID : nil
+                }
+            )
+        )
+    }
+
+    /// A terminal durable run is authoritative for the current chat. Team
+    /// workers intentionally remain alive between turns, so neither their
+    /// process nor a stale pre-completion snapshot proves work is still active.
+    static func shouldWarnBeforeQuit(
+        isBusy: Bool,
+        hasPendingPermission: Bool,
+        currentSessionID: String,
+        orchestrationState: TeamRunState?,
+        taskConversationStates: [String: TaskConversationState],
+        liveWorkerSessionIDs: Set<String>
+    ) -> Bool {
+        // These foreground flags are set synchronously when a new solo or team
+        // turn begins, before a fresh orchestration event can replace the last
+        // run's terminal state.
+        if isBusy || hasPendingPermission {
+            return true
+        }
+        if let orchestrationState, !orchestrationState.isTerminal {
+            return true
+        }
+        let currentRunIsTerminal = orchestrationState?.isTerminal == true
+        return taskConversationStates.contains { sessionID, snapshot in
+            guard liveWorkerSessionIDs.contains(sessionID), !snapshot.state.isTerminal else {
+                return false
+            }
+            // Completion events can arrive before older foreground flags and
+            // task snapshots are cleared. Do not turn those stale values into
+            // a destructive-looking quit confirmation.
+            return sessionID != currentSessionID || !currentRunIsTerminal
         }
     }
 
@@ -2485,10 +2530,7 @@ final class AppModel: ObservableObject {
             // Give every worker a bounded window to append its interrupted
             // task state and terminal event before shutdown stops processes.
             for _ in 0..<20 {
-                let backgroundActive = taskConversationStates.values.contains {
-                    ![.completed, .failed, .interrupted].contains($0.state)
-                }
-                if !isBusy && !backgroundActive { break }
+                if !hasRunningWorkForQuit { break }
                 try? await Task.sleep(for: .milliseconds(150))
             }
             completion()
@@ -2767,6 +2809,24 @@ final class AppModel: ObservableObject {
 
     var teamModeEnabled: Bool { selectedAgentTeam != nil }
 
+    var shouldShowTeamDispatchProgress: Bool {
+        isBusy && orchestrationRunID != nil && orchestrationState == .dispatching
+            && pendingDispatchPlan == nil
+    }
+
+    var shouldShowTeamDispatchApproval: Bool {
+        orchestrationState == .waitingDispatchApproval && pendingDispatchPlan != nil
+    }
+
+    var activeOrchestrationTeam: AgentTeam? {
+        if let id = selectedOrchestrationRun?.teamID.flatMap(UUID.init(uuidString:)),
+           let team = agentTeams.first(where: { $0.id == id })
+        {
+            return team
+        }
+        return selectedAgentTeam
+    }
+
     func selectAgentTeam(_ id: UUID?) {
         selectedAgentTeamID = id
         showToast(id == nil ? "Solo mode" : "Team mode")
@@ -3007,7 +3067,9 @@ final class AppModel: ObservableObject {
             "name": team.name,
             "member_ids": team.memberIDs.map(\.uuidString),
             "use_managed_worktree": team.useManagedWorktree,
-            "dispatch_approval_mode": team.resolvedDispatchApprovalMode.rawValue,
+            // One approval releases the complete plan. Individual jobs and
+            // models do not introduce additional dispatch confirmations.
+            "dispatch_approval_mode": DispatchApprovalMode.preview.rawValue,
             "routing_mode": team.resolvedRoutingMode.rawValue,
             "routing_weights": [
                 "quality": team.resolvedRoutingWeights.quality,
@@ -3457,7 +3519,18 @@ final class AppModel: ObservableObject {
             showToast("The dispatch decision could not be delivered")
             return
         }
-        if action != "redispatch" { pendingDispatchPlan = nil }
+        pendingDispatchPlan = nil
+        if action == "redispatch" {
+            orchestrationState = .dispatching
+            dispatcherValidationReason = nil
+            if var activity = dispatcherActivity {
+                activity.state = .running
+                activity.output = "Creating a new dispatcher plan…"
+                activity.startedAt = Date()
+                dispatcherActivity = activity
+            }
+            updateTaskConversation(state: .dispatching, event: ["run_id": runID])
+        }
     }
 
     func dispatchPlanErrors(_ plan: DispatchPlan) -> [String] {
@@ -4252,6 +4325,7 @@ final class AppModel: ObservableObject {
                 sessionInfo = response.sessionInfo
                 currentSessionID = response.sessionInfo.sessionID
                 dispatcherActivity = nil
+                dispatcherValidationReason = nil
                 agentActivities = response.agentActivities
                 orchestrationState = response.orchestrationState
                 orchestrationRunID = response.orchestrationRunID
@@ -4292,6 +4366,7 @@ final class AppModel: ObservableObject {
         isBusy = false
         orchestrationState = nil
         dispatcherActivity = nil
+        dispatcherValidationReason = nil
         agentActivities = []
         activeTaskRecord = nil
         taskHasChanges = false
@@ -6021,6 +6096,7 @@ final class AppModel: ObservableObject {
             orchestrationState = .dispatching
             activeWorkerID = event["worker_id"] as? String ?? activeWorkerID
             dispatcherActivity = nil
+            dispatcherValidationReason = nil
             agentActivities = []
             teamModelCalls = 0
             teamMeteredTokens = 0
@@ -6037,6 +6113,7 @@ final class AppModel: ObservableObject {
             if persistenceEnabled { Task { await refreshMetadata() } }
 
         case "dispatcher_started":
+            dispatcherValidationReason = nil
             let runID = event["run_id"] as? String ?? orchestrationRunID ?? "current"
             dispatcherActivity = AgentActivity(
                 id: "dispatcher-\(runID)",
@@ -6070,6 +6147,16 @@ final class AppModel: ObservableObject {
             if let usage = event["usage"] as? [String: Any] {
                 teamModelCalls = usage["model_calls"] as? Int ?? teamModelCalls
                 teamMeteredTokens = usage["metered_tokens"] as? Int ?? teamMeteredTokens
+            }
+
+        case "dispatcher_plan_rejected":
+            dispatcherValidationReason = event["reason"] as? String
+            if var activity = dispatcherActivity {
+                activity.state = .running
+                activity.output = event["message"] as? String
+                    ?? event["reason"] as? String
+                    ?? "Correcting dispatcher plan…"
+                dispatcherActivity = activity
             }
 
         case "orchestration_state":
@@ -6502,6 +6589,7 @@ final class AppModel: ObservableObject {
             orchestrationState = nil
             activeWorkerID = nil
             dispatcherActivity = nil
+            dispatcherValidationReason = nil
             agentActivities = []
             teamModelCalls = 0
             teamMeteredTokens = 0
@@ -7023,9 +7111,15 @@ final class AppModel: ObservableObject {
 
     private func seedUITestRunFixtureIfNeeded() {
         guard let fixture = ProcessInfo.processInfo.environment["LOCUS_UI_TESTING_RUN_FIXTURE"],
-              fixture == "completed" || fixture == "recoverable"
+              ["completed", "recoverable", "dispatcher-repair", "dispatch-plan"].contains(fixture)
         else { return }
-        let state: TeamRunState = fixture == "completed" ? .completed : .interrupted
+        let state: TeamRunState = switch fixture {
+        case "completed": .completed
+        case "recoverable": .interrupted
+        case "dispatch-plan": .waitingDispatchApproval
+        default: .dispatching
+        }
+        let lastSequence = ["dispatcher-repair", "dispatch-plan"].contains(fixture) ? 1 : 1_200
         let run = OrchestrationRun(
             id: "seed-run",
             sessionID: "seed-current",
@@ -7040,7 +7134,7 @@ final class AppModel: ObservableObject {
             createdAt: Date().addingTimeInterval(-300).timeIntervalSince1970,
             updatedAt: Date().timeIntervalSince1970,
             completedAt: fixture == "completed" ? Date().timeIntervalSince1970 : nil,
-            lastSequence: 1_200,
+            lastSequence: lastSequence,
             pinned: false,
             legacy: false,
             recoverable: fixture == "recoverable",
@@ -7052,15 +7146,123 @@ final class AppModel: ObservableObject {
         selectedOrchestrationRun = run
         orchestrationRunID = run.id
         orchestrationState = state
-        let rawEvents: [[String: Any]] = (1...1_200).map { sequence in
-            [
-                "event_id": "seed-event-\(sequence)",
-                "run_id": run.id,
-                "seq": sequence,
-                "type": sequence == 1_200 ? "orchestration_completed" : "agent_job_completed",
-                "summary": sequence == 1_200 ? "Team run completed" : "Durable result \(sequence)",
-                "detail": String(repeating: "Verified output. ", count: 12),
+        let rawEvents: [[String: Any]]
+        if ["dispatcher-repair", "dispatch-plan"].contains(fixture) {
+            let dispatcherID = UUID(uuidString: "00000000-0000-0000-0000-000000000501")!
+            let writerID = UUID(uuidString: "00000000-0000-0000-0000-000000000502")!
+            let teamID = UUID(uuidString: "00000000-0000-0000-0000-000000000503")!
+            agentProfiles = [
+                AgentProfile(
+                    id: dispatcherID,
+                    name: "Qwen Dispatcher",
+                    model: "qwen3:8b",
+                    role: .dispatcher
+                ),
+                AgentProfile(
+                    id: writerID,
+                    name: "Kimi Writer",
+                    model: "qwen3:8b",
+                    role: .implementer,
+                    accessCeiling: .workspaceWrite
+                ),
             ]
+            agentTeams = [AgentTeam(
+                id: teamID,
+                name: "Codex Team",
+                dispatcherID: dispatcherID,
+                fallbackDispatcherID: nil,
+                memberIDs: [dispatcherID, writerID],
+                defaultWriterID: writerID
+            )]
+            selectedAgentTeamID = teamID
+            isBusy = true
+            if fixture == "dispatcher-repair" {
+                dispatcherActivity = AgentActivity(
+                    id: "dispatcher-seed-run",
+                    agentName: "Qwen Dispatcher",
+                    role: AgentRole.dispatcher.rawValue,
+                    provider: "vLLM",
+                    model: "qwen3:8b",
+                    goal: "Creating the team plan",
+                    state: .running,
+                    output: "Correcting dispatcher plan…",
+                    reasoningText: nil,
+                    tool: nil,
+                    evidence: [],
+                    startedAt: Date().addingTimeInterval(-5),
+                    elapsedMilliseconds: 0,
+                    promptTokens: 0,
+                    completionTokens: 0
+                )
+                dispatcherValidationReason = "dispatcher plan has no jobs"
+                rawEvents = [[
+                    "event_id": "seed-event-1",
+                    "run_id": run.id,
+                    "seq": 1,
+                    "type": "dispatcher_plan_rejected",
+                    "stage": "initial",
+                    "message": "Correcting dispatcher plan…",
+                    "reason": "dispatcher plan has no jobs",
+                    "will_retry": true,
+                ]]
+            } else {
+                dispatcherActivity = AgentActivity(
+                    id: "dispatcher-seed-run",
+                    agentName: "Qwen Dispatcher",
+                    role: AgentRole.dispatcher.rawValue,
+                    provider: "vLLM",
+                    model: "qwen3:8b",
+                    goal: "Creating the team plan",
+                    state: .completed,
+                    output: "Dispatch plan ready",
+                    reasoningText: nil,
+                    tool: nil,
+                    evidence: [],
+                    startedAt: Date().addingTimeInterval(-5),
+                    elapsedMilliseconds: 5_000,
+                    promptTokens: 1_000,
+                    completionTokens: 250
+                )
+                pendingDispatchPlan = DispatchPlan(
+                    summary: "Inspect the checker, implement the fix, and review it.",
+                    jobs: [
+                        DispatchJob(
+                            id: "inspect",
+                            agentID: dispatcherID.uuidString,
+                            goal: "Inspect the current implementation and constraints",
+                            dependencies: [],
+                            kind: "specialist"
+                        ),
+                        DispatchJob(
+                            id: "write",
+                            agentID: writerID.uuidString,
+                            goal: "Implement and verify the stock checker",
+                            dependencies: ["inspect"],
+                            kind: "writer"
+                        ),
+                    ],
+                    budget: OrchestrationBudget(),
+                    maximumEstimatedCost: nil
+                )
+                rawEvents = [[
+                    "event_id": "seed-event-1",
+                    "run_id": run.id,
+                    "seq": 1,
+                    "type": "dispatch_plan_ready",
+                    "state": "waiting_dispatch_approval",
+                ]]
+            }
+        } else {
+            rawEvents = (1...1_200).map { sequence in
+                [
+                    "event_id": "seed-event-\(sequence)",
+                    "run_id": run.id,
+                    "seq": sequence,
+                    "type": sequence == 1_200 ? "orchestration_completed" : "agent_job_completed",
+                    "summary": sequence == 1_200 ? "Team run completed" : "Durable result \(sequence)",
+                    "detail": String(repeating: "Verified output. ", count: 12),
+                ]
+            }
         }
         orchestrationEvents = rawEvents.compactMap {
             decode(OrchestrationEvent.self, from: $0)
@@ -7068,6 +7270,19 @@ final class AppModel: ObservableObject {
         orchestrationEventIDs = Set(orchestrationEvents.map(\.id))
         inspectorTab = .runs
         inspectorCollapsed = false
+        if fixture == "completed",
+           ProcessInfo.processInfo.environment["LOCUS_UI_TESTING_STALE_QUIT_STATE"] == "1"
+        {
+            taskConversationStates[currentSessionID] = TaskConversationState(
+                sessionID: currentSessionID,
+                taskID: "seed-task",
+                teamID: "seed-team",
+                workerID: "seed-worker",
+                runID: run.id,
+                state: .running,
+                updatedAt: Date().addingTimeInterval(-1)
+            )
+        }
         if ProcessInfo.processInfo.environment["LOCUS_UI_TESTING_UNCLEAN_RECOVERY"] == "1" {
             lifecycleRecoveryMessage = fixture == "completed"
                 ? "Locus was force quit after the team run completed. Its results were restored."

--- a/Locus/ComposerView.swift
+++ b/Locus/ComposerView.swift
@@ -29,6 +29,16 @@ struct ComposerView: View {
                 PermissionPromptView(request: request)
                     .frame(maxWidth: 740)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+            } else if model.shouldShowTeamDispatchApproval,
+                      let plan = model.pendingDispatchPlan
+            {
+                TeamDispatchApprovalPromptView(plan: plan)
+                    .frame(maxWidth: 740)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            } else if model.shouldShowTeamDispatchProgress {
+                TeamDispatchProgressView()
+                    .frame(maxWidth: 740)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
             } else if model.planApprovalPending {
                 // Same contract as the permission panel: the finished plan is
                 // a decision point, so the decision replaces the input.
@@ -95,6 +105,8 @@ struct ComposerView: View {
             )
         )
         .animation(.easeInOut(duration: 0.18), value: model.activePermissionRequest?.requestID)
+        .animation(.easeInOut(duration: 0.18), value: model.shouldShowTeamDispatchProgress)
+        .animation(.easeInOut(duration: 0.18), value: model.shouldShowTeamDispatchApproval)
         .animation(.easeInOut(duration: 0.18), value: model.planApprovalPending)
         .onAppear { restoreFocus() }
         .onChange(of: model.activePermissionRequest?.requestID) {
@@ -106,6 +118,11 @@ struct ComposerView: View {
             // Same for "keep planning": the natural next act is typing the
             // refinement, so the editor takes focus back.
             if !model.planApprovalPending { restoreFocus() }
+        }
+        .onChange(of: model.shouldShowTeamDispatchApproval) {
+            if !model.shouldShowTeamDispatchApproval && !model.shouldShowTeamDispatchProgress {
+                restoreFocus()
+            }
         }
         .onChange(of: model.draftText) {
             popupSelection = 0

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -651,6 +651,7 @@ struct InspectorRunsTab: View {
                 event.type, event.title, event.jobID, event.attemptID,
                 event.text("agent_name"), event.text("agent_id"),
                 event.text("state"), event.text("provider"), event.text("model"),
+                event.text("reason"),
             ]
                 .compactMap { $0 }.joined(separator: " ").lowercased().contains(query)
         }

--- a/Locus/Models.swift
+++ b/Locus/Models.swift
@@ -249,6 +249,7 @@ enum SettingsPage: String, CaseIterable, Identifiable {
     case knowledge = "Knowledge"
     case permissions = "Permissions"
     case extensions = "Extensions"
+    case shortcuts = "Keyboard Shortcuts"
 
     var id: String { rawValue }
 
@@ -261,7 +262,12 @@ enum SettingsPage: String, CaseIterable, Identifiable {
         case .knowledge: "books.vertical.fill"
         case .permissions: "lock.shield"
         case .extensions: "puzzlepiece.extension"
+        case .shortcuts: "keyboard"
         }
+    }
+
+    var accessibilityKey: String {
+        self == .shortcuts ? "shortcuts" : rawValue.lowercased()
     }
 }
 

--- a/Locus/PlanApprovalPromptView.swift
+++ b/Locus/PlanApprovalPromptView.swift
@@ -1,5 +1,456 @@
 import SwiftUI
 
+/// Replaces the composer while the selected team's dispatcher is building a
+/// plan. It reports observable stages and validation diagnostics without
+/// presenting provider reasoning or raw structured output.
+struct TeamDispatchProgressView: View {
+    @EnvironmentObject private var model: AppModel
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { timeline in
+            content(now: timeline.date)
+        }
+    }
+
+    private func content(now: Date) -> some View {
+        let startedAt = model.dispatcherActivity?.startedAt ?? model.activeWorkStartedAt
+        let elapsed = startedAt.map { max(now.timeIntervalSince($0), 0) } ?? 0
+
+        return VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 9) {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel("Dispatcher is creating the team plan")
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("DISPATCHER PLANNING")
+                        .font(.system(size: 8, weight: .bold))
+                        .tracking(0.8)
+                        .foregroundStyle(LocusTheme.signalDeep)
+                    Text(model.activeOrchestrationTeam?.name ?? "Team run")
+                        .font(.system(size: 12, weight: .bold))
+                }
+                Spacer()
+                if startedAt != nil {
+                    Text(duration(elapsed))
+                        .font(.system(size: 9, design: .monospaced))
+                        .foregroundStyle(LocusTheme.muted)
+                }
+            }
+            .padding(13)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 9) {
+                    Image(systemName: "point.3.connected.trianglepath.dotted")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(LocusTheme.signalDeep)
+                        .frame(width: 16)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(dispatcherName)
+                            .font(.system(size: 11, weight: .semibold))
+                        Text(dispatcherRoute)
+                            .font(.system(size: 8, design: .monospaced))
+                            .foregroundStyle(LocusTheme.muted)
+                            .lineLimit(2)
+                        Text(stageDetail)
+                            .font(.system(size: 10))
+                            .foregroundStyle(LocusTheme.inkSoft)
+                            .lineLimit(4)
+                    }
+                }
+
+                if let reason = model.dispatcherValidationReason, !reason.isEmpty {
+                    Label(reason, systemImage: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(LocusTheme.warning)
+                        .lineLimit(3)
+                        .padding(9)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(LocusTheme.warning.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+                        .accessibilityIdentifier("teamDispatch.validationReason")
+                }
+
+                VStack(alignment: .leading, spacing: 5) {
+                    stageRow(
+                        "Dispatcher connected",
+                        complete: model.dispatcherActivity != nil
+                    )
+                    stageRow(
+                        model.dispatcherValidationReason == nil
+                            ? "Create and validate one complete team plan"
+                            : "Correct and revalidate the team plan",
+                        complete: model.dispatcherActivity?.state == .completed
+                    )
+                    stageRow("Show the plan for your approval", complete: false)
+                }
+                .padding(9)
+                .background(LocusTheme.paperDeep.opacity(0.65))
+                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+
+                if !requestSummary.isEmpty {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("REQUEST")
+                            .font(.system(size: 7, weight: .bold))
+                            .tracking(0.7)
+                            .foregroundStyle(LocusTheme.muted)
+                        Text(requestSummary)
+                            .font(.system(size: 9))
+                            .foregroundStyle(LocusTheme.inkSoft)
+                            .lineLimit(3)
+                    }
+                }
+            }
+            .padding(13)
+
+            Divider()
+
+            HStack {
+                Text("No agents or jobs begin until you approve the completed plan once.")
+                    .font(.system(size: 8))
+                    .foregroundStyle(LocusTheme.muted)
+                Spacer()
+                if let runID = model.orchestrationRunID {
+                    Button("Stop", role: .destructive) {
+                        model.cancelOrchestration(runID)
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(LocusTheme.coral)
+                    .accessibilityIdentifier("teamDispatch.stop")
+                }
+            }
+            .padding(12)
+        }
+        .locusCard(radius: 13)
+        .overlay {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .stroke(LocusTheme.signalDeep.opacity(0.45), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.08), radius: 22, y: 9)
+        .accessibilityIdentifier("teamDispatch.progress")
+    }
+
+    private func stageRow(_ title: String, complete: Bool) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: complete ? "checkmark.circle.fill" : "circle.dotted")
+                .font(.system(size: 9))
+                .foregroundStyle(complete ? LocusTheme.success : LocusTheme.signalDeep)
+                .frame(width: 12)
+            Text(title)
+                .font(.system(size: 9, weight: complete ? .medium : .regular))
+                .foregroundStyle(LocusTheme.inkSoft)
+        }
+    }
+
+    private var dispatcherName: String {
+        model.dispatcherActivity?.agentName ?? dispatcherProfile?.name ?? "Starting dispatcher…"
+    }
+
+    private var dispatcherRoute: String {
+        if let activity = model.dispatcherActivity, !activity.model.isEmpty {
+            return [activity.provider, activity.model].filter { !$0.isEmpty }.joined(separator: " · ")
+        }
+        guard let profile = dispatcherProfile else { return "Preparing model route" }
+        let provider: String
+        switch profile.route {
+        case .localOllama:
+            provider = "Local Ollama"
+        case .providerAccount(let id):
+            provider = model.providerAccounts.first(where: { $0.id == id })?.displayName
+                ?? "Configured provider"
+        }
+        return "\(provider) · \(profile.model)"
+    }
+
+    private var stageDetail: String {
+        if let output = model.dispatcherActivity?.output, !output.isEmpty { return output }
+        if model.dispatcherActivity == nil {
+            return "Opening the dispatcher route and preparing the team roster."
+        }
+        return "Creating assignments, dependencies, and the single-writer boundary."
+    }
+
+    private var dispatcherProfile: AgentProfile? {
+        guard let id = model.activeOrchestrationTeam?.dispatcherID else { return nil }
+        return model.agentProfiles.first(where: { $0.id == id })
+    }
+
+    private var requestSummary: String {
+        if let request = model.selectedOrchestrationRun?.request, !request.isEmpty {
+            return request
+        }
+        return model.blocks.last(where: { $0.kind == .user })?.text ?? ""
+    }
+
+    private func duration(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        return total < 60 ? "\(total)s" : "\(total / 60)m \(total % 60)s"
+    }
+}
+
+/// The one and only dispatch decision for a team run. Approving this card
+/// releases the complete dependency graph; individual agents and jobs do not
+/// ask for additional dispatch approval.
+struct TeamDispatchApprovalPromptView: View {
+    @EnvironmentObject private var model: AppModel
+    let plan: DispatchPlan
+
+    @State private var selection = 0
+    @FocusState private var panelFocused: Bool
+
+    private static let optionCount = 3
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+                .padding(.horizontal, 13)
+                .padding(.top, 12)
+            planSummary
+                .padding(.horizontal, 13)
+                .padding(.top, 9)
+            options
+                .padding(.horizontal, 8)
+                .padding(.vertical, 8)
+        }
+        .locusCard(radius: 13)
+        .overlay {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .stroke(LocusTheme.signalDeep.opacity(0.55), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.08), radius: 22, y: 9)
+        .focusable()
+        .focusEffectDisabled()
+        .focused($panelFocused)
+        .onKeyPress(.upArrow) {
+            selection = max(selection - 1, 0)
+            return .handled
+        }
+        .onKeyPress(.downArrow) {
+            selection = min(selection + 1, Self.optionCount - 1)
+            return .handled
+        }
+        .onKeyPress(.return) {
+            confirm(selection)
+            return .handled
+        }
+        .onKeyPress(.escape) {
+            confirm(2)
+            return .handled
+        }
+        .onKeyPress(characters: CharacterSet(charactersIn: "123")) { press in
+            guard press.modifiers.isEmpty,
+                  let digit = Int(press.characters),
+                  (1...Self.optionCount).contains(digit)
+            else { return .ignored }
+            confirm(digit - 1)
+            return .handled
+        }
+        .onTapGesture { panelFocused = true }
+        .onAppear { panelFocused = true }
+        .accessibilityIdentifier("teamDispatch.approval")
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("TEAM PLAN READY")
+                .font(.system(size: 8, weight: .bold))
+                .tracking(0.8)
+                .foregroundStyle(LocusTheme.signalDeep)
+            HStack(spacing: 7) {
+                Image(systemName: "person.3.sequence.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(LocusTheme.signalDeep)
+                Text("\(plan.jobs.count) jobs")
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .padding(.horizontal, 6)
+                    .frame(height: 18)
+                    .background(LocusTheme.paperDeep)
+                    .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+                Text("Approve this complete plan once?")
+                    .font(.system(size: 12, weight: .bold))
+            }
+            Text("After Run Plan, every listed agent and step proceeds without another dispatch approval. Tool permissions still follow your security settings.")
+                .font(.system(size: 8))
+                .foregroundStyle(LocusTheme.muted)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var planSummary: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if !plan.summary.isEmpty {
+                Text(plan.summary)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(LocusTheme.inkSoft)
+                    .lineLimit(3)
+            }
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 7) {
+                    ForEach(Array(plan.jobs.enumerated()), id: \.element.id) { index, job in
+                        HStack(alignment: .top, spacing: 8) {
+                            Text("\(index + 1).")
+                                .font(.system(size: 9, design: .monospaced))
+                                .foregroundStyle(LocusTheme.muted)
+                            VStack(alignment: .leading, spacing: 2) {
+                                HStack(spacing: 5) {
+                                    Text(agentName(for: job))
+                                        .font(.system(size: 9, weight: .semibold))
+                                    Text("· \(job.kind.capitalized)")
+                                        .font(.system(size: 8))
+                                        .foregroundStyle(LocusTheme.muted)
+                                }
+                                Text(job.goal)
+                                    .font(.system(size: 9))
+                                    .foregroundStyle(LocusTheme.inkSoft)
+                                    .lineLimit(2)
+                                if !job.dependencies.isEmpty {
+                                    Text("After: \(job.dependencies.joined(separator: ", "))")
+                                        .font(.system(size: 7, design: .monospaced))
+                                        .foregroundStyle(LocusTheme.muted)
+                                }
+                            }
+                            Spacer(minLength: 0)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 150)
+            .accessibilityIdentifier("teamDispatch.jobs")
+
+            if let budget = plan.budget ?? model.activeOrchestrationTeam?.budget {
+                HStack(spacing: 8) {
+                    budgetPill("\(budget.maxJobs) jobs max")
+                    budgetPill("\(budget.maxModelCalls) calls")
+                    budgetPill("\(budget.maxConcurrentCalls) concurrent")
+                    if let cost = plan.maximumEstimatedCost, cost > 0 {
+                        budgetPill(cost.formatted(.currency(code: "USD")))
+                    }
+                }
+            }
+
+            Button("Review or edit in Runs") {
+                model.selectInspectorTab(.runs)
+            }
+            .buttonStyle(.borderless)
+            .font(.system(size: 8, weight: .semibold))
+            .accessibilityIdentifier("teamDispatch.openRuns")
+        }
+        .padding(10)
+        .background(LocusTheme.paperDeep.opacity(0.65))
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+    }
+
+    private var options: some View {
+        VStack(spacing: 1) {
+            optionRow(
+                index: 0,
+                title: "Run Plan",
+                detail: "Approve once and start the complete team plan",
+                identifier: "teamDispatch.run"
+            )
+            optionRow(
+                index: 1,
+                title: "Re-dispatch",
+                detail: "Ask the dispatcher to replace this plan",
+                identifier: "teamDispatch.redispatch"
+            )
+            optionRow(
+                index: 2,
+                title: "Cancel",
+                detail: "Stop this team run before any jobs begin",
+                keyCap: "esc",
+                identifier: "teamDispatch.cancel"
+            )
+        }
+    }
+
+    private func optionRow(
+        index: Int,
+        title: String,
+        detail: String,
+        keyCap: String? = nil,
+        identifier: String
+    ) -> some View {
+        let isSelected = index == selection
+        return Button {
+            confirm(index)
+        } label: {
+            HStack(spacing: 8) {
+                Text(isSelected ? "❯" : " ")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(LocusTheme.signalDeep)
+                    .frame(width: 10)
+                Text("\(index + 1).")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(LocusTheme.muted)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
+                    Text(detail)
+                        .font(.system(size: 8))
+                        .foregroundStyle(LocusTheme.muted)
+                }
+                .lineLimit(1)
+                Spacer()
+                if let keyCap {
+                    Text(keyCap)
+                        .font(.system(size: 8, design: .monospaced))
+                        .foregroundStyle(LocusTheme.muted)
+                        .padding(.horizontal, 5)
+                        .frame(height: 15)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                .stroke(LocusTheme.line, lineWidth: 1)
+                        }
+                }
+                if isSelected {
+                    Text("↵")
+                        .font(.system(size: 8, design: .monospaced))
+                        .foregroundStyle(LocusTheme.muted)
+                }
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 38)
+            .background(isSelected ? LocusTheme.paperDeep : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering { selection = index }
+        }
+        .accessibilityLabel(title)
+        .accessibilityIdentifier(identifier)
+    }
+
+    private func budgetPill(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 7, design: .monospaced))
+            .foregroundStyle(LocusTheme.muted)
+            .padding(.horizontal, 6)
+            .frame(height: 17)
+            .background(LocusTheme.white.opacity(0.75))
+            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+    }
+
+    private func agentName(for job: DispatchJob) -> String {
+        guard let id = UUID(uuidString: job.agentID) else { return job.agentID }
+        return model.agentProfiles.first(where: { $0.id == id })?.name ?? job.agentID
+    }
+
+    private func confirm(_ index: Int) {
+        switch index {
+        case 0: model.decideDispatch("run")
+        case 1: model.decideDispatch("redispatch")
+        default: model.decideDispatch("cancel")
+        }
+    }
+}
+
 /// The composer-area follow-up to a finished Plan-mode run, the way Claude
 /// Code closes plan mode: the input is replaced by this panel until the user
 /// decides whether the plan gets implemented. ↑/↓ move the selection, 1–3

--- a/Locus/SessionSidebarView.swift
+++ b/Locus/SessionSidebarView.swift
@@ -19,7 +19,6 @@ struct SessionSidebarView: View {
     @EnvironmentObject private var model: AppModel
     @State private var sessionToRename: SessionSummary?
     @State private var renameText = ""
-    @State private var teamProgressPresented = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -164,21 +163,6 @@ struct SessionSidebarView: View {
             }
 
             navigationRow(
-                symbol: "person.3.sequence.fill",
-                title: "Agents & Teams",
-                help: "Configure dispatchers, specialists, writers, and team budgets",
-                accessibilityLabel: "Manage agents and teams",
-                identifier: "sidebar.agentsTeams"
-            ) {
-                model.settingsPage = .agents
-                model.settingsPresented = true
-            }
-
-            if model.selectedAgentTeam != nil {
-                teamProgressRow
-            }
-
-            navigationRow(
                 symbol: "shippingbox",
                 title: "Hugging Face",
                 help: "Browse and install GGUF models from Hugging Face",
@@ -190,62 +174,6 @@ struct SessionSidebarView: View {
         }
         .padding(.horizontal, SidebarMetrics.gutter)
         .padding(.bottom, 10)
-    }
-
-    private var teamProgressRow: some View {
-        Button {
-            teamProgressPresented.toggle()
-        } label: {
-            HStack(spacing: SidebarMetrics.iconGap) {
-                Image(systemName: "waveform.path.ecg")
-                    .font(.system(size: 12, weight: .medium))
-                    .frame(width: SidebarMetrics.iconColumn)
-                Text("Team progress")
-                    .font(.system(size: 10, weight: .semibold))
-                Spacer(minLength: 4)
-                HStack(spacing: 4) {
-                    Circle()
-                        .fill(teamProgressColor)
-                        .frame(width: 6, height: 6)
-                    Text(teamProgressTitle)
-                        .font(.system(size: 8, weight: .semibold))
-                        .lineLimit(1)
-                }
-            }
-            .foregroundStyle(LocusTheme.inkSoft)
-            .padding(.horizontal, SidebarMetrics.rowInset)
-            .frame(height: 30)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .background(teamProgressPresented ? LocusTheme.signal.opacity(0.12) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .help("Show the active team's dispatcher, jobs, models, and usage")
-        .accessibilityLabel("Team progress, \(teamProgressTitle)")
-        .accessibilityIdentifier("sidebar.teamProgress")
-        .popover(isPresented: $teamProgressPresented, arrowEdge: .leading) {
-            TeamProgressPopover {
-                teamProgressPresented = false
-            }
-            .environmentObject(model)
-        }
-    }
-
-    private var teamProgressTitle: String {
-        if model.selectedTeamRouteIssue != nil { return "Needs setup" }
-        return model.orchestrationState?.title ?? "Ready"
-    }
-
-    private var teamProgressColor: Color {
-        if model.selectedTeamRouteIssue != nil { return LocusTheme.coral }
-        switch model.orchestrationState {
-        case .completed: return LocusTheme.success
-        case .failed, .interrupted, .cancelled, .discarded: return LocusTheme.coral
-        case .waitingPermission, .waitingComputer, .waitingDispatchApproval, .paused:
-            return LocusTheme.warning
-        case .queued, .dispatching, .running, .reviewing: return LocusTheme.signalDeep
-        case nil: return LocusTheme.success
-        }
     }
 
     /// One row of the nav stack. They share an icon column with the New chat,
@@ -607,7 +535,7 @@ struct SessionSidebarView: View {
     }
 }
 
-private struct TeamProgressPopover: View {
+struct TeamProgressPopover: View {
     @EnvironmentObject private var model: AppModel
     let dismiss: () -> Void
 

--- a/Locus/Sheets.swift
+++ b/Locus/Sheets.swift
@@ -990,7 +990,7 @@ struct SettingsView: View {
                 List(SettingsPage.allCases, selection: $model.settingsPage) { item in
                     Label(item.rawValue, systemImage: item.symbol)
                         .tag(item)
-                        .accessibilityIdentifier("settings.page.\(item.id.lowercased())")
+                        .accessibilityIdentifier("settings.page.\(item.accessibilityKey)")
                 }
                 .listStyle(.sidebar)
                 .frame(width: 155)
@@ -1011,6 +1011,8 @@ struct SettingsView: View {
                 case .extensions:
                     ExtensionsSettingsView()
                         .environmentObject(model)
+                case .shortcuts:
+                    KeyboardShortcutsSettingsView()
                 }
             }
 

--- a/Locus/ShortcutsSheet.swift
+++ b/Locus/ShortcutsSheet.swift
@@ -1,51 +1,108 @@
 import SwiftUI
 
-/// Keyboard shortcut reference, presented with ⌘/ like Claude Code's
-/// shortcuts help.
+private struct ShortcutReference: Identifiable {
+    let keys: String
+    let title: String
+    var id: String { keys + title }
+}
+
+private struct ShortcutReferenceGroup: Identifiable {
+    let name: String
+    let shortcuts: [ShortcutReference]
+    var id: String { name }
+}
+
+private let shortcutReferenceGroups: [ShortcutReferenceGroup] = [
+    ShortcutReferenceGroup(name: "General", shortcuts: [
+        ShortcutReference(keys: "⌘K", title: "Command palette"),
+        ShortcutReference(keys: "⌘F", title: "Find in conversation"),
+        ShortcutReference(keys: "⌘/", title: "Keyboard shortcuts"),
+        ShortcutReference(keys: "⌘N", title: "New session"),
+        ShortcutReference(keys: "⌘⇧K", title: "Clear chat"),
+        ShortcutReference(keys: "⌘S", title: "Create checkpoint"),
+        ShortcutReference(keys: "⌘R", title: "Review changes"),
+    ]),
+    ShortcutReferenceGroup(name: "Composer", shortcuts: [
+        ShortcutReference(keys: "⌘↵", title: "Send message (queues while busy)"),
+        ShortcutReference(keys: "Esc", title: "Stop the current run / close popups"),
+        ShortcutReference(keys: "↑ ↓", title: "Browse prompt history (empty composer)"),
+        ShortcutReference(keys: "/", title: "Slash commands"),
+        ShortcutReference(keys: "@", title: "Mention a workspace file"),
+        ShortcutReference(keys: "↑↓ · 1–3 · ↵ · Esc", title: "Answer an approval or permission request"),
+    ]),
+    ShortcutReferenceGroup(name: "Panels", shortcuts: [
+        ShortcutReference(keys: "⌘0", title: "Show/hide sidebar"),
+        ShortcutReference(keys: "⌘1–⌘8", title: "Open inspector tabs"),
+        ShortcutReference(keys: "⌘⌥I", title: "Show/hide inspector"),
+    ]),
+    ShortcutReferenceGroup(name: "Modes", shortcuts: [
+        ShortcutReference(keys: "⌥A", title: "Just Chat"),
+        ShortcutReference(keys: "⌥P", title: "Plan mode"),
+        ShortcutReference(keys: "⌥B", title: "Build mode"),
+    ]),
+]
+
+private struct KeyboardShortcutsReference: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            ForEach(shortcutReferenceGroups) { group in
+                VStack(alignment: .leading, spacing: 7) {
+                    Text(group.name.uppercased())
+                        .font(.system(size: 8, weight: .bold))
+                        .tracking(0.9)
+                        .foregroundStyle(LocusTheme.muted)
+                    VStack(spacing: 0) {
+                        ForEach(Array(group.shortcuts.enumerated()), id: \.element.id) { index, shortcut in
+                            HStack {
+                                Text(shortcut.title)
+                                    .font(.system(size: 10, weight: .medium))
+                                Spacer()
+                                Text(shortcut.keys)
+                                    .font(.system(size: 9, design: .monospaced))
+                                    .foregroundStyle(LocusTheme.muted)
+                                    .padding(.horizontal, 7)
+                                    .frame(height: 20)
+                                    .background(LocusTheme.paperDeep)
+                                    .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+                            }
+                            .padding(.horizontal, 11)
+                            .frame(minHeight: 34)
+                            if index < group.shortcuts.count - 1 {
+                                Divider().overlay(LocusTheme.line.opacity(0.6))
+                            }
+                        }
+                    }
+                    .locusCard(radius: 9)
+                }
+            }
+        }
+        .accessibilityIdentifier("shortcuts.reference")
+    }
+}
+
+/// The persistent reference requested in Settings, directly below Extensions.
+struct KeyboardShortcutsSettingsView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Keyboard shortcuts")
+                    .font(.system(size: 15, weight: .bold))
+                Text("Everything in Locus remains reachable from the keyboard, including the command palette with ⌘K.")
+                    .font(.system(size: 9))
+                    .foregroundStyle(LocusTheme.muted)
+                    .padding(.bottom, 14)
+                KeyboardShortcutsReference()
+            }
+            .padding(20)
+        }
+        .background(LocusTheme.panel)
+        .accessibilityIdentifier("settings.shortcuts")
+    }
+}
+
+/// Keyboard shortcut reference, still presented with ⌘/ and `/shortcuts`.
 struct ShortcutsSheet: View {
     @Environment(\.dismiss) private var dismiss
-
-    private struct Shortcut: Identifiable {
-        let keys: String
-        let title: String
-        var id: String { keys + title }
-    }
-
-    private struct Group: Identifiable {
-        let name: String
-        let shortcuts: [Shortcut]
-        var id: String { name }
-    }
-
-    private let groups: [Group] = [
-        Group(name: "General", shortcuts: [
-            Shortcut(keys: "⌘K", title: "Command palette"),
-            Shortcut(keys: "⌘F", title: "Find in conversation"),
-            Shortcut(keys: "⌘/", title: "Keyboard shortcuts"),
-            Shortcut(keys: "⌘N", title: "New session"),
-            Shortcut(keys: "⌘⇧K", title: "Clear chat"),
-            Shortcut(keys: "⌘S", title: "Create checkpoint"),
-            Shortcut(keys: "⌘R", title: "Review changes"),
-        ]),
-        Group(name: "Composer", shortcuts: [
-            Shortcut(keys: "⌘↵", title: "Send message (queues while busy)"),
-            Shortcut(keys: "Esc", title: "Stop the current run / close popups"),
-            Shortcut(keys: "↑ ↓", title: "Browse prompt history (empty composer)"),
-            Shortcut(keys: "/", title: "Slash commands"),
-            Shortcut(keys: "@", title: "Mention a workspace file"),
-            Shortcut(keys: "↑↓ · 1–3 · ↵ · Esc", title: "Answer a permission request"),
-        ]),
-        Group(name: "Panels", shortcuts: [
-            Shortcut(keys: "⌘0", title: "Show/hide sidebar"),
-            Shortcut(keys: "⌘1–⌘7", title: "Plan · Changes · Files · Console · Preview · Checkpoints · AGENTS.md"),
-            Shortcut(keys: "⌘⌥I", title: "Show/hide inspector"),
-        ]),
-        Group(name: "Modes", shortcuts: [
-            Shortcut(keys: "⌥A", title: "Just Chat"),
-            Shortcut(keys: "⌥P", title: "Plan mode"),
-            Shortcut(keys: "⌥B", title: "Build mode"),
-        ]),
-    ]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -73,39 +130,8 @@ struct ShortcutsSheet: View {
             }
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    ForEach(groups) { group in
-                        VStack(alignment: .leading, spacing: 7) {
-                            Text(group.name.uppercased())
-                                .font(.system(size: 8, weight: .bold))
-                                .tracking(0.9)
-                                .foregroundStyle(LocusTheme.muted)
-                            VStack(spacing: 0) {
-                                ForEach(Array(group.shortcuts.enumerated()), id: \.element.id) { index, shortcut in
-                                    HStack {
-                                        Text(shortcut.title)
-                                            .font(.system(size: 10, weight: .medium))
-                                        Spacer()
-                                        Text(shortcut.keys)
-                                            .font(.system(size: 9, design: .monospaced))
-                                            .foregroundStyle(LocusTheme.muted)
-                                            .padding(.horizontal, 7)
-                                            .frame(height: 20)
-                                            .background(LocusTheme.paperDeep)
-                                            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
-                                    }
-                                    .padding(.horizontal, 11)
-                                    .frame(height: 34)
-                                    if index < group.shortcuts.count - 1 {
-                                        Divider().overlay(LocusTheme.line.opacity(0.6))
-                                    }
-                                }
-                            }
-                            .locusCard(radius: 9)
-                        }
-                    }
-                }
-                .padding(16)
+                KeyboardShortcutsReference()
+                    .padding(16)
             }
         }
         .frame(width: 430, height: 520)

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct WorkspaceView: View {
     @EnvironmentObject private var model: AppModel
     @State private var modelPickerPresented = false
+    @State private var teamProgressPresented = false
 
     private var sessionTitle: String {
         model.sessions.first(where: { $0.id == model.currentSessionID })?.displayTitle
@@ -85,6 +86,43 @@ struct WorkspaceView: View {
 
             Spacer()
 
+            if model.selectedAgentTeam != nil {
+                Button {
+                    teamProgressPresented.toggle()
+                } label: {
+                    ZStack(alignment: .topTrailing) {
+                        Image(systemName: "waveform.path.ecg")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(LocusTheme.inkSoft)
+                            .frame(width: 32, height: 32)
+                        Circle()
+                            .fill(teamProgressColor)
+                            .frame(width: 7, height: 7)
+                            .overlay {
+                                Circle().stroke(LocusTheme.panel, lineWidth: 1.5)
+                            }
+                            .offset(x: -3, y: 3)
+                    }
+                    .background(LocusTheme.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(LocusTheme.line, lineWidth: 1)
+                    }
+                }
+                .buttonStyle(.plain)
+                .frame(width: 32, height: 32)
+                .help("Team progress · \(teamProgressTitle)")
+                .accessibilityLabel("Team progress, \(teamProgressTitle)")
+                .accessibilityIdentifier("workspace.teamProgress")
+                .popover(isPresented: $teamProgressPresented, arrowEdge: .top) {
+                    TeamProgressPopover {
+                        teamProgressPresented = false
+                    }
+                    .environmentObject(model)
+                }
+            }
+
             ContextUsageChip()
                 .environmentObject(model)
 
@@ -122,31 +160,13 @@ struct WorkspaceView: View {
                 ? "Active team, \(model.modelPickerLabel)"
                 : "Select model")
             .accessibilityIdentifier("workspace.modelPicker")
+            .frame(height: 32)
             .popover(isPresented: $modelPickerPresented, arrowEdge: .top) {
                 ModelPickerPopover {
                     modelPickerPresented = false
                 }
                 .environmentObject(model)
             }
-
-            Button {
-                model.commandPalettePresented = true
-            } label: {
-                Image(systemName: "command")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(LocusTheme.muted)
-                    .frame(width: 32, height: 32)
-                    .background(Color.clear)
-                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .stroke(LocusTheme.line, lineWidth: 1)
-                    }
-            }
-            .buttonStyle(.plain)
-            .help("Command palette (⌘K)")
-            .accessibilityLabel("Open command palette")
-            .accessibilityIdentifier("workspace.commandPalette")
 
             Menu {
                 // ⌘⇧K lives on the app menu's Clear Chat only — declaring it
@@ -184,6 +204,8 @@ struct WorkspaceView: View {
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(LocusTheme.muted)
                     .frame(width: 32, height: 32)
+                    .background(LocusTheme.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                     .overlay {
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
                             .stroke(LocusTheme.line, lineWidth: 1)
@@ -191,6 +213,7 @@ struct WorkspaceView: View {
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
+            .frame(width: 32, height: 32)
             .accessibilityLabel("Workspace actions")
             .accessibilityIdentifier("workspace.actions")
 
@@ -211,6 +234,23 @@ struct WorkspaceView: View {
         .background(LocusTheme.panel)
         .overlay(alignment: .bottom) {
             Rectangle().fill(LocusTheme.line).frame(height: 1)
+        }
+    }
+
+    private var teamProgressTitle: String {
+        if model.selectedTeamRouteIssue != nil { return "Needs setup" }
+        return model.orchestrationState?.title ?? "Ready"
+    }
+
+    private var teamProgressColor: Color {
+        if model.selectedTeamRouteIssue != nil { return LocusTheme.coral }
+        switch model.orchestrationState {
+        case .completed: return LocusTheme.success
+        case .failed, .interrupted, .cancelled, .discarded: return LocusTheme.coral
+        case .waitingPermission, .waitingComputer, .waitingDispatchApproval, .paused:
+            return LocusTheme.warning
+        case .queued, .dispatching, .running, .reviewing: return LocusTheme.signalDeep
+        case nil: return LocusTheme.success
         }
     }
 
@@ -317,6 +357,15 @@ private struct ModelPickerPopover: View {
                 ) {
                     dismiss()
                     model.settingsPage = .accounts
+                    model.settingsPresented = true
+                }
+                pickerAction(
+                    "Manage Agents & Teams…",
+                    symbol: "person.3.sequence.fill",
+                    identifier: "workspace.modelPicker.manageAgentsTeams"
+                ) {
+                    dismiss()
+                    model.settingsPage = .agents
                     model.settingsPresented = true
                 }
             }

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -244,6 +244,112 @@ final class AppModelTests: XCTestCase {
     }
 
     @MainActor
+    func testCompletedForegroundRunDoesNotShowQuitWarningForStaleSnapshot() {
+        let stale = TaskConversationState(
+            sessionID: "current-session",
+            taskID: "task-1",
+            teamID: "team-1",
+            workerID: "worker-1",
+            runID: "run-1",
+            state: .running,
+            updatedAt: Date()
+        )
+
+        XCTAssertFalse(AppModel.shouldWarnBeforeQuit(
+            isBusy: false,
+            hasPendingPermission: false,
+            currentSessionID: stale.sessionID,
+            orchestrationState: .completed,
+            taskConversationStates: [stale.sessionID: stale],
+            liveWorkerSessionIDs: [stale.sessionID]
+        ))
+        XCTAssertTrue(AppModel.shouldWarnBeforeQuit(
+            isBusy: true,
+            hasPendingPermission: false,
+            currentSessionID: stale.sessionID,
+            orchestrationState: .completed,
+            taskConversationStates: [stale.sessionID: stale],
+            liveWorkerSessionIDs: [stale.sessionID]
+        ), "a newly-started turn must override the previous run's terminal state")
+    }
+
+    @MainActor
+    func testQuitWarningRequiresLiveNonTerminalBackgroundWorker() {
+        let background = TaskConversationState(
+            sessionID: "background-session",
+            taskID: "task-2",
+            teamID: "team-1",
+            workerID: "worker-2",
+            runID: "run-2",
+            state: .running,
+            updatedAt: Date()
+        )
+        let arguments = (
+            isBusy: false,
+            hasPendingPermission: false,
+            currentSessionID: "current-session",
+            orchestrationState: TeamRunState.completed,
+            taskConversationStates: [background.sessionID: background]
+        )
+
+        XCTAssertFalse(AppModel.shouldWarnBeforeQuit(
+            isBusy: arguments.isBusy,
+            hasPendingPermission: arguments.hasPendingPermission,
+            currentSessionID: arguments.currentSessionID,
+            orchestrationState: arguments.orchestrationState,
+            taskConversationStates: arguments.taskConversationStates,
+            liveWorkerSessionIDs: []
+        ))
+        XCTAssertTrue(AppModel.shouldWarnBeforeQuit(
+            isBusy: arguments.isBusy,
+            hasPendingPermission: arguments.hasPendingPermission,
+            currentSessionID: arguments.currentSessionID,
+            orchestrationState: arguments.orchestrationState,
+            taskConversationStates: arguments.taskConversationStates,
+            liveWorkerSessionIDs: [background.sessionID]
+        ))
+    }
+
+    @MainActor
+    func testDispatcherRepairAndFallbackMessagesUpdateProgress() {
+        let model = AppModel(startImmediately: false)
+        model.handleEventForTesting([
+            "type": "dispatcher_started",
+            "run_id": "run-1",
+            "agent_name": "Qwen Dispatcher",
+        ])
+        model.handleEventForTesting([
+            "type": "dispatcher_plan_rejected",
+            "run_id": "run-1",
+            "stage": "initial",
+            "reason": "dispatcher plan has no jobs",
+            "message": "Correcting dispatcher plan…",
+        ])
+
+        XCTAssertEqual(model.dispatcherActivity?.state, .running)
+        XCTAssertEqual(model.dispatcherActivity?.output, "Correcting dispatcher plan…")
+
+        let fallback = "Dispatcher plan could not be validated after repair: dispatcher plan has no jobs. Continuing safely with Kimi Writer only."
+        model.handleEventForTesting([
+            "type": "dispatcher_plan_rejected",
+            "run_id": "run-1",
+            "stage": "repair",
+            "reason": "dispatcher plan has no jobs",
+            "message": fallback,
+        ])
+        model.handleEventForTesting([
+            "type": "dispatcher_completed",
+            "run_id": "run-1",
+            "state": "completed",
+            "outcome": "fallback",
+            "message": fallback,
+        ])
+
+        XCTAssertEqual(model.dispatcherActivity?.state, .completed)
+        XCTAssertEqual(model.dispatcherActivity?.output, fallback)
+    }
+
+    @MainActor
     func testGlobalAgentConcurrencyStaysWithinApplicationCeiling() {
         let model = AppModel(startImmediately: false)
         model.globalAgentConcurrency = 99
@@ -280,10 +386,61 @@ final class AppModelTests: XCTestCase {
 
         let manifest = try XCTUnwrap(model.teamManifest(for: "Implement this"))
         let profiles = try XCTUnwrap(manifest["profiles"] as? [[String: Any]])
+        let teamPayload = try XCTUnwrap(manifest["team"] as? [String: Any])
         XCTAssertEqual(Set(profiles.compactMap { $0["id"] as? String }), Set(team.memberIDs.map(\.uuidString)))
+        XCTAssertEqual(teamPayload["dispatch_approval_mode"] as? String, "preview")
         XCTAssertTrue(JSONSerialization.isValidJSONObject(manifest))
         let encoded = try JSONSerialization.data(withJSONObject: manifest)
         XCTAssertFalse(String(decoding: encoded, as: UTF8.self).contains("api_key"))
+    }
+
+    @MainActor
+    func testTeamDispatchProgressBecomesOneTimePlanApproval() {
+        let model = AppModel(startImmediately: false)
+        model.isBusy = true
+        model.handleEventForTesting([
+            "type": "orchestration_started",
+            "run_id": "run-once",
+            "state": "dispatching",
+        ])
+
+        XCTAssertTrue(model.shouldShowTeamDispatchProgress)
+        XCTAssertFalse(model.shouldShowTeamDispatchApproval)
+
+        model.handleEventForTesting([
+            "type": "dispatcher_started",
+            "run_id": "run-once",
+            "agent_name": "Qwen Dispatcher",
+            "provider": "vLLM",
+            "model": "qwen",
+        ])
+        model.handleEventForTesting([
+            "type": "dispatcher_plan_rejected",
+            "run_id": "run-once",
+            "reason": "writer job was missing",
+            "message": "Correcting dispatcher plan…",
+        ])
+        XCTAssertEqual(model.dispatcherValidationReason, "writer job was missing")
+
+        model.handleEventForTesting([
+            "type": "dispatch_plan_ready",
+            "run_id": "run-once",
+            "state": "waiting_dispatch_approval",
+            "plan": [
+                "summary": "Implement once",
+                "jobs": [[
+                    "id": "write",
+                    "agent_id": UUID().uuidString,
+                    "goal": "Implement the request",
+                    "dependencies": [],
+                    "kind": "writer",
+                ]],
+            ],
+        ])
+
+        XCTAssertFalse(model.shouldShowTeamDispatchProgress)
+        XCTAssertTrue(model.shouldShowTeamDispatchApproval)
+        XCTAssertEqual(model.pendingDispatchPlan?.jobs.count, 1)
     }
 
     func testWorkModeInstructionsAreDistinct() {

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -1672,6 +1672,26 @@ final class FeatureLogicTests: XCTestCase {
         )
     }
 
+    func testLegacyTeamApprovalModesMigrateToOneTimePreview() {
+        let team = AgentTeam(
+            name: "Legacy automatic team",
+            dispatcherID: nil,
+            fallbackDispatcherID: nil,
+            memberIDs: [],
+            defaultWriterID: nil,
+            dispatchApprovalMode: .automatic
+        )
+
+        let migration = AgentTeamStore.migrateToOneTimeApproval([team])
+
+        XCTAssertTrue(migration.changed)
+        XCTAssertEqual(migration.teams.first?.dispatchApprovalMode, .preview)
+        XCTAssertEqual(migration.teams.first?.resolvedDispatchApprovalMode, .preview)
+
+        let alreadyPreview = AgentTeamStore.migrateToOneTimeApproval(migration.teams)
+        XCTAssertFalse(alreadyPreview.changed)
+    }
+
     func testAgentTeamRejectsAModelTheSelectedProviderDoesNotReport() {
         let account = ProviderAccount(
             kind: .custom,

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -40,7 +40,7 @@ final class LocusUITests: XCTestCase {
     }
 
     func testReopeningLocusKeepsOneMainWindowAndItsPresentedSheet() throws {
-        anyElement("workspace.commandPalette").click()
+        app.typeKey("k", modifierFlags: .command)
         let search = app.textFields["palette.search"]
         XCTAssertTrue(search.waitForExistence(timeout: 3))
         search.typeText("keep this state")
@@ -265,8 +265,7 @@ final class LocusUITests: XCTestCase {
         XCTAssertEqual(app.windows.firstMatch.frame, originalFrame)
 
         anyElement("workspace.modelPicker.close").click()
-        XCTAssertTrue(anyElement("workspace.commandPalette").waitForExistence(timeout: 3))
-        anyElement("workspace.commandPalette").click()
+        app.typeKey("k", modifierFlags: .command)
         XCTAssertTrue(app.textFields["palette.search"].waitForExistence(timeout: 3))
     }
 
@@ -288,6 +287,21 @@ final class LocusUITests: XCTestCase {
         app.typeKey("/", modifierFlags: .command)
         XCTAssertTrue(app.buttons["shortcuts.close"].waitForExistence(timeout: 3))
         app.buttons["shortcuts.close"].click()
+    }
+
+    func testKeyboardShortcutsHaveASettingsTabBelowExtensions() {
+        anyElement("workspace.modelPicker").click()
+        anyElement("workspace.modelPicker.manageAccounts").click()
+
+        let extensions = anyElement("settings.page.extensions")
+        let shortcuts = anyElement("settings.page.shortcuts")
+        XCTAssertTrue(extensions.waitForExistence(timeout: 3))
+        XCTAssertTrue(shortcuts.exists)
+        XCTAssertLessThan(extensions.frame.maxY, shortcuts.frame.minY)
+
+        shortcuts.click()
+        XCTAssertTrue(anyElement("settings.shortcuts").waitForExistence(timeout: 3))
+        XCTAssertTrue(anyElement("shortcuts.reference").exists)
     }
 
     func testCommandPaletteNavigatesWithArrowKeys() {
@@ -473,10 +487,15 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
     }
 
-    private func relaunchWithRunFixture(_ fixture: String, uncleanRecovery: Bool = false) {
+    private func relaunchWithRunFixture(
+        _ fixture: String,
+        uncleanRecovery: Bool = false,
+        staleQuitState: Bool = false
+    ) {
         app.terminate()
         app.launchEnvironment["LOCUS_UI_TESTING_RUN_FIXTURE"] = fixture
         app.launchEnvironment["LOCUS_UI_TESTING_UNCLEAN_RECOVERY"] = uncleanRecovery ? "1" : nil
+        app.launchEnvironment["LOCUS_UI_TESTING_STALE_QUIT_STATE"] = staleQuitState ? "1" : nil
         app.launch()
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
     }
@@ -515,6 +534,59 @@ final class LocusUITests: XCTestCase {
                 NSPredicate(format: "value CONTAINS[c] %@ OR label CONTAINS[c] %@", "can be resumed", "can be resumed")
             ).firstMatch.exists
         )
+    }
+
+    func testCompletedRunQuitsWithoutAStopRunningWarningFromStaleState() {
+        relaunchWithRunFixture("completed", staleQuitState: true)
+
+        app.typeKey("q", modifierFlags: .command)
+
+        XCTAssertTrue(
+            app.wait(for: .notRunning, timeout: 5),
+            "a durable completed run must not be mistaken for active work"
+        )
+    }
+
+    func testDispatcherRepairIsVisibleInProgressAndRuns() {
+        relaunchWithRunFixture("dispatcher-repair")
+
+        XCTAssertTrue(anyElement("teamDispatch.progress").waitForExistence(timeout: 3))
+        let progress = anyElement("workspace.teamProgress")
+        XCTAssertTrue(progress.waitForExistence(timeout: 3))
+        progress.click()
+        XCTAssertTrue(anyElement("teamProgress.popover").waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            app.staticTexts.matching(
+                NSPredicate(
+                    format: "value CONTAINS[c] %@ OR label CONTAINS[c] %@",
+                    "Correcting dispatcher plan",
+                    "Correcting dispatcher plan"
+                )
+            ).firstMatch.exists
+        )
+
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertTrue(
+            app.staticTexts.matching(
+                NSPredicate(
+                    format: "value CONTAINS[c] %@ OR label CONTAINS[c] %@",
+                    "dispatcher plan has no jobs",
+                    "dispatcher plan has no jobs"
+                )
+            ).firstMatch.waitForExistence(timeout: 3)
+        )
+    }
+
+    func testTeamPlanAppearsOnceInComposerWithWholePlanActions() {
+        relaunchWithRunFixture("dispatch-plan")
+
+        XCTAssertTrue(anyElement("teamDispatch.approval").waitForExistence(timeout: 3))
+        XCTAssertFalse(app.textViews["composer.input"].exists)
+        XCTAssertTrue(anyElement("teamDispatch.jobs").exists)
+        XCTAssertTrue(anyElement("teamDispatch.run").exists)
+        XCTAssertTrue(anyElement("teamDispatch.redispatch").exists)
+        XCTAssertTrue(anyElement("teamDispatch.cancel").exists)
+        XCTAssertTrue(anyElement("workspace.teamProgress").exists)
     }
 
     func testPermissionPanelRepliesWithTheKeyboard() {

--- a/README.md
+++ b/README.md
@@ -25,10 +25,19 @@ like; macOS remembers the size you choose for later launches.
   replaying its last approval after reconnecting. Run updates are coalesced and
   loaded incrementally so large timelines stay responsive at completion. After
   an unexpected quit, Locus reopens the latest run and explains whether it
-  finished or can be resumed.
-- **Live Team Progress in the sidebar** shows the active dispatcher and its
+  finished or can be resumed. A completed run no longer triggers the active-work
+  warning when you quit just because an older in-memory status is still present.
+- **Live Team Progress in the header** sits immediately left of the context
+  meter and shows the active dispatcher and its
   provider/model, elapsed time, delegated jobs, model calls, and hosted-token
-  usage. Its Stop button remains available while a team is running.
+  usage. During dispatch, the composer itself explains the current stage and
+  any bounded validation repair. When the plan is ready, the composer asks for
+  one approval for the complete plan; individual models, jobs, and steps do not
+  ask again. Its Stop button remains available while a team is running. Common
+  Qwen/vLLM plan wrappers are normalized before validation; when correction is
+  needed, both Team Progress and Runs show the repair stage and exact bounded
+  validation reason. If repair still fails, Locus explains why it is continuing
+  safely with the designated writer instead of silently skipping specialists.
 - **Team-aware model controls** label the workspace with the selected team and
   distinct model count, list the exact team models in a bounded, scrollable
   header picker, and use provider-backed model dropdowns when editing agent
@@ -52,7 +61,7 @@ for setup, examples, permission boundaries, recovery, and troubleshooting.
 ## Designed for real project work
 
 - **One calm sidebar** holds the conversation list: rows for Plugins & MCP,
-  Manage Accounts, Agents & Teams, live Team Progress, and Hugging Face, then
+  Manage Accounts, and Hugging Face, then
   New chat, search, recents, and a footer with the workspace selector,
   connection status, and the rest of the app's actions. It starts open,
   collapses with `⌘0` or the header button when you want the room, and remembers
@@ -130,7 +139,9 @@ for setup, examples, permission boundaries, recovery, and troubleshooting.
 - **Session checkpoints** restore the conversation, plan, workspace, model, and
   context together.
 - **Native command palette and shortcuts** keep frequent actions close at
-  hand — ⌘K palette with arrow-key navigation, ⌘/ shortcut reference.
+  hand — ⌘K opens the palette with arrow-key navigation, ⌘/ opens the shortcut
+  reference, and the same reference has a permanent Settings tab below
+  Extensions.
 - **Background notifications** announce finished runs and pending permission
   requests when Locus is not the active app.
 - **Local sessions and model switching** work directly with the Ollama Code
@@ -294,6 +305,14 @@ count rather than the solo session's provider. Open it to see each exact model,
 switch back to Solo, or manage the team. Agent profiles use a model dropdown
 filled from their selected provider; the refresh and **Test Connection** actions
 can wake a scaled-to-zero vLLM endpoint before its model catalog is available.
+
+The Team Progress button appears immediately left of the context meter. While
+the dispatcher is building a plan, the composer shows its route, elapsed time,
+observable stage, and validation status. The completed plan then replaces the
+composer with **Run Plan**, **Re-dispatch**, and **Cancel**. Run Plan is a
+single approval for the entire dependency graph; it is not repeated for each
+agent or step. Security-sensitive tool permissions still follow the permission
+mode selected separately.
 
 **Test Connection** confirms the account answers before you send a message,
 and reports the actual reason when it does not — a rejected key, a wrong URL,
@@ -567,7 +586,7 @@ xcodebuild \
 cd agent && .venv/bin/python -m pytest -q
 ```
 
-The repository currently contains 244 unit tests, 29 UI tests, and 378 backend
+The repository currently contains 249 unit tests, 33 UI tests, and 392 backend
 test cases.
 
 The unit suite covers work modes, lightweight context migration, session

--- a/agent/PROTOCOL.md
+++ b/agent/PROTOCOL.md
@@ -57,6 +57,9 @@ Every persisted event has immutable `event_id`, per-run monotonic `seq`,
 `occurred_at`, `schema_version`, and optional job/attempt identity. Clients
 deduplicate by `event_id`. The database uses WAL, foreign keys, transactional
 additive migrations, and reopens read-only if a migration cannot complete.
+`dispatcher_plan_rejected` is an additive diagnostic event with `stage`
+(`initial` or `repair`), a bounded validation `reason`, `response_source`, and
+`will_retry`. It never contains the raw model response or provider credentials.
 
 `GET /api/orchestrations/{run_id}/export?include_content=false` produces the
 redacted `locusrun` version-1 document. Conversation, goal, output, reasoning,
@@ -598,8 +601,11 @@ for the session.
 - `orchestration_started` identifies `run_id`, `team_id`, `team_name`,
   `worker_id`, state, and the accepted hard budget.
 - `dispatch_plan` carries the validated, acyclic job graph. It is emitted only
-  after a required `submit_dispatch_plan` tool call, strict JSON fallback, one
-  JSON repair, or the deterministic default-writer recovery.
+  after a required `submit_dispatch_plan` tool call, a normalized JSON candidate,
+  one schema-aware repair, or the deterministic default-writer recovery.
+- `dispatcher_plan_rejected` records the bounded validation reason and whether
+  repair will be attempted. It deliberately omits the rejected model output and
+  credentials. A second rejection explains the one-writer safe fallback.
 - `orchestration_state` reports `dispatching`, `running`, `reviewing`, or a
   permission/computer wait. Steering cancels unstarted jobs and returns to
   dispatching without an intermediate `turn_done`.
@@ -769,7 +775,12 @@ session_info
 
 With dispatch preview, `dispatch_plan_ready` is persisted before the server
 enters `waiting_dispatch_approval`; no jobs start until `dispatch_decision`
-chooses Run Plan. Every edit or re-dispatch is fully revalidated. With recovery,
+chooses Run Plan. That single decision releases the complete validated graph;
+there is no dispatch decision per model, agent, job, or step. The native Locus
+client always requests preview, including for teams previously stored as
+automatic, while the protocol retains automatic mode for other clients. Tool
+permission requests remain independent. Every edit or re-dispatch is fully
+revalidated. With recovery,
 an `orchestration_checkpoint` follows validated dispatch and each terminal
 specialist wave, writer, review, revision, and synthesis boundary. Pause waits
 for a safe boundary: streams and cancellable tools stop cooperatively, while a

--- a/agent/ollama_code/orchestration.py
+++ b/agent/ollama_code/orchestration.py
@@ -204,6 +204,10 @@ class AgentResult:
 class DispatchPlan:
     summary: str
     jobs: tuple[AgentJob, ...]
+    # Internal resolution metadata. It is deliberately absent from
+    # `structured()` so existing plan/checkpoint payloads remain compatible.
+    outcome: str = field(default="valid", repr=False, compare=False)
+    validation_reason: str = field(default="", repr=False, compare=False)
 
     def structured(self) -> dict[str, Any]:
         return {
@@ -837,7 +841,12 @@ class TeamOrchestrator:
                 "reason": "Highest eligible transparent scorecard total.",
                 "candidates": scorecards,
             })
-        return DispatchPlan(plan.summary, tuple(resolved))
+        return DispatchPlan(
+            plan.summary,
+            tuple(resolved),
+            outcome=plan.outcome,
+            validation_reason=plan.validation_reason,
+        )
 
     def _scorecard(self, profile: AgentProfile, team: AgentTeam) -> dict[str, Any]:
         samples = self.run_store.routing_samples(
@@ -1016,7 +1025,7 @@ class TeamOrchestrator:
         })
         try:
             plan = self._dispatch(
-                request, workspace, team, profiles, dispatcher, forced_agent,
+                run_id, request, workspace, team, profiles, dispatcher, forced_agent,
             )
         except Exception as exc:
             self.emit({
@@ -1029,12 +1038,18 @@ class TeamOrchestrator:
                 "usage": self.usage(),
             })
             raise
+        completion_message = {
+            "valid": "Dispatch plan ready",
+            "repaired": "Dispatch plan repaired",
+            "fallback": plan.summary,
+        }.get(plan.outcome, "Dispatch plan ready")
         self.emit({
             "type": "dispatcher_completed",
             "run_id": run_id,
             "agent_id": dispatcher.id,
             "state": "completed",
-            "message": "Dispatch plan ready",
+            "message": completion_message,
+            "outcome": plan.outcome,
             "elapsed_ms": max(int((time.monotonic() - started) * 1_000), 0),
             "usage": self.usage(),
         })
@@ -1042,6 +1057,7 @@ class TeamOrchestrator:
 
     def _dispatch(
         self,
+        run_id: str,
         request: str,
         workspace: str,
         team: AgentTeam,
@@ -1069,7 +1085,7 @@ class TeamOrchestrator:
             f"Hard max jobs: {team.budget.max_jobs}\nRoster:\n{json.dumps(roster)}"
         )
         response = self._raw_call(
-            team.id,
+            run_id,
             dispatcher,
             [
                 {"role": "system", "content": dispatcher.instructions},
@@ -1079,39 +1095,95 @@ class TeamOrchestrator:
             tools=[DISPATCH_TOOL],
             force_tool="submit_dispatch_plan",
         )
-        raw: Any = None
-        for call in response.tool_calls:
-            if call.name == "submit_dispatch_plan":
-                raw = call.arguments
-                break
-        if raw is None:
-            raw = _extract_json(response.content)
-        try:
-            return validate_dispatch_plan(raw, team, profiles, forced_agent)
-        except OrchestrationError:
-            repair = self._raw_call(
-                team.id,
-                dispatcher,
-                [
-                    {"role": "system", "content": dispatcher.instructions},
-                    {"role": "user", "content": prompt},
-                    {"role": "assistant", "content": response.content},
-                    {
-                        "role": "user",
-                        "content": "Repair the plan once. Return only strict JSON matching the submit_dispatch_plan arguments schema.",
-                    },
-                ],
-                team.budget,
-            )
-            try:
-                return validate_dispatch_plan(_extract_json(repair.content), team, profiles, forced_agent)
-            except OrchestrationError:
-                # Deterministic recovery: the designated writer receives the
-                # request directly; this preserves the one-writer boundary.
-                return DispatchPlan(
-                    summary="Dispatcher plan invalid; using the team's default writer.",
-                    jobs=(AgentJob("writer", team.default_writer_id, request, (), "writer"),),
-                )
+        plan, rejected, source, initial_reason = _validate_dispatch_response(
+            response, team, profiles, forced_agent,
+        )
+        if plan is not None:
+            return plan
+        if self.should_stop():
+            raise InterruptedError("orchestration redirected or cancelled")
+
+        initial_reason = _bounded_dispatch_reason(initial_reason)
+        self.emit({
+            "type": "dispatcher_plan_rejected",
+            "run_id": run_id,
+            "agent_id": dispatcher.id,
+            "agent_name": dispatcher.name,
+            "provider": _route_label(dispatcher.route),
+            "model": dispatcher.model,
+            "stage": "initial",
+            "reason": initial_reason,
+            "response_source": source,
+            "will_retry": True,
+            "message": "Correcting dispatcher plan…",
+        })
+        repair_prompt = (
+            "The previous dispatch candidate failed validation. Correct only the structural "
+            "or routing errors and return one strict JSON object matching the "
+            "submit_dispatch_plan arguments schema. Do not wrap it in prose or Markdown.\n\n"
+            f"Exact validation error:\n{initial_reason}\n\n"
+            f"Rejected candidate:\n{_bounded_dispatch_candidate(rejected)}\n\n"
+            f"Default writer id: {team.default_writer_id}\n"
+            f"Hard max jobs: {team.budget.max_jobs}\n"
+            f"Roster:\n{json.dumps(roster, ensure_ascii=False)}\n\n"
+            "Arguments schema:\n"
+            f"{json.dumps(DISPATCH_TOOL['function']['parameters'], ensure_ascii=False)}"
+        )
+        repair = self._raw_call(
+            run_id,
+            dispatcher,
+            [
+                {"role": "system", "content": dispatcher.instructions},
+                {"role": "user", "content": prompt},
+                {
+                    "role": "assistant",
+                    "content": _bounded_dispatch_candidate(
+                        response.content or rejected,
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": repair_prompt,
+                },
+            ],
+            team.budget,
+        )
+        repaired, _, repair_source, repair_reason = _validate_dispatch_response(
+            repair, team, profiles, forced_agent,
+        )
+        if repaired is not None:
+            return replace(repaired, outcome="repaired")
+        if self.should_stop():
+            raise InterruptedError("orchestration redirected or cancelled")
+
+        repair_reason = _bounded_dispatch_reason(repair_reason)
+        writer_name = profiles[team.default_writer_id].name
+        summary = (
+            "Dispatcher plan could not be validated after repair: "
+            f"{repair_reason}. Continuing safely with {writer_name} only."
+        )
+        self.emit({
+            "type": "dispatcher_plan_rejected",
+            "run_id": run_id,
+            "agent_id": dispatcher.id,
+            "agent_name": dispatcher.name,
+            "provider": _route_label(dispatcher.route),
+            "model": dispatcher.model,
+            "stage": "repair",
+            "reason": repair_reason,
+            "response_source": repair_source,
+            "will_retry": False,
+            "message": summary,
+        })
+        # Deterministic recovery: the designated writer receives the request
+        # directly; this preserves the one-writer boundary without pretending
+        # that specialists were dispatched.
+        return DispatchPlan(
+            summary=summary,
+            jobs=(AgentJob("writer", team.default_writer_id, request, (), "writer"),),
+            outcome="fallback",
+            validation_reason=repair_reason,
+        )
 
     def _run_pre_writer_jobs(
         self,
@@ -1470,6 +1542,103 @@ def validate_dispatch_plan(
     return DispatchPlan(str(value.get("summary") or "Team dispatch plan")[:4_000], tuple(jobs))
 
 
+def normalize_dispatch_candidate(value: Any, *, _depth: int = 0) -> Any:
+    """Unwrap bounded provider/tool envelopes without changing plan semantics."""
+    if _depth > 4:
+        raise OrchestrationError("dispatcher plan wrapper nesting is too deep")
+    if isinstance(value, str):
+        return normalize_dispatch_candidate(_extract_json(value), _depth=_depth + 1)
+    if not isinstance(value, dict):
+        return value
+    if "jobs" in value:
+        return value
+
+    plan = value.get("plan")
+    if plan is not None:
+        return normalize_dispatch_candidate(plan, _depth=_depth + 1)
+
+    function = value.get("function")
+    if isinstance(function, dict):
+        name = str(function.get("name") or value.get("name") or "")
+        if name == "submit_dispatch_plan" and "arguments" in function:
+            return normalize_dispatch_candidate(
+                function["arguments"], _depth=_depth + 1,
+            )
+
+    tool_call = value.get("tool_call")
+    if isinstance(tool_call, dict):
+        return normalize_dispatch_candidate(tool_call, _depth=_depth + 1)
+
+    calls = value.get("tool_calls")
+    if isinstance(calls, list):
+        for call in calls[:8]:
+            if not isinstance(call, dict):
+                continue
+            try:
+                candidate = normalize_dispatch_candidate(call, _depth=_depth + 1)
+            except OrchestrationError:
+                continue
+            if isinstance(candidate, dict) and "jobs" in candidate:
+                return candidate
+
+    name = str(value.get("name") or value.get("tool") or "")
+    if name == "submit_dispatch_plan":
+        for key in ("arguments", "input"):
+            if key in value:
+                return normalize_dispatch_candidate(value[key], _depth=_depth + 1)
+
+    # vLLM-compatible clients preserve malformed streamed arguments under
+    # `_raw`; top-level `arguments`/`input` wrappers are also common.
+    for key in ("_raw", "arguments", "input"):
+        if key in value:
+            return normalize_dispatch_candidate(value[key], _depth=_depth + 1)
+    return value
+
+
+def _validate_dispatch_response(
+    response: Any,
+    team: AgentTeam,
+    profiles: dict[str, AgentProfile],
+    forced_agent: str | None,
+) -> tuple[DispatchPlan | None, Any, str, str]:
+    candidates: list[tuple[Any, str]] = []
+    for call in getattr(response, "tool_calls", ()):
+        if getattr(call, "name", "") == "submit_dispatch_plan":
+            candidates.append((getattr(call, "arguments", None), "tool_call"))
+    content = str(getattr(response, "content", "") or "").strip()
+    if content:
+        candidates.append((content, "content"))
+    if not candidates:
+        candidates.append((None, "empty"))
+
+    first_rejected: Any = candidates[0][0]
+    first_source = candidates[0][1]
+    first_reason = "dispatcher did not return a dispatch candidate"
+    for index, (raw, source) in enumerate(candidates):
+        try:
+            candidate = normalize_dispatch_candidate(raw)
+            plan = validate_dispatch_plan(candidate, team, profiles, forced_agent)
+            return plan, candidate, source, ""
+        except OrchestrationError as exc:
+            if index == 0:
+                first_rejected = raw
+                first_source = source
+                first_reason = str(exc)
+    return None, first_rejected, first_source, first_reason
+
+
+def _bounded_dispatch_reason(value: str) -> str:
+    return " ".join(str(value or "dispatcher plan was rejected").split())[:500]
+
+
+def _bounded_dispatch_candidate(value: Any) -> str:
+    try:
+        encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        encoded = str(value)
+    return encoded[:16_000]
+
+
 def collect_workspace_evidence(workspace: str) -> str:
     root = Path(workspace).expanduser().resolve()
     sections = [f"Workspace root: {root}"]
@@ -1765,5 +1934,6 @@ __all__ = [
     "collect_workspace_evidence",
     "client_for_profile", "orchestration_fingerprint",
     "parse_manifest",
+    "normalize_dispatch_candidate",
     "validate_dispatch_plan",
 ]

--- a/agent/ollama_code/remote.py
+++ b/agent/ollama_code/remote.py
@@ -503,7 +503,10 @@ class RemoteClient:
             # tools so the user still gets an answer, and say what happened.
             if tools and ("tool" in message or "function" in message):
                 payload.pop("tools", None)
+                payload.pop("tool_choice", None)
+                payload.pop("parallel_tool_calls", None)
                 response = stream(payload, on_token, should_stop, on_thinking)
+                response.provider_fields["tools_rejected"] = True
                 response.content_parts.insert(
                     0,
                     "[This endpoint rejected tool calling, so I answered without "

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -184,7 +184,7 @@ class ChatService:
             event.setdefault("worker_id", self.worker_id)
             event.setdefault("process_id", os.getpid())
         if event_type.startswith(("agent_job_", "orchestration_", "scheduler_lease", "mcp_task_")) \
-                or event_type == "dispatch_plan":
+                or event_type in {"dispatch_plan", "dispatcher_plan_rejected"}:
             event = dict(event)
             event.setdefault("worker_id", self.worker_id)
         run_id = str(event.get("run_id") or self.active_run_id or "")
@@ -192,7 +192,7 @@ class ChatService:
             "message_start", "message_end", "tool_call_proposed", "permission_request",
             "tool_result", "steer_ack", "steer_applied", "computer_action_request",
             "workspace_changed", "note", "error", "dispatch_plan",
-            "orchestration_checkpoint", "dispatch_plan_ready",
+            "orchestration_checkpoint", "dispatch_plan_ready", "dispatcher_plan_rejected",
         }
         durable_agent_event = (
             event_type.startswith("agent_job_") and event_type != "agent_job_stream"
@@ -211,7 +211,8 @@ class ChatService:
                 # damaged or temporarily locked history store must never stop
                 # an otherwise healthy agent turn.
                 event = {**event, "persistence_error": str(exc)}
-        if event_type in {"agent_job_started", "agent_job_completed", "dispatch_plan"} \
+        if event_type in {"agent_job_started", "agent_job_completed", "dispatch_plan",
+                          "dispatcher_plan_rejected"} \
                 or event_type.startswith("orchestration_") \
                 or event_type.startswith("scheduler_lease") \
                 or event_type.startswith("mcp_task_"):

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -1127,7 +1127,7 @@ def test_remote_retries_without_tools_when_unsupported(monkeypatch):
         timeout=None,
         allow_redirects=None,
     ):
-        attempts.append("tools" in (json or {}))
+        attempts.append(dict(json or {}))
         if "tools" in (json or {}):
             return FakeResponse(
                 status_code=400,
@@ -1141,12 +1141,21 @@ def test_remote_retries_without_tools_when_unsupported(monkeypatch):
     client = remote_mod.RemoteClient("https://endpoint.example", model="m")
 
     resp = client.chat_stream(
-        "m", [{"role": "user", "content": "hi"}], tools=[{"type": "function"}]
+        "m",
+        [{"role": "user", "content": "hi"}],
+        tools=[{"type": "function"}],
+        options={
+            "tool_choice": {"type": "function", "function": {"name": "submit"}},
+            "parallel_tool_calls": False,
+        },
     )
 
-    assert attempts == [True, False], "it must retry once without tools"
+    assert len(attempts) == 2, "it must retry exactly once"
+    assert {"tools", "tool_choice", "parallel_tool_calls"} <= attempts[0].keys()
+    assert {"tools", "tool_choice", "parallel_tool_calls"}.isdisjoint(attempts[1])
     assert "plain answer" in resp.content
     assert "rejected tool calling" in resp.content
+    assert resp.provider_fields["tools_rejected"] is True
 
 
 def test_remote_stream_interrupt_closes_a_stalled_response(monkeypatch):
@@ -2938,6 +2947,31 @@ def test_specialist_token_streams_do_not_flood_durable_run_history(tmp_path):
         })
 
     assert service.run_store.events("stream-run") == []
+
+
+def test_dispatcher_rejection_is_persisted_as_a_bounded_durable_event(tmp_path):
+    core = _core(tmp_path, [])
+    service = server_mod.ChatService(core)
+    service.run_store.start_run("dispatch-run", request="work")
+    service.active_run_id = "dispatch-run"
+
+    service.emit({
+        "type": "dispatcher_plan_rejected",
+        "run_id": "dispatch-run",
+        "stage": "initial",
+        "reason": "dispatcher plan has no jobs",
+        "response_source": "tool_call",
+        "will_retry": True,
+        "message": "Correcting dispatcher plan…",
+    })
+
+    events = service.run_store.events("dispatch-run")
+    assert len(events) == 1
+    assert events[0]["type"] == "dispatcher_plan_rejected"
+    assert events[0]["reason"] == "dispatcher plan has no jobs"
+    assert events[0]["will_retry"] is True
+    assert "content" not in events[0]
+    assert "raw" not in events[0]
 
 
 def test_team_writer_reserves_calls_for_review_and_synthesis():

--- a/agent/tests/test_orchestration.py
+++ b/agent/tests/test_orchestration.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -14,6 +16,7 @@ from ollama_code.orchestration import (
     OrchestrationError,
     TeamOrchestrator,
     TeamPreparation,
+    normalize_dispatch_candidate,
     orchestration_fingerprint,
     parse_manifest,
     validate_dispatch_plan,
@@ -141,6 +144,47 @@ def test_dispatcher_progress_names_the_model_and_reports_completion(monkeypatch)
     assert events[-1]["message"] == "Dispatch plan ready"
 
 
+def test_preview_approves_the_complete_plan_once_before_any_jobs(monkeypatch):
+    events = []
+    approvals = []
+    manifest = _manifest(dispatch_approval_mode="preview")
+    _, team, profiles, forced = parse_manifest(manifest)
+    plan = validate_dispatch_plan(_valid_plan(), team, profiles, forced)
+
+    def approve(run_id, candidate):
+        approvals.append((run_id, candidate))
+        return {"action": "run"}
+
+    orchestrator = TeamOrchestrator(
+        events.append,
+        lambda: False,
+        approve_dispatch=approve,
+    )
+    dispatches = []
+
+    def dispatch_once(*_args):
+        dispatches.append("dispatch")
+        return plan
+
+    monkeypatch.setattr(orchestrator, "_dispatch_with_status", dispatch_once)
+    monkeypatch.setattr(orchestrator, "_run_pre_writer_jobs", lambda *_args: [])
+
+    prepared = orchestrator.prepare(
+        "Build it", "/tmp/workspace", manifest,
+    )
+
+    assert dispatches == ["dispatch"]
+    assert len(approvals) == 1
+    assert approvals[0][0] == "run-1"
+    assert [job["id"] for job in approvals[0][1]["jobs"]] == [
+        "plan", "write", "review",
+    ]
+    assert prepared.plan == plan
+    assert [event["type"] for event in events].count("dispatch_plan") == 1
+    assert events[-1]["type"] == "orchestration_state"
+    assert events[-1]["state"] == "running"
+
+
 def test_dispatch_cancel_does_not_start_repair_or_fallback_calls(monkeypatch):
     events = []
     _, team, profiles, forced = parse_manifest(_manifest())
@@ -155,11 +199,161 @@ def test_dispatch_cancel_does_not_start_repair_or_fallback_calls(monkeypatch):
 
     with pytest.raises(InterruptedError, match="cancelled"):
         orchestrator._dispatch(
-            "Build it", "/tmp/workspace", team, profiles,
+            "run-1", "Build it", "/tmp/workspace", team, profiles,
             profiles[team.dispatcher_id], forced,
         )
 
     assert calls == ["call"]
+
+
+def test_dispatch_cancel_after_rejection_does_not_start_repair(monkeypatch):
+    events = []
+    cancelled = False
+    _, team, profiles, forced = parse_manifest(_manifest())
+    orchestrator = TeamOrchestrator(events.append, lambda: cancelled)
+    calls = 0
+
+    def raw_call(*_args, **_kwargs):
+        nonlocal calls, cancelled
+        calls += 1
+        cancelled = True
+        return SimpleNamespace(
+            tool_calls=[],
+            content=json.dumps({"summary": "bad", "jobs": []}),
+        )
+
+    monkeypatch.setattr(orchestrator, "_raw_call", raw_call)
+
+    with pytest.raises(InterruptedError, match="cancelled"):
+        orchestrator._dispatch(
+            "run-1", "Build it", "/tmp/workspace", team, profiles,
+            profiles[team.dispatcher_id], forced,
+        )
+
+    assert calls == 1
+    assert events == []
+
+
+@pytest.mark.parametrize("wrapped", [
+    lambda plan: plan,
+    lambda plan: f"```json\n{json.dumps(plan)}\n```",
+    lambda plan: f"Candidate follows:\n{json.dumps(plan)}\nEnd candidate.",
+    lambda plan: {"plan": plan},
+    lambda plan: {
+        "function": {
+            "name": "submit_dispatch_plan",
+            "arguments": json.dumps(plan),
+        },
+    },
+    lambda plan: {"tool": "submit_dispatch_plan", "input": {"plan": plan}},
+    lambda plan: {"tool_calls": [{
+        "function": {
+            "name": "submit_dispatch_plan",
+            "arguments": json.dumps(plan),
+        },
+    }]},
+    lambda plan: {"_raw": json.dumps({"arguments": plan})},
+])
+def test_dispatch_candidate_normalizes_common_vllm_wrappers(wrapped):
+    assert normalize_dispatch_candidate(wrapped(_valid_plan())) == _valid_plan()
+
+
+def test_dispatch_repair_receives_the_candidate_and_exact_validation_error(monkeypatch):
+    events = []
+    _, team, profiles, forced = parse_manifest(_manifest())
+    orchestrator = TeamOrchestrator(events.append, lambda: False)
+    responses = [
+        SimpleNamespace(
+            tool_calls=[SimpleNamespace(
+                name="submit_dispatch_plan",
+                arguments={"summary": "bad", "jobs": []},
+            )],
+            content="",
+        ),
+        SimpleNamespace(tool_calls=[], content=json.dumps(_valid_plan())),
+    ]
+    calls = []
+
+    def raw_call(*args, **kwargs):
+        calls.append((args, kwargs))
+        return responses.pop(0)
+
+    monkeypatch.setattr(orchestrator, "_raw_call", raw_call)
+
+    plan = orchestrator._dispatch(
+        "run-1", "Build it", "/tmp/workspace", team, profiles,
+        profiles[team.dispatcher_id], forced,
+    )
+
+    assert plan.outcome == "repaired"
+    assert [job.id for job in plan.jobs] == ["plan", "write", "review"]
+    assert len(calls) == 2
+    repair_prompt = calls[1][0][2][-1]["content"]
+    assert "dispatcher plan has no jobs" in repair_prompt
+    assert '"summary":"bad"' in repair_prompt
+    assert '"default_writer_id"' not in repair_prompt  # schema, not a manifest rewrite
+    assert [event["stage"] for event in events] == ["initial"]
+    assert events[0]["will_retry"] is True
+    assert "jobs" not in events[0]
+
+
+def test_dispatch_accepts_a_valid_direct_tool_call_without_repair(monkeypatch):
+    events = []
+    _, team, profiles, forced = parse_manifest(_manifest())
+    orchestrator = TeamOrchestrator(events.append, lambda: False)
+    calls = 0
+
+    def raw_call(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(
+            tool_calls=[SimpleNamespace(
+                name="submit_dispatch_plan",
+                arguments=_valid_plan(),
+            )],
+            content="",
+        )
+
+    monkeypatch.setattr(orchestrator, "_raw_call", raw_call)
+
+    plan = orchestrator._dispatch(
+        "run-1", "Build it", "/tmp/workspace", team, profiles,
+        profiles[team.dispatcher_id], forced,
+    )
+
+    assert plan.outcome == "valid"
+    assert calls == 1
+    assert events == []
+
+
+def test_dispatch_failed_repair_emits_safe_diagnostics_and_uses_writer(monkeypatch):
+    events = []
+    _, team, profiles, forced = parse_manifest(_manifest())
+    orchestrator = TeamOrchestrator(events.append, lambda: False)
+    invalid = {"summary": "bad", "jobs": [], "api_key": "must-not-be-persisted"}
+    responses = [
+        SimpleNamespace(tool_calls=[], content=json.dumps(invalid)),
+        SimpleNamespace(tool_calls=[], content=json.dumps(invalid)),
+    ]
+    monkeypatch.setattr(orchestrator, "_raw_call", lambda *_a, **_k: responses.pop(0))
+
+    plan = orchestrator._dispatch(
+        "run-1", "Build it", "/tmp/workspace", team, profiles,
+        profiles[team.dispatcher_id], forced,
+    )
+
+    assert plan.outcome == "fallback"
+    assert [(job.id, job.agent_id, job.kind) for job in plan.jobs] == [
+        ("writer", "writer", "writer"),
+    ]
+    assert "dispatcher plan has no jobs" in plan.summary
+    assert "Writer only" in plan.summary
+    diagnostics = [event for event in events if event["type"] == "dispatcher_plan_rejected"]
+    assert [event["stage"] for event in diagnostics] == ["initial", "repair"]
+    assert [event["will_retry"] for event in diagnostics] == [True, False]
+    encoded = json.dumps(diagnostics)
+    assert "must-not-be-persisted" not in encoded
+    assert "api_key" not in encoded
 
 
 def test_orchestration_fingerprint_ignores_credentials_but_tracks_models():


### PR DESCRIPTION
## What changed

- moves Team Progress from the sidebar to the header beside the context meter and removes the standalone command-palette button
- adds Keyboard Shortcuts beneath Extensions in Settings while preserving ⌘K, ⌘/, app-menu commands, and `/shortcuts`
- replaces the composer during dispatch with bounded progress, repair status, and Stop controls
- shows the completed team graph in the composer with Run Plan, Re-dispatch, and Cancel
- makes native teams use one preview decision for the complete graph; individual models, agents, jobs, and steps do not request additional dispatch approval
- preserves security-sensitive tool permissions as a separate control
- normalizes common Qwen/vLLM dispatcher wrappers, improves schema-aware repair, persists bounded rejection diagnostics, and explains safe writer-only fallback
- coalesces completion refreshes, incrementally loads run events, restores the last run after abnormal termination, and prevents stale completed state from showing the quit warning
- updates README, protocol documentation, team documentation, and seeded UI scenarios

## Why

Team runs were difficult to follow and could freeze at completion, dispatcher validation failures lacked actionable diagnostics, and the previous controls made plan approval appear to happen per agent. The new flow puts progress and a single whole-plan decision at the point of action while retaining detailed inspection in Runs.

## Validation

- Backend: 392 tests passed
- Native unit suite: 249 tests passed
- Clean macOS Debug build succeeded
- Built bundle verified as `io.sparktales.locus`, version `1.11.0`, build `15`
- UI test source compiled; macOS UI suite intentionally not run because the user will run it
- Disabled vLLM endpoint was not contacted
