### PR TITLE
Add live team run boards and adaptive team budgets

### DIFF
--- a/Docs/AGENT_TEAMS_FEATURE_GUIDE.md
+++ b/Docs/AGENT_TEAMS_FEATURE_GUIDE.md
@@ -13,7 +13,7 @@ The main areas are:
 3. Smooth streaming and transcript navigation
 4. Workspace-organized chats and recoverable deletion
 5. Multi-agent teams and isolated worktrees
-6. Durable team runs and the Run Inspector
+6. Durable team runs, live boards, and Team Runs
 7. Recovery and job-level controls
 8. Evaluation Lab
 9. Editable dispatch plans
@@ -195,11 +195,11 @@ An agent profile describes one model and the job it is allowed to perform. A pro
 - A name, such as `Local Planner` or `Claude Reviewer`
 - A role: Dispatcher, Planner, Researcher, Implementer, Tester, Reviewer, or Generalist
 - A provider route and exact model
+- Custom role instructions, with a role template as a starting point
 - Capability tags, such as `swift`, `research`, or `tests`
 - An access ceiling: read-only, workspace write, or computer control
-- Timeout and token limits
-- Metered or self-hosted classification and optional user-entered cost rates
-- Explicit MCP allowlists
+- An **Advanced Settings** checkbox containing timeout, token limits, optional
+  metered cost rates, and explicit MCP allowlists
 
 Use **Test Connection** before adding a profile to a team.
 
@@ -247,36 +247,42 @@ It never records API keys, authorization headers, secure-field values, provider 
 
 Example: if Wi-Fi drops during a reviewer job, reopen the same chat. Locus asks for all events after the last sequence it saw and deduplicates them, so the Inspector fills in the missing activity without duplicating earlier events.
 
-### Compact run status
+### Live team run board
 
-While a team works, a compact status bar appears below the transcript. It shows the current phase and completed job count without expanding a large activity panel into the conversation.
+Each team request owns one durable board directly below its user message. The
+same board progresses through Planning → Approval → Specialists → ordered
+Coding Jobs → Review → Complete, and returns to the same message after a
+relaunch. Multiple team requests in one chat keep separate boards.
 
-The Team Progress button immediately left of the header's context meter opens
-the dispatcher, delegated-job, model, and usage summary. Click **Inspect Run**
-or **Open Runs** to open the full Run Inspector.
+During dispatch the board names the dispatcher route, elapsed time, request,
+observable stage, and any bounded validation correction. At approval it shows
+the complete ordered plan and its budget. While running it shows the active
+agent/model, job position, waits, duration, calls, tokens, Pause, and Stop.
+Terminal boards collapse automatically to a result summary with Expand and
+**Open Team Runs**. Raw model output and hidden reasoning are not shown.
 
-While the dispatcher creates the plan, the composer becomes a progress card.
-It names the dispatcher route, elapsed time, request, observable stage, and any
-bounded validation correction. Raw model output and hidden reasoning are not
-shown.
+The ordinary composer remains usable throughout. A message sent while a plan
+awaits approval is queued for the next turn and cannot modify the pending plan.
+The Team Progress button immediately left of the header's context meter scrolls
+to the active board or opens Team Runs when the board is not in view.
 
-### Run Inspector: Timeline view
+### Team Runs: Overview and Activity
 
-The Timeline view shows the run in exact event order. It includes dispatching, agent attempts, scheduler leases, permission waits, steering, tool activity, routing decisions, checkpoints, and terminal results.
-
-Use the filter box to search by agent, event type, job state, or attempt.
+**Overview** explains the request, state, phase, assignments and exact models,
+results, changed files, duration, usage, and recovery actions. **Activity**
+groups human-readable events by phase. Its filter searches agents, event types,
+job state, and attempts. Raw events and dependency details are available only
+under the optional **Technical Log** disclosure.
 
 Example: search for `fallback` to see whether the primary dispatcher failed and which fallback route Locus used.
 
-If a dispatcher returns a plan that Locus cannot validate, Team Progress first
-shows **Correcting dispatcher plan…**. The Timeline records the bounded reason.
+If a dispatcher returns a plan that Locus cannot validate, the live board first
+shows **Correcting dispatcher plan…**. Activity records the bounded reason.
 If the corrected plan is still invalid, Locus continues safely with the team's
 Lead Writer and states why specialists were skipped; raw provider output
 and credentials are not written to run history.
 
-### Run Inspector: Dependencies view
-
-The Dependencies view groups work by job and attempt. Each row can show:
+The Team Runs assignment cards group work by job and attempt. Each row can show:
 
 - Agent, provider, and exact model
 - Assigned goal and role
@@ -308,7 +314,7 @@ Example: pin a release investigation so its agent trace and evidence remain avai
 
 ### Redacted `.locusrun` export
 
-Use the Run Inspector's **Export** menu to create a portable `.locusrun` file.
+Use Team Runs' **Export** menu to create a portable `.locusrun` file.
 
 - **Redacted .locusrun** excludes conversation, goals, output, reasoning, tool arguments, and tool results.
 - **Include Visible Content…** includes content the user could already see.
@@ -473,8 +479,8 @@ Successful, unpinned evaluation checkouts are eligible for automatic cleanup aft
 ### One approval for the complete plan
 
 Every native Locus team pauses once after the dispatcher returns a validated
-plan and before any jobs begin. The plan appears in the composer with its jobs,
-assignments, dependencies, and budget.
+plan and before any jobs begin. The plan appears in the request's live board
+with its jobs, assignments, dependencies, and budget.
 
 - **Run Plan** approves the entire dependency graph. Locus does not ask again
   for each model, agent, job, or step.
@@ -507,6 +513,21 @@ Example: the dispatcher proposes Research → Writer → Review. Add a parallel 
 - **Cancel** returns without starting the plan.
 
 The pending one-time approval survives reconnects.
+
+### Automatic and fixed call budgets
+
+New teams use **Automatic** call budgeting: an adaptive pool capped at 100 model
+calls. Coding models work in bounded slices. After each slice Locus either
+continues the same coding job, or preserves enough calls for later ordered
+writers, review, possible Lead Writer revision, and synthesis. Older teams that
+still have the former untouched 12-call default migrate to Automatic; explicitly
+customized limits remain Fixed.
+
+A coding job reaching its model-call allocation or the separate 100-step team
+writer guard is incomplete, never successful. Locus checkpoints and pauses the
+run with an accurate reason and Resume/Discard actions. Later writers, review,
+and synthesis do not begin until the coding job genuinely completes. Solo turns
+retain their independent 40-step safety ceiling.
 
 Example: select Re-dispatch when the proposed plan spends three specialist jobs on documentation but the task is primarily a test failure.
 
@@ -753,7 +774,7 @@ Suppose you want a team to fix a Swift concurrency bug safely:
 2. Create `Swift Team`, choose scorecard routing, and set a `$3` estimated-cost ceiling.
 3. In the composer, select Team and `Swift Team`, then send: `Investigate and fix the actor-isolation warnings. Add regression tests.`
 4. Review the proposed dependency graph. Add a parallel test-design job if needed, then choose **Run Plan**.
-5. Click **Inspect Run** to watch routing explanations, evidence, tokens, and checkpoints.
+5. Use the live board while the team works, then click **Open Team Runs** for routing explanations, evidence, tokens, and checkpoints.
 6. If the reviewer fails, retry or reassign only that job.
 7. Review the baseline-relative diff and choose **Apply to Workspace**. Locus leaves the changes unstaged and uncommitted.
 8. Save the task as an Evaluation case with required test and changed-path assertions.

--- a/Locus/AgentTeams.swift
+++ b/Locus/AgentTeams.swift
@@ -226,11 +226,20 @@ struct AgentProfile: Identifiable, Codable, Hashable {
 }
 
 struct OrchestrationBudget: Codable, Hashable {
+    enum CallBudgetMode: String, Codable, CaseIterable, Identifiable {
+        case automatic
+        case fixed
+
+        var id: String { rawValue }
+        var title: String { self == .automatic ? "Automatic (up to 100)" : "Fixed limit" }
+    }
+
     var maxJobs = 4
     var maxRounds = 3
-    var maxModelCalls = 12
+    var maxModelCalls = 100
     var maxConcurrentCalls = 3
     var maxMeteredTokens = 500_000
+    var callBudgetMode: CallBudgetMode = .automatic
 
     private enum CodingKeys: String, CodingKey {
         case maxJobs = "max_jobs"
@@ -238,6 +247,7 @@ struct OrchestrationBudget: Codable, Hashable {
         case maxModelCalls = "max_model_calls"
         case maxConcurrentCalls = "max_concurrent_calls"
         case maxMeteredTokens = "max_metered_tokens"
+        case callBudgetMode = "call_budget_mode"
     }
 
     private enum LegacyCodingKeys: String, CodingKey {
@@ -247,15 +257,17 @@ struct OrchestrationBudget: Codable, Hashable {
     init(
         maxJobs: Int = 4,
         maxRounds: Int = 3,
-        maxModelCalls: Int = 12,
+        maxModelCalls: Int = 100,
         maxConcurrentCalls: Int = 3,
-        maxMeteredTokens: Int = 500_000
+        maxMeteredTokens: Int = 500_000,
+        callBudgetMode: CallBudgetMode = .automatic
     ) {
         self.maxJobs = maxJobs
         self.maxRounds = maxRounds
         self.maxModelCalls = maxModelCalls
         self.maxConcurrentCalls = maxConcurrentCalls
         self.maxMeteredTokens = maxMeteredTokens
+        self.callBudgetMode = callBudgetMode
     }
 
     init(from decoder: Decoder) throws {
@@ -271,6 +283,14 @@ struct OrchestrationBudget: Codable, Hashable {
             ?? legacy.decodeIfPresent(Int.self, forKey: .maxConcurrentCalls) ?? 3
         maxMeteredTokens = try current.decodeIfPresent(Int.self, forKey: .maxMeteredTokens)
             ?? legacy.decodeIfPresent(Int.self, forKey: .maxMeteredTokens) ?? 500_000
+        // A missing mode is an older saved or protocol budget. The store
+        // migration upgrades only the exact former native default; custom
+        // limits remain fixed.
+        callBudgetMode = try current.decodeIfPresent(CallBudgetMode.self, forKey: .callBudgetMode)
+            ?? .fixed
+        if callBudgetMode == .automatic {
+            maxModelCalls = 100
+        }
     }
 
     func encode(to encoder: Encoder) throws {
@@ -280,12 +300,13 @@ struct OrchestrationBudget: Codable, Hashable {
         try container.encode(maxModelCalls, forKey: .maxModelCalls)
         try container.encode(maxConcurrentCalls, forKey: .maxConcurrentCalls)
         try container.encode(maxMeteredTokens, forKey: .maxMeteredTokens)
+        try container.encode(callBudgetMode, forKey: .callBudgetMode)
     }
 
     mutating func clamp() {
         maxJobs = min(max(maxJobs, 1), 16)
         maxRounds = min(max(maxRounds, 1), 8)
-        maxModelCalls = min(max(maxModelCalls, 1), 48)
+        maxModelCalls = min(max(maxModelCalls, 1), 100)
         maxConcurrentCalls = min(max(maxConcurrentCalls, 1), 8)
         maxMeteredTokens = min(max(maxMeteredTokens, 1_000), 2_000_000)
     }
@@ -434,6 +455,27 @@ enum AgentTeamStore {
             },
             changed
         )
+    }
+
+    static func migrateLegacyCallBudgets(_ teams: [AgentTeam]) -> (teams: [AgentTeam], changed: Bool) {
+        var changed = false
+        let migrated = teams.map { stored in
+            var team = stored
+            let budget = team.budget
+            let isFormerDefault = budget.callBudgetMode == .fixed
+                && budget.maxJobs == 4
+                && budget.maxRounds == 3
+                && budget.maxModelCalls == 12
+                && budget.maxConcurrentCalls == 3
+                && budget.maxMeteredTokens == 500_000
+            if isFormerDefault {
+                team.budget.callBudgetMode = .automatic
+                team.budget.maxModelCalls = 100
+                changed = true
+            }
+            return team
+        }
+        return (migrated, changed)
     }
 
     static func save(profiles: [AgentProfile], teams: [AgentTeam], to defaults: UserDefaults = .standard) {
@@ -776,9 +818,13 @@ struct OrchestrationRun: Identifiable, Codable, Hashable {
     let recoveryReason: String?
     let checkpoint: RunCheckpoint?
     let attempts: [AgentJobAttempt]?
+    let plan: DispatchPlan?
+    let usage: [String: JSONValue]?
+    let jobCount: Int?
+    let completedJobCount: Int?
 
     enum CodingKeys: String, CodingKey {
-        case id, state, request, pinned, legacy, recoverable, checkpoint, attempts
+        case id, state, request, pinned, legacy, recoverable, checkpoint, attempts, plan, usage
         case sessionID = "session_id"
         case teamID = "team_id"
         case teamName = "team_name"
@@ -791,6 +837,8 @@ struct OrchestrationRun: Identifiable, Codable, Hashable {
         case completedAt = "completed_at"
         case lastSequence = "last_seq"
         case recoveryReason = "recovery_reason"
+        case jobCount = "job_count"
+        case completedJobCount = "completed_job_count"
     }
 }
 

--- a/Locus/AgentTeamsSettingsView.swift
+++ b/Locus/AgentTeamsSettingsView.swift
@@ -167,7 +167,7 @@ struct AgentTeamsSettingsView: View {
                             .frame(width: 18)
                         VStack(alignment: .leading, spacing: 2) {
                             Text(team.name).font(.system(size: 11, weight: .semibold))
-                            Text(errors.first ?? "\(team.memberIDs.count) members · \(team.budget.maxConcurrentCalls) concurrent calls · \(team.budget.maxModelCalls) calls max")
+                            Text(errors.first ?? "\(team.memberIDs.count) members · \(team.budget.maxConcurrentCalls) concurrent calls · \(team.budget.callBudgetMode.title.lowercased())")
                                 .font(.system(size: 8))
                                 .foregroundStyle(errors.isEmpty ? LocusTheme.muted : LocusTheme.coral)
                                 .lineLimit(2)
@@ -451,6 +451,7 @@ private struct AgentProfileEditor: View {
     @State private var mcpTools: String
     @State private var mcpResources: String
     @State private var mcpPrompts: String
+    @State private var advancedSettings = false
     let onSave: (AgentProfile) -> Void
 
     init(profile: AgentProfile, onSave: @escaping (AgentProfile) -> Void) {
@@ -527,43 +528,52 @@ private struct AgentProfileEditor: View {
             Picker("Classification", selection: $draft.metering) {
                 ForEach(AgentMetering.allCases) { Text($0.title).tag($0) }
             }
+            Text("Custom role instructions").font(.caption).foregroundStyle(LocusTheme.muted)
+            TextEditor(text: $draft.instructions)
+                .frame(minHeight: 100)
+                .accessibilityIdentifier("agent.instructions")
+            Button("Use \(draft.role.title) Template") {
+                draft.instructions = draft.role.defaultInstructions
+            }
+            .buttonStyle(.borderless)
             TextField("Capability tags", text: $tags, prompt: Text("code, tests, research"))
-            Stepper("Timeout: \(draft.timeoutSeconds)s", value: $draft.timeoutSeconds, in: 30...3_600, step: 30)
-            Stepper("Token limit: \(draft.tokenLimit.formatted())", value: $draft.tokenLimit, in: 1_024...1_000_000, step: 1_024)
-            if draft.metering == .metered {
-                TextField("Input $ / 1M tokens", value: $draft.inputCostPerMillion, format: .number)
-                TextField("Output $ / 1M tokens", value: $draft.outputCostPerMillion, format: .number)
-            }
-            Section("MCP access · none by default") {
-                ForEach(model.extensions.mcpServers) { server in
-                    Toggle(server.name, isOn: Binding(
-                        get: { draft.mcpPolicy?.serverIDs.contains(server.id) == true },
-                        set: { enabled in
-                            var policy = draft.mcpPolicy ?? MCPAgentPolicy()
-                            if enabled { policy.serverIDs.append(server.id) }
-                            else { policy.serverIDs.removeAll { $0 == server.id } }
-                            draft.mcpPolicy = policy
-                        }
-                    ))
+            Toggle("Advanced Settings", isOn: $advancedSettings)
+                .accessibilityIdentifier("agent.advancedSettings")
+            if advancedSettings {
+                Section("Advanced Settings") {
+                    Stepper("Timeout: \(draft.timeoutSeconds)s", value: $draft.timeoutSeconds, in: 30...3_600, step: 30)
+                    Stepper("Token limit: \(draft.tokenLimit.formatted())", value: $draft.tokenLimit, in: 1_024...1_000_000, step: 1_024)
+                    if draft.metering == .metered {
+                        TextField("Input $ / 1M tokens", value: $draft.inputCostPerMillion, format: .number)
+                        TextField("Output $ / 1M tokens", value: $draft.outputCostPerMillion, format: .number)
+                    }
                 }
-                TextField("Allowed tools", text: $mcpTools, prompt: Text("tool names, comma separated"))
-                TextField("Allowed resources", text: $mcpResources, prompt: Text("resource URIs or names"))
-                TextField("Allowed prompts", text: $mcpPrompts, prompt: Text("prompt names"))
-                Text("Prompts introduce instructions and must be named explicitly. Mutating MCP tools remain writer-only.")
-                    .font(.system(size: 8))
-                    .foregroundStyle(LocusTheme.muted)
+                Section("MCP access · none by default") {
+                    ForEach(model.extensions.mcpServers) { server in
+                        Toggle(server.name, isOn: Binding(
+                            get: { draft.mcpPolicy?.serverIDs.contains(server.id) == true },
+                            set: { enabled in
+                                var policy = draft.mcpPolicy ?? MCPAgentPolicy()
+                                if enabled { policy.serverIDs.append(server.id) }
+                                else { policy.serverIDs.removeAll { $0 == server.id } }
+                                draft.mcpPolicy = policy
+                            }
+                        ))
+                    }
+                    TextField("Allowed tools", text: $mcpTools, prompt: Text("tool names, comma separated"))
+                    TextField("Allowed resources", text: $mcpResources, prompt: Text("resource URIs or names"))
+                    TextField("Allowed prompts", text: $mcpPrompts, prompt: Text("prompt names"))
+                    Text("Prompts introduce instructions and must be named explicitly. Mutating MCP tools remain writer-only.")
+                        .font(.system(size: 8))
+                        .foregroundStyle(LocusTheme.muted)
+                }
             }
-            Text("Role instructions").font(.caption).foregroundStyle(LocusTheme.muted)
-            TextEditor(text: $draft.instructions).frame(minHeight: 130)
             if let connectionResult {
                 Text(connectionResult)
                     .font(.system(size: 9))
                     .foregroundStyle(LocusTheme.muted)
             }
             HStack {
-                Button("Use \(draft.role.title) Template") {
-                    draft.instructions = draft.role.defaultInstructions
-                }
                 Button(testingConnection ? "Testing…" : "Test Connection") {
                     testingConnection = true
                     Task {
@@ -751,7 +761,26 @@ private struct AgentTeamEditor: View {
                     Section("Hard budgets") {
                         Stepper("Delegated jobs: \(draft.budget.maxJobs)", value: $draft.budget.maxJobs, in: 1...16)
                         Stepper("Orchestration rounds: \(draft.budget.maxRounds)", value: $draft.budget.maxRounds, in: 1...8)
-                        Stepper("Model calls: \(draft.budget.maxModelCalls)", value: $draft.budget.maxModelCalls, in: 1...48)
+                        Picker("Call budget", selection: Binding(
+                            get: { draft.budget.callBudgetMode },
+                            set: { mode in
+                                draft.budget.callBudgetMode = mode
+                                if mode == .automatic {
+                                    draft.budget.maxModelCalls = 100
+                                }
+                            }
+                        )) {
+                            ForEach(OrchestrationBudget.CallBudgetMode.allCases) { mode in
+                                Text(mode.title).tag(mode)
+                            }
+                        }
+                        if draft.budget.callBudgetMode == .fixed {
+                            Stepper("Model calls: \(draft.budget.maxModelCalls)", value: $draft.budget.maxModelCalls, in: 1...100)
+                        } else {
+                            Text("Locus allocates calls in small slices and preserves enough capacity for later coding jobs, review, and the final handoff.")
+                                .font(.system(size: 8))
+                                .foregroundStyle(LocusTheme.muted)
+                        }
                         Stepper("Concurrent calls: \(draft.budget.maxConcurrentCalls)", value: $draft.budget.maxConcurrentCalls, in: 1...8)
                         Stepper("Metered tokens: \(draft.budget.maxMeteredTokens.formatted())", value: $draft.budget.maxMeteredTokens, in: 1_000...2_000_000, step: 10_000)
                     }
@@ -899,7 +928,7 @@ private struct EvaluationSuiteEditor: View {
                                 )
                                 Stepper(
                                     "Model calls · \(caseBudget(index).wrappedValue.maxModelCalls)",
-                                    value: caseBudgetValue(index, \.maxModelCalls), in: 1...48
+                                    value: caseBudgetValue(index, \.maxModelCalls), in: 1...100
                                 )
                                 Stepper(
                                     "Concurrent calls · \(caseBudget(index).wrappedValue.maxConcurrentCalls)",

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -252,6 +252,7 @@ final class AppModel: ObservableObject {
     @Published var transcriptSearchSelection = 0
     @Published var previewReloadID = UUID()
     @Published var streamRevision = 0
+    @Published private(set) var teamBoardFocusRequest = 0
     @Published var toast: AppToast?
     var toastMessage: String? { toast?.message }
     @Published private(set) var lifecycleRecoveryMessage: String?
@@ -337,6 +338,7 @@ final class AppModel: ObservableObject {
     /// so a mid-run mode change cannot relabel the completion marker or alter
     /// plan reconciliation.
     var turnDispatchedMode: WorkMode?
+    private var turnDispatchedTeamRunID: String?
     /// Client-side fallback for agents from before `turn_done.duration_ms`.
     private var turnStartedAt: Date?
     /// Turning Just Chat off returns to the last mode that could act on the
@@ -486,12 +488,13 @@ final class AppModel: ObservableObject {
             let loadedProfiles = AgentTeamStore.loadProfiles(from: defaults)
             let storedTeams = AgentTeamStore.loadTeams(from: defaults)
             let approvalMigration = AgentTeamStore.migrateToOneTimeApproval(storedTeams)
-            let loadedTeams = approvalMigration.teams
+            let budgetMigration = AgentTeamStore.migrateLegacyCallBudgets(approvalMigration.teams)
+            let loadedTeams = budgetMigration.teams
             let loadedSelection = defaults.string(forKey: AgentTeamStore.selectionKey)
                 .flatMap(UUID.init(uuidString:))
             agentProfiles = loadedProfiles
             agentTeams = loadedTeams
-            if approvalMigration.changed {
+            if approvalMigration.changed || budgetMigration.changed {
                 AgentTeamStore.save(profiles: loadedProfiles, teams: loadedTeams, to: defaults)
             }
             teamRoutingConsentAccountIDs = AgentTeamStore.loadConsent(from: defaults)
@@ -1081,12 +1084,15 @@ final class AppModel: ObservableObject {
             }
         }
 
-        inspectorTab = .runs
-        inspectorCollapsed = false
-        settings.inspectorLastTab = InspectorTab.runs.rawValue
         let message = lifecycleRecoveryExplanation(fallback: recovery)
-        lifecycleRecoveryMessage = message
-        showToast(message, duration: 8)
+        if selectedOrchestrationRun?.recoverable == true {
+            lifecycleRecoveryMessage = message
+            showToast("A saved team run can be resumed", duration: 6)
+        } else {
+            // Terminal runs already have durable boards in the conversation.
+            // Restoring one is normal data loading, not a warning condition.
+            lifecycleRecoveryMessage = nil
+        }
     }
 
     private func lifecycleRecoveryExplanation(fallback: AppLifecycleRecovery) -> String {
@@ -2202,6 +2208,7 @@ final class AppModel: ObservableObject {
         // running one is housekeeping, never a plan worth offering to build.
         turnDispatchedInPlanMode = dispatchedMode == .plan && !isSlashPassthrough
         turnDispatchedMode = isSlashPassthrough ? nil : dispatchedMode
+        turnDispatchedTeamRunID = dispatchedTeam?["run_id"] as? String
         Task { [weak self] in
             guard let self else { return }
             var transport = self.conversationBackend
@@ -2210,6 +2217,7 @@ final class AppModel: ObservableObject {
                     self.isBusy = false
                     self.turnStartedAt = nil
                     self.turnDispatchedMode = nil
+                    self.turnDispatchedTeamRunID = nil
                     self.turnDispatchedInPlanMode = false
                     self.stashUnsent(
                         text,
@@ -2256,6 +2264,7 @@ final class AppModel: ObservableObject {
                 isBusy = false
                 turnStartedAt = nil
                 turnDispatchedMode = nil
+                turnDispatchedTeamRunID = nil
                 turnDispatchedInPlanMode = false
                 stashUnsent(text, requeue: requeueingOnFailure, preserveDraft: preservingDraftOnFailure)
                 return
@@ -2271,7 +2280,8 @@ final class AppModel: ObservableObject {
             let visibleText = [text.nilIfEmpty, attachmentLine]
                 .compactMap { $0 }
                 .joined(separator: "\n\n")
-            blocks.append(ChatBlock(kind: .user, text: visibleText))
+            let teamRunID = (dispatchedTeam?["run_id"] as? String)?.nilIfEmpty
+            blocks.append(ChatBlock(kind: .user, text: visibleText, teamRunID: teamRunID))
             if !text.isEmpty { recordPrompt(text) }
             if draftText.trimmingCharacters(in: .whitespacesAndNewlines) == text {
                 draftText = ""
@@ -2324,7 +2334,9 @@ final class AppModel: ObservableObject {
 
     func submitDraft() {
         if isBusy {
-            if steeringState?.hasPrefix("Stopping") == true {
+            if orchestrationState == .waitingDispatchApproval
+                || steeringState?.hasPrefix("Stopping") == true
+            {
                 queueDraft()
             } else {
                 steerDraft()
@@ -3125,6 +3137,7 @@ final class AppModel: ObservableObject {
                 "max_model_calls": team.budget.maxModelCalls,
                 "max_concurrent_calls": team.budget.maxConcurrentCalls,
                 "max_metered_tokens": team.budget.maxMeteredTokens,
+                "call_budget_mode": team.budget.callBudgetMode.rawValue,
             ],
         ]
         if let id = team.dispatcherID { teamPayload["dispatcher_id"] = id.uuidString }
@@ -4420,6 +4433,7 @@ final class AppModel: ObservableObject {
                 appliedWorkspacePath = response.sessionInfo.cwd
                 pendingWorkspacePath = nil
                 blocks = Self.blocks(from: response.messages)
+                refreshAnchoredTeamRunsIfNeeded()
                 sessionInfo = response.sessionInfo
                 currentSessionID = response.sessionInfo.sessionID
                 dispatcherActivity = nil
@@ -4486,6 +4500,7 @@ final class AppModel: ObservableObject {
                     as: SessionDetailResponse.self
                 )
                 blocks = Self.blocks(from: detail.messages)
+                refreshAnchoredTeamRunsIfNeeded()
                 agentActivities = detail.agentActivities ?? []
                 orchestrationState = detail.orchestrationState
                     ?? taskConversationStates[runtime.sessionID]?.state
@@ -5524,6 +5539,30 @@ final class AppModel: ObservableObject {
         settings.inspectorLastTab = tab.rawValue
     }
 
+    func focusActiveTeamBoard() {
+        guard let runID = orchestrationRunID,
+              blocks.contains(where: { $0.teamRunID == runID })
+        else {
+            selectInspectorTab(.runs)
+            return
+        }
+        teamBoardFocusRequest += 1
+    }
+
+    func openTeamRun(_ runID: String) {
+        selectInspectorTab(.runs)
+        Task { @MainActor [weak self] in
+            await self?.loadOrchestrationRun(runID)
+        }
+    }
+
+    private func refreshAnchoredTeamRunsIfNeeded() {
+        guard blocks.contains(where: { $0.teamRunID != nil }) else { return }
+        Task { @MainActor [weak self] in
+            await self?.refreshOrchestrationRuns()
+        }
+    }
+
     func toggleInspector() {
         guard !justChatEnabled else { return }
         inspectorCollapsed.toggle()
@@ -6340,6 +6379,36 @@ final class AppModel: ObservableObject {
                 ))
             }
 
+        case "agent_job_continuing":
+            let jobID = event["job_id"] as? String ?? ""
+            if let index = agentActivities.firstIndex(where: { $0.id == jobID }) {
+                agentActivities[index].state = .running
+                agentActivities[index].output = event["message"] as? String
+                    ?? "Continuing coding job…"
+            }
+            if let usage = event["usage"] as? [String: Any] {
+                teamModelCalls = usage["model_calls"] as? Int ?? teamModelCalls
+                teamMeteredTokens = usage["metered_tokens"] as? Int ?? teamMeteredTokens
+            }
+
+        case "agent_job_incomplete":
+            let jobID = event["job_id"] as? String ?? ""
+            if let index = agentActivities.firstIndex(where: { $0.id == jobID }) {
+                agentActivities[index].state = .paused
+                agentActivities[index].output = event["message"] as? String
+                    ?? "This coding job stopped before it finished."
+                if let result = event["result"] as? [String: Any] {
+                    agentActivities[index].elapsedMilliseconds = result["elapsed_ms"] as? Int ?? 0
+                    agentActivities[index].promptTokens = result["prompt_tokens"] as? Int ?? 0
+                    agentActivities[index].completionTokens = result["completion_tokens"] as? Int ?? 0
+                }
+            }
+            orchestrationState = .paused
+            if let usage = event["usage"] as? [String: Any] {
+                teamModelCalls = usage["model_calls"] as? Int ?? teamModelCalls
+                teamMeteredTokens = usage["metered_tokens"] as? Int ?? teamMeteredTokens
+            }
+
         case "agent_job_completed":
             guard let result = event["result"] as? [String: Any] else { return }
             let jobID = result["job_id"] as? String ?? ""
@@ -6511,11 +6580,14 @@ final class AppModel: ObservableObject {
             if reason == "complete", dispatchedMode == .build {
                 reconcileFinishedPlanStep()
             }
-            appendTurnCompletion(
-                reason: reason,
-                mode: dispatchedMode,
-                backendDurationMilliseconds: event["duration_ms"] as? Int
-            )
+            if turnDispatchedTeamRunID == nil {
+                appendTurnCompletion(
+                    reason: reason,
+                    mode: dispatchedMode,
+                    backendDurationMilliseconds: event["duration_ms"] as? Int,
+                    modelCallLimit: event["model_call_limit"] as? Int
+                )
+            }
             isBusy = false
             pendingRetry = false
             steeringState = nil
@@ -6542,6 +6614,7 @@ final class AppModel: ObservableObject {
             planReadyThisTurn = false
             turnDispatchedInPlanMode = false
             turnDispatchedMode = nil
+            turnDispatchedTeamRunID = nil
             turnStartedAt = nil
             notifyTurnCompleteIfInactive()
             if persistenceEnabled {
@@ -6569,6 +6642,7 @@ final class AppModel: ObservableObject {
             planTodosChangedThisTurn = false
             turnDispatchedInPlanMode = false
             turnDispatchedMode = nil
+            turnDispatchedTeamRunID = nil
             pendingSessionReset = false
             pendingCheckpointRestore = nil
             pendingRewindDraft = nil
@@ -6762,7 +6836,8 @@ final class AppModel: ObservableObject {
     private func appendTurnCompletion(
         reason: String,
         mode: WorkMode?,
-        backendDurationMilliseconds: Int?
+        backendDurationMilliseconds: Int?,
+        modelCallLimit: Int? = nil
     ) {
         let measured = turnStartedAt.map {
             max(Int(Date().timeIntervalSince($0) * 1_000), 0)
@@ -6777,7 +6852,9 @@ final class AppModel: ObservableObject {
             durationMilliseconds: duration,
             // Carried only for the outcome it explains, so an ordinary finished
             // turn does not persist a number nothing reads.
-            iterationLimit: outcome == .maxIterations ? sessionInfo?.maxIterations : nil
+            iterationLimit: outcome == .maxIterations
+                ? sessionInfo?.maxIterations
+                : outcome == .modelCallBudget ? modelCallLimit : nil
         )
         blocks.append(ChatBlock(kind: .note, completion: completion))
     }
@@ -6809,6 +6886,7 @@ final class AppModel: ObservableObject {
         planTodosChangedThisTurn = false
         turnDispatchedInPlanMode = false
         turnDispatchedMode = nil
+        turnDispatchedTeamRunID = nil
         pendingSessionReset = false
         pendingCheckpointRestore = nil
         pendingRewindDraft = nil
@@ -7273,8 +7351,16 @@ final class AppModel: ObservableObject {
             recoverable: fixture == "recoverable",
             recoveryReason: fixture == "recoverable" ? "Saved checkpoint available" : nil,
             checkpoint: nil,
-            attempts: nil
+            attempts: nil,
+            plan: nil,
+            usage: ["model_calls": .number(12)],
+            jobCount: 4,
+            completedJobCount: fixture == "completed" ? 4 : 2
         )
+        if let requestIndex = blocks.firstIndex(where: { $0.kind == .user }) {
+            blocks[requestIndex].text = run.request
+            blocks[requestIndex].teamRunID = run.id
+        }
         orchestrationRuns = [run]
         selectedOrchestrationRun = run
         orchestrationRunID = run.id
@@ -7806,7 +7892,11 @@ final class AppModel: ObservableObject {
         messages.compactMap { message in
             switch message.role {
             case "user":
-                ChatBlock(kind: .user, text: displayUserText(message.content))
+                ChatBlock(
+                    kind: .user,
+                    text: displayUserText(message.content),
+                    teamRunID: message.teamRunID
+                )
             case "assistant" where !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 || !(message.reasoning?.isEmpty ?? true):
                 ChatBlock(

--- a/Locus/ComposerView.swift
+++ b/Locus/ComposerView.swift
@@ -29,16 +29,6 @@ struct ComposerView: View {
                 PermissionPromptView(request: request)
                     .frame(maxWidth: 740)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
-            } else if model.shouldShowTeamDispatchApproval,
-                      let plan = model.pendingDispatchPlan
-            {
-                TeamDispatchApprovalPromptView(plan: plan)
-                    .frame(maxWidth: 740)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-            } else if model.shouldShowTeamDispatchProgress {
-                TeamDispatchProgressView()
-                    .frame(maxWidth: 740)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
             } else if model.planApprovalPending {
                 // Same contract as the permission panel: the finished plan is
                 // a decision point, so the decision replaces the input.
@@ -105,8 +95,6 @@ struct ComposerView: View {
             )
         )
         .animation(.easeInOut(duration: 0.18), value: model.activePermissionRequest?.requestID)
-        .animation(.easeInOut(duration: 0.18), value: model.shouldShowTeamDispatchProgress)
-        .animation(.easeInOut(duration: 0.18), value: model.shouldShowTeamDispatchApproval)
         .animation(.easeInOut(duration: 0.18), value: model.planApprovalPending)
         .onAppear { restoreFocus() }
         .onChange(of: model.activePermissionRequest?.requestID) {
@@ -639,32 +627,35 @@ struct ComposerView: View {
                 .foregroundStyle(LocusTheme.muted.opacity(0.62))
 
             if model.isBusy {
-                Menu {
-                    Button("Queue for Next Turn", systemImage: "tray.and.arrow.down") {
-                        model.queueDraft()
+                if !isWaitingForTeamApproval {
+                    Menu {
+                        Button("Queue for Next Turn", systemImage: "tray.and.arrow.down") {
+                            model.queueDraft()
+                        }
+                        Button("Stop & Send as New Turn", systemImage: "stop.circle") {
+                            model.stopAndSendDraft()
+                        }
+                    } label: {
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundStyle(LocusTheme.muted)
+                            .frame(width: 24, height: 30)
+                            .background(LocusTheme.paperDeep)
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                     }
-                    Button("Stop & Send as New Turn", systemImage: "stop.circle") {
-                        model.stopAndSendDraft()
-                    }
-                } label: {
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 9, weight: .bold))
-                        .foregroundStyle(LocusTheme.muted)
-                        .frame(width: 24, height: 30)
-                        .background(LocusTheme.paperDeep)
-                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .disabled(!canSubmit)
+                    .help("Choose how this message joins the conversation")
+                    .accessibilityLabel("More send choices")
+                    .accessibilityIdentifier("composer.sendChoices")
                 }
-                .menuStyle(.borderlessButton)
-                .menuIndicator(.hidden)
-                .disabled(!canSubmit)
-                .help("Choose how this message joins the conversation")
-                .accessibilityLabel("More send choices")
-                .accessibilityIdentifier("composer.sendChoices")
 
                 Button {
                     submit()
                 } label: {
-                    Image(systemName: "arrow.turn.up.right")
+                    Image(systemName: isWaitingForTeamApproval
+                        ? "tray.and.arrow.down.fill" : "arrow.turn.up.right")
                         .font(.system(size: 12, weight: .bold))
                         .foregroundStyle(canSubmit ? Color.white : LocusTheme.muted)
                         .frame(width: 30, height: 30)
@@ -673,9 +664,10 @@ struct ComposerView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(!canSubmit)
-                .help("Steer the active turn (⌘↵)")
-                .accessibilityLabel("Steer now")
-                .accessibilityIdentifier("composer.steer")
+                .help(isWaitingForTeamApproval
+                    ? "Queue for the next turn (⌘↵)" : "Steer the active turn (⌘↵)")
+                .accessibilityLabel(isWaitingForTeamApproval ? "Queue for next turn" : "Steer now")
+                .accessibilityIdentifier(isWaitingForTeamApproval ? "composer.queue" : "composer.steer")
 
                 // The visible menu cannot own the shortcut, so this zero-size
                 // target makes the primary busy action deterministic.
@@ -778,16 +770,25 @@ struct ComposerView: View {
     private var sendHint: String {
         // No permission branch: while a request is pending the whole card —
         // including this hint — is replaced by the permission panel.
-        model.isBusy ? "⌘↵ Steer Now" : "⌘↵ Send"
+        model.isBusy
+            ? (isWaitingForTeamApproval ? "⌘↵ Queue for Next Turn" : "⌘↵ Steer Now")
+            : "⌘↵ Send"
     }
 
     private var placeholder: String {
-        switch model.selectedMode {
+        if isWaitingForTeamApproval {
+            return "Write the next message — it will send after the plan decision…"
+        }
+        return switch model.selectedMode {
         case .ask: "Ask anything…  (attach files or images · no workspace tools)"
         case .work: "What should Locus work on?  ( / commands · @ files )"
         case .plan: "Describe the change you want to plan…  ( / commands · @ files )"
         case .build: "What should we build next?  ( / commands · @ files )"
         }
+    }
+
+    private var isWaitingForTeamApproval: Bool {
+        model.orchestrationState == .waitingDispatchApproval
     }
 
     private func submit() {

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -216,33 +216,14 @@ private struct InspectorResizeHandle: View {
 
 struct InspectorRunsTab: View {
     @EnvironmentObject private var model: AppModel
-    @State private var viewMode = "timeline"
+    @State private var viewMode = "overview"
     @State private var filter = ""
     @State private var draftPlan: DispatchPlan?
+    @State private var showTechnicalLog = false
 
     var body: some View {
         VStack(spacing: 0) {
             header
-            if let message = model.lifecycleRecoveryMessage {
-                HStack(alignment: .top, spacing: 8) {
-                    Image(systemName: "arrow.counterclockwise.circle.fill")
-                        .foregroundStyle(LocusTheme.signalDeep)
-                    Text(message)
-                        .font(.system(size: 9))
-                        .fixedSize(horizontal: false, vertical: true)
-                    Spacer(minLength: 4)
-                    Button {
-                        model.dismissLifecycleRecoveryMessage()
-                    } label: {
-                        Image(systemName: "xmark")
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Dismiss recovery explanation")
-                }
-                .padding(10)
-                .background(LocusTheme.signal.opacity(0.1))
-                .accessibilityIdentifier("runs.recoveryExplanation")
-            }
             if let plan = draftPlan, model.pendingDispatchPlan != nil {
                 dispatchEditor(plan)
             } else if let run = model.selectedOrchestrationRun {
@@ -251,7 +232,7 @@ struct InspectorRunsTab: View {
                 InspectorPlaceholder(
                     symbol: "point.3.connected.trianglepath.dotted",
                     title: "No team run selected",
-                    message: "Team runs appear here with their ordered events, attempts, checkpoints, routing, and recovery controls.",
+                    message: "Team Runs shows each plan, model assignment, live progress, result, and any available recovery action.",
                     identifier: "runs.empty"
                 )
             }
@@ -270,7 +251,7 @@ struct InspectorRunsTab: View {
             HStack(spacing: 8) {
                 Image(systemName: "point.3.connected.trianglepath.dotted")
                     .foregroundStyle(LocusTheme.signalDeep)
-                Text("TEAM RUN INSPECTOR")
+                Text("TEAM RUNS")
                     .font(.system(size: 8, weight: .bold))
                     .tracking(0.7)
                 Spacer()
@@ -301,13 +282,13 @@ struct InspectorRunsTab: View {
         VStack(spacing: 0) {
             runSummary(run)
             Picker("View", selection: $viewMode) {
-                Text("Timeline").tag("timeline")
-                Text("Dependencies").tag("graph")
+                Text("Overview").tag("overview")
+                Text("Activity").tag("activity")
             }
             .pickerStyle(.segmented)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
-            if viewMode == "timeline" { timeline(run) } else { dependencyView(run) }
+            if viewMode == "overview" { overview(run) } else { activity(run) }
         }
     }
 
@@ -316,7 +297,7 @@ struct InspectorRunsTab: View {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(run.teamName ?? "Team run").font(.system(size: 11, weight: .bold))
-                    Text("\(run.state.replacingOccurrences(of: "_", with: " ")) · \(run.lastSequence) events")
+                    Text(runStateTitle(run))
                         .font(.system(size: 8, design: .monospaced))
                         .foregroundStyle(LocusTheme.muted)
                         .accessibilityIdentifier("runs.state")
@@ -329,11 +310,6 @@ struct InspectorRunsTab: View {
                     .font(.system(size: 8))
                     .foregroundStyle(LocusTheme.warning)
                     .fixedSize(horizontal: false, vertical: true)
-            }
-            if let checkpoint = run.checkpoint {
-                Text("Checkpoint · \(checkpoint.kind.replacingOccurrences(of: "_", with: " ")) at event \(checkpoint.sequence)")
-                    .font(.system(size: 8, design: .monospaced))
-                    .foregroundStyle(LocusTheme.muted)
             }
             if let task = model.activeTaskRecord, task.id == run.taskID {
                 HStack(spacing: 7) {
@@ -397,13 +373,277 @@ struct InspectorRunsTab: View {
             .menuIndicator(.hidden)
     }
 
-    private func timeline(_ run: OrchestrationRun) -> some View {
+    private func overview(_ run: OrchestrationRun) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                overviewCard("REQUEST", symbol: "text.bubble") {
+                    Text(run.request.isEmpty ? "No request was recorded." : run.request)
+                        .font(.system(size: 9))
+                        .foregroundStyle(LocusTheme.inkSoft)
+                        .lineLimit(8)
+                }
+
+                overviewCard("PROGRESS", symbol: "chart.bar.fill") {
+                    VStack(alignment: .leading, spacing: 7) {
+                        ForEach(Array(runPhases(run).enumerated()), id: \.offset) { index, phase in
+                            HStack(spacing: 8) {
+                                Image(systemName: phase.done
+                                    ? "checkmark.circle.fill"
+                                    : phase.active ? "circle.inset.filled" : "circle")
+                                    .foregroundStyle(phase.done
+                                        ? LocusTheme.success
+                                        : phase.active ? LocusTheme.signalDeep : LocusTheme.lineStrong)
+                                    .frame(width: 13)
+                                Text(phase.title)
+                                    .font(.system(size: 9, weight: phase.active ? .bold : .regular))
+                                Spacer()
+                                if phase.active {
+                                    Text("Current")
+                                        .font(.system(size: 7, weight: .semibold))
+                                        .foregroundStyle(LocusTheme.signalDeep)
+                                }
+                            }
+                            if index < runPhases(run).count - 1 {
+                                Rectangle().fill(phase.done ? LocusTheme.success.opacity(0.4) : LocusTheme.line)
+                                    .frame(width: 1, height: 7)
+                                    .padding(.leading, 6)
+                            }
+                        }
+                    }
+                }
+
+                if let jobs = run.plan?.jobs, !jobs.isEmpty {
+                    overviewCard("PLAN AND ASSIGNMENTS", symbol: "list.bullet.clipboard") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            if let summary = run.plan?.summary, !summary.isEmpty {
+                                Text(summary)
+                                    .font(.system(size: 9, weight: .medium))
+                            }
+                            ForEach(Array(jobs.enumerated()), id: \.element.id) { index, job in
+                                let attempt = run.attempts?.last(where: { $0.jobID == job.id })
+                                VStack(alignment: .leading, spacing: 2) {
+                                    HStack(spacing: 5) {
+                                        Text("\(index + 1). \(friendlyJobKind(job.kind))")
+                                            .font(.system(size: 8, weight: .bold))
+                                        Text("· \(attempt?.agentName ?? job.agentID)")
+                                            .font(.system(size: 8))
+                                            .foregroundStyle(LocusTheme.muted)
+                                    }
+                                    Text(job.goal)
+                                        .font(.system(size: 8))
+                                        .foregroundStyle(LocusTheme.inkSoft)
+                                        .lineLimit(4)
+                                    if let provider = attempt?.provider, !provider.isEmpty {
+                                        Text("\(provider) · \(attempt?.model ?? "")")
+                                            .font(.system(size: 7, design: .monospaced))
+                                            .foregroundStyle(LocusTheme.muted)
+                                    }
+                                    if !job.dependencies.isEmpty {
+                                        Text("Runs after: \(job.dependencies.joined(separator: ", "))")
+                                            .font(.system(size: 7))
+                                            .foregroundStyle(LocusTheme.muted)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if let attempts = run.attempts, !attempts.isEmpty {
+                    overviewCard("JOB RESULTS", symbol: "person.3.fill") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(attempts) { attempt in
+                                VStack(alignment: .leading, spacing: 3) {
+                                    HStack(spacing: 6) {
+                                        Image(systemName: attempt.state == "completed"
+                                            ? "checkmark.circle.fill"
+                                            : attempt.state == "paused" ? "pause.circle.fill" : "circle.dotted")
+                                            .foregroundStyle(attempt.state == "completed"
+                                                ? LocusTheme.success
+                                                : attempt.state == "paused" ? LocusTheme.warning : LocusTheme.signalDeep)
+                                        Text(attempt.agentName ?? attempt.agentID ?? "Agent")
+                                            .font(.system(size: 8, weight: .bold))
+                                        Text(attempt.state.replacingOccurrences(of: "_", with: " "))
+                                            .font(.system(size: 7, design: .monospaced))
+                                            .foregroundStyle(LocusTheme.muted)
+                                        Spacer()
+                                        if attempt.state != "running"
+                                            && !model.isCodingAttempt(attempt, in: run) {
+                                            Menu {
+                                                Button("Retry with Same Agent") {
+                                                    model.retryOrchestrationJob(attempt, in: run)
+                                                }
+                                                let candidates = model.reassignmentCandidates(for: attempt, in: run)
+                                                if !candidates.isEmpty {
+                                                    Menu("Reassign") {
+                                                        ForEach(candidates) { profile in
+                                                            Button(profile.name) {
+                                                                model.reassignOrchestrationJob(attempt, in: run, to: profile)
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            } label: { Image(systemName: "arrow.clockwise.circle") }
+                                                .menuStyle(.borderlessButton)
+                                                .menuIndicator(.hidden)
+                                        }
+                                    }
+                                    if let output = attempt.output, !output.isEmpty {
+                                        Text(output)
+                                            .font(.system(size: 8))
+                                            .foregroundStyle(LocusTheme.inkSoft)
+                                            .lineLimit(5)
+                                            .textSelection(.enabled)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                overviewCard("RESULTS", symbol: "checkmark.seal") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        metricRow("Jobs", "\(run.completedJobCount ?? 0) of \(run.jobCount ?? 0) completed")
+                        metricRow("Duration", runDuration(run))
+                        if let calls = run.usage?["model_calls"]?.integer {
+                            metricRow("Model calls", calls.formatted())
+                        }
+                        if run.id == model.orchestrationRunID, !model.gitChanges.isEmpty {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text("Changed files")
+                                    .font(.system(size: 8))
+                                    .foregroundStyle(LocusTheme.muted)
+                                ForEach(model.gitChanges.prefix(8)) { change in
+                                    Text("\(change.status.marker)  \(change.path)")
+                                        .font(.system(size: 7, design: .monospaced))
+                                        .lineLimit(1)
+                                }
+                                if model.gitChanges.count > 8 {
+                                    Text("+ \(model.gitChanges.count - 8) more")
+                                        .font(.system(size: 7))
+                                        .foregroundStyle(LocusTheme.muted)
+                                }
+                            }
+                        }
+                        if let reason = run.recoveryReason, !reason.isEmpty {
+                            Label(reason, systemImage: run.recoverable
+                                ? "arrow.clockwise.circle.fill" : "exclamationmark.circle.fill")
+                                .font(.system(size: 8))
+                                .foregroundStyle(run.recoverable ? LocusTheme.warning : LocusTheme.coral)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+
+                DisclosureGroup("Technical details") {
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text("Run ID · \(run.id)")
+                        Text("Saved events · \(run.lastSequence)")
+                        if let checkpoint = run.checkpoint {
+                            Text("Checkpoint · \(checkpoint.kind.replacingOccurrences(of: "_", with: " "))")
+                        }
+                    }
+                    .font(.system(size: 7, design: .monospaced))
+                    .foregroundStyle(LocusTheme.muted)
+                    .padding(.top, 6)
+                }
+                .font(.system(size: 8, weight: .semibold))
+            }
+            .padding(12)
+        }
+        .accessibilityIdentifier("runs.overview")
+    }
+
+    private func activity(_ run: OrchestrationRun) -> some View {
         VStack(spacing: 0) {
-            TextField("Filter agent, event, state, or attempt", text: $filter)
-                .textFieldStyle(.roundedBorder)
-                .accessibilityIdentifier("runs.filter")
-                .padding(.horizontal, 12)
-                .padding(.bottom, 7)
+            HStack {
+                TextField("Filter team activity", text: $filter)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("runs.filter")
+                Toggle("Technical log", isOn: $showTechnicalLog)
+                    .toggleStyle(.checkbox)
+                    .font(.system(size: 8, weight: .semibold))
+                    .accessibilityIdentifier("runs.technicalLog")
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 7)
+            if showTechnicalLog {
+                timeline(run, showsFilter: false)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(activityGroups) { group in
+                            Text(group.title.uppercased())
+                                .font(.system(size: 7, weight: .bold))
+                                .tracking(0.6)
+                                .foregroundStyle(LocusTheme.muted)
+                                .padding(.horizontal, 12)
+                                .padding(.top, 10)
+                                .padding(.bottom, 4)
+                            ForEach(group.events) { event in
+                                HStack(alignment: .top, spacing: 8) {
+                                    Image(systemName: friendlyEventSymbol(event))
+                                        .foregroundStyle(color(for: event.type))
+                                        .frame(width: 14)
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(friendlyEventTitle(event))
+                                            .font(.system(size: 9, weight: .semibold))
+                                        Text(friendlyEventDetail(event))
+                                            .font(.system(size: 8))
+                                            .foregroundStyle(LocusTheme.inkSoft)
+                                            .lineLimit(6)
+                                    }
+                                    Spacer(minLength: 0)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 8)
+                                Divider().padding(.leading, 34)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("runs.activity")
+    }
+
+    private func overviewCard<Content: View>(
+        _ title: String,
+        symbol: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: symbol)
+                .font(.system(size: 8, weight: .bold))
+                .tracking(0.5)
+                .foregroundStyle(LocusTheme.muted)
+            content()
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(LocusTheme.white.opacity(0.58))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay { RoundedRectangle(cornerRadius: 8).stroke(LocusTheme.line) }
+    }
+
+    private func metricRow(_ title: String, _ value: String) -> some View {
+        HStack {
+            Text(title).foregroundStyle(LocusTheme.muted)
+            Spacer()
+            Text(value).fontWeight(.semibold)
+        }
+        .font(.system(size: 8))
+    }
+
+    private func timeline(_ run: OrchestrationRun, showsFilter: Bool = true) -> some View {
+        VStack(spacing: 0) {
+            if showsFilter {
+                TextField("Filter agent, event, state, or attempt", text: $filter)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("runs.filter")
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 7)
+            }
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(filteredEvents) { event in
@@ -561,10 +801,17 @@ struct InspectorRunsTab: View {
                                 "Rounds · \(draftPlan?.budget?.maxRounds ?? 0)",
                                 value: budgetBinding(\.maxRounds), in: 1...8
                             )
-                            Stepper(
-                                "Model calls · \(draftPlan?.budget?.maxModelCalls ?? 0)",
-                                value: budgetBinding(\.maxModelCalls), in: 1...48
-                            )
+                            Picker("Call budget", selection: callBudgetModeBinding) {
+                                ForEach(OrchestrationBudget.CallBudgetMode.allCases) { mode in
+                                    Text(mode.title).tag(mode)
+                                }
+                            }
+                            if draftPlan?.budget?.callBudgetMode == .fixed {
+                                Stepper(
+                                    "Model calls · \(draftPlan?.budget?.maxModelCalls ?? 0)",
+                                    value: budgetBinding(\.maxModelCalls), in: 1...100
+                                )
+                            }
                             Stepper(
                                 "Concurrent calls · \(draftPlan?.budget?.maxConcurrentCalls ?? 0)",
                                 value: budgetBinding(\.maxConcurrentCalls), in: 1...8
@@ -757,6 +1004,173 @@ struct InspectorRunsTab: View {
                 draftPlan = plan
             }
         )
+    }
+
+    private var callBudgetModeBinding: Binding<OrchestrationBudget.CallBudgetMode> {
+        Binding(
+            get: { draftPlan?.budget?.callBudgetMode ?? .fixed },
+            set: { value in
+                guard var plan = draftPlan, var budget = plan.budget else { return }
+                budget.callBudgetMode = value
+                if value == .automatic { budget.maxModelCalls = 100 }
+                plan.budget = budget
+                draftPlan = plan
+            }
+        )
+    }
+
+    private struct RunPhase {
+        let title: String
+        let done: Bool
+        let active: Bool
+    }
+
+    private struct ActivityGroup: Identifiable {
+        let title: String
+        let events: [OrchestrationEvent]
+        var id: String { title }
+    }
+
+    private var activityGroups: [ActivityGroup] {
+        let visible = filteredEvents.filter(isUserFacingEvent)
+        let order = ["Planning", "Approval", "Specialists", "Coding jobs", "Review", "Complete"]
+        let grouped = Dictionary(grouping: visible, by: activityPhase)
+        return order.compactMap { title in
+            guard let events = grouped[title], !events.isEmpty else { return nil }
+            return ActivityGroup(title: title, events: events)
+        }
+    }
+
+    private func runPhases(_ run: OrchestrationRun) -> [RunPhase] {
+        let state = TeamRunState(rawValue: run.state) ?? .failed
+        let current: Int = switch state {
+        case .queued, .dispatching: 0
+        case .waitingDispatchApproval: 1
+        case .running, .waitingPermission, .waitingComputer:
+            (run.attempts ?? []).contains { model.isCodingAttempt($0, in: run) } ? 3 : 2
+        case .reviewing: 4
+        case .completed: 5
+        case .paused, .failed, .interrupted, .cancelled, .discarded:
+            phaseIndex(for: run)
+        }
+        return ["Planning", "Plan approval", "Specialists", "Coding jobs", "Review", "Complete"]
+            .enumerated().map { index, title in
+                RunPhase(
+                    title: title,
+                    done: state == .completed || index < current,
+                    active: state != .completed && index == current
+                )
+            }
+    }
+
+    private func phaseIndex(for run: OrchestrationRun) -> Int {
+        let kind = run.checkpoint?.kind.lowercased() ?? ""
+        if kind.contains("synthesis") { return 5 }
+        if kind.contains("review") || kind.contains("revision") { return 4 }
+        if kind.contains("writer") { return 3 }
+        if kind.contains("dispatch") { return 2 }
+        return run.plan == nil ? 0 : 2
+    }
+
+    private func runStateTitle(_ run: OrchestrationRun) -> String {
+        let state = TeamRunState(rawValue: run.state)?.title
+            ?? run.state.replacingOccurrences(of: "_", with: " ").capitalized
+        let total = run.jobCount ?? 0
+        guard total > 0 else { return state }
+        return "\(state) · \(run.completedJobCount ?? 0) of \(total) jobs"
+    }
+
+    private func runDuration(_ run: OrchestrationRun) -> String {
+        let end = run.completedAt ?? run.updatedAt
+        let seconds = max(Int(end - run.createdAt), 0)
+        return seconds < 60 ? "\(seconds)s" : "\(seconds / 60)m \(seconds % 60)s"
+    }
+
+    private func friendlyJobKind(_ kind: String) -> String {
+        switch kind {
+        case "writer": "Coding job"
+        case "reviewer": "Review"
+        default: "Specialist"
+        }
+    }
+
+    private func isUserFacingEvent(_ event: OrchestrationEvent) -> Bool {
+        event.type == "error"
+            || event.type == "permission_request"
+            || event.type == "dispatch_plan_ready"
+            || event.type == "dispatcher_plan_rejected"
+            || event.type == "task_changes"
+            || event.type.hasPrefix("agent_job_")
+            || event.type.hasPrefix("orchestration_")
+    }
+
+    private func activityPhase(_ event: OrchestrationEvent) -> String {
+        switch event.type {
+        case "dispatch_plan_ready", "dispatch_plan", "dispatch_decision":
+            return "Approval"
+        case "dispatcher_plan_rejected":
+            return "Planning"
+        case "task_changes", "orchestration_completed":
+            return "Complete"
+        case "permission_request", "agent_job_continuing", "agent_job_incomplete":
+            return "Coding jobs"
+        case "agent_job_started", "agent_job_completed":
+            if event.text("writer_position") != nil || event.text("writer_job_id") != nil {
+                return "Coding jobs"
+            }
+            if event.text("role")?.lowercased() == "reviewer" {
+                return "Review"
+            }
+            return "Specialists"
+        case "orchestration_state":
+            return event.text("state") == "reviewing" ? "Review" : "Planning"
+        case "error", "orchestration_paused":
+            return model.orchestrationState == .reviewing ? "Review" : "Coding jobs"
+        default:
+            return "Planning"
+        }
+    }
+
+    private func friendlyEventTitle(_ event: OrchestrationEvent) -> String {
+        switch event.type {
+        case "orchestration_started": "Team run started"
+        case "orchestration_state": event.text("state") == "reviewing" ? "Review started" : "Team progressed"
+        case "dispatch_plan_ready": "Plan ready for your approval"
+        case "dispatcher_plan_rejected": "Correcting dispatcher plan"
+        case "agent_job_started": event.text("writer_position").map {
+            "Coding job \($0) started"
+        } ?? "Specialist started"
+        case "agent_job_continuing": "Coding job is continuing"
+        case "agent_job_incomplete": "Coding job needs more capacity"
+        case "agent_job_completed": "Job completed"
+        case "permission_request": "Waiting for permission"
+        case "orchestration_paused": "Run paused safely"
+        case "orchestration_completed": event.text("state") == "completed"
+            ? "Team run completed" : "Team run stopped"
+        case "task_changes": "Workspace changes are ready"
+        case "error": "Run error"
+        default: event.title
+        }
+    }
+
+    private func friendlyEventDetail(_ event: OrchestrationEvent) -> String {
+        let agent = event.text("agent_name")
+        let model = event.text("model")
+        let route = [agent, model].compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " · ")
+        return event.text("message")?.nilIfEmpty
+            ?? event.text("reason")?.nilIfEmpty
+            ?? event.detail?.nilIfEmpty
+            ?? route.nilIfEmpty
+            ?? event.title
+    }
+
+    private func friendlyEventSymbol(_ event: OrchestrationEvent) -> String {
+        if event.type.contains("completed") { return "checkmark.circle.fill" }
+        if event.type.contains("incomplete") || event.type.contains("paused") { return "pause.circle.fill" }
+        if event.type.contains("error") || event.type.contains("rejected") { return "exclamationmark.circle.fill" }
+        if event.type.contains("permission") { return "lock.circle.fill" }
+        if event.type.contains("plan") { return "list.bullet.clipboard.fill" }
+        return "circle.inset.filled"
     }
 
     private func color(for type: String) -> Color {

--- a/Locus/Models.swift
+++ b/Locus/Models.swift
@@ -291,6 +291,7 @@ struct TurnCompletion: Codable, Hashable {
         case complete
         case interrupted
         case maxIterations = "max_iterations"
+        case modelCallBudget = "model_call_budget"
         case error
 
         init(reason: String) {
@@ -325,6 +326,12 @@ struct TurnCompletion: Codable, Hashable {
                 "Iteration limit reached (\(iterationLimit) steps)"
             } else {
                 "Iteration limit reached"
+            }
+        case .modelCallBudget:
+            if let iterationLimit, iterationLimit > 0 {
+                "Team call budget reached (\(iterationLimit) calls)"
+            } else {
+                "Team call budget reached"
             }
         case .error: "Run failed"
         }
@@ -852,6 +859,12 @@ struct HistoryMessage: Codable {
     let content: String
     let name: String?
     let reasoning: String?
+    let teamRunID: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case role, content, name, reasoning
+        case teamRunID = "team_run_id"
+    }
 
     // A single null-content tool message must not fail an entire resume.
     init(from decoder: Decoder) throws {
@@ -860,6 +873,7 @@ struct HistoryMessage: Codable {
         content = try container.decodeIfPresent(String.self, forKey: .content) ?? ""
         name = try? container.decodeIfPresent(String.self, forKey: .name)
         reasoning = try? container.decodeIfPresent(String.self, forKey: .reasoning)
+        teamRunID = try? container.decodeIfPresent(String.self, forKey: .teamRunID)
     }
 }
 
@@ -901,6 +915,9 @@ struct ChatBlock: Identifiable, Codable, Hashable {
     /// Present only for the quiet end-of-turn note rendered after a run.
     /// Optional keeps checkpoints written by older Locus releases decodable.
     var completion: TurnCompletion?
+    /// Links a team request to its durable board without changing ordinary
+    /// transcript rendering. Optional decoding keeps existing checkpoints.
+    var teamRunID: String?
 
     init(
         id: UUID = UUID(),
@@ -909,7 +926,8 @@ struct ChatBlock: Identifiable, Codable, Hashable {
         reasoningText: String? = nil,
         isStreaming: Bool = false,
         tool: ToolPayload? = nil,
-        completion: TurnCompletion? = nil
+        completion: TurnCompletion? = nil,
+        teamRunID: String? = nil
     ) {
         self.id = id
         self.kind = kind
@@ -918,6 +936,7 @@ struct ChatBlock: Identifiable, Codable, Hashable {
         self.isStreaming = isStreaming
         self.tool = tool
         self.completion = completion
+        self.teamRunID = teamRunID
     }
 }
 

--- a/Locus/PlanApprovalPromptView.swift
+++ b/Locus/PlanApprovalPromptView.swift
@@ -1,8 +1,365 @@
 import SwiftUI
 
-/// Replaces the composer while the selected team's dispatcher is building a
-/// plan. It reports observable stages and validation diagnostics without
-/// presenting provider reasoning or raw structured output.
+/// A durable, user-facing representation of one team run. It is rendered in
+/// the conversation directly below the request carrying the same run id, so
+/// planning and execution never displace the message composer.
+struct TeamRunBoardView: View {
+    @EnvironmentObject private var model: AppModel
+    let runID: String
+    let request: String
+
+    @State private var terminalExpanded = false
+
+    var body: some View {
+        Group {
+            if isActive, model.shouldShowTeamDispatchProgress {
+                TeamDispatchProgressView()
+            } else if isActive, model.shouldShowTeamDispatchApproval,
+                      let plan = model.pendingDispatchPlan
+            {
+                TeamDispatchApprovalPromptView(plan: plan)
+            } else if shouldCollapseTerminal, !terminalExpanded {
+                compactTerminal
+            } else if isActive, state != .paused, !state.isTerminal {
+                TimelineView(.periodic(from: .now, by: 1)) { timeline in
+                    board(now: timeline.date)
+                }
+            } else {
+                board(now: Date())
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier("teamBoard.\(runID)")
+    }
+
+    private func board(now: Date) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            boardHeader(now: now)
+            Divider()
+            phaseRail
+                .padding(12)
+            if !visibleActivities.isEmpty {
+                Divider()
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("TEAM JOBS")
+                        .font(.system(size: 8, weight: .bold))
+                        .tracking(0.7)
+                        .foregroundStyle(LocusTheme.muted)
+                    ForEach(visibleActivities) { activity in
+                        activityRow(activity, now: now)
+                    }
+                }
+                .padding(12)
+            }
+            if let explanation = statusExplanation {
+                Divider()
+                Label(explanation, systemImage: state == .paused
+                    ? "pause.circle.fill" : "info.circle.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(state == .paused ? LocusTheme.warning : LocusTheme.inkSoft)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(12)
+            }
+            Divider()
+            actionRow
+                .padding(12)
+        }
+        .locusCard(radius: 12)
+        .overlay {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(stateColor.opacity(0.45), lineWidth: 1)
+        }
+    }
+
+    private var compactTerminal: some View {
+        HStack(spacing: 10) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.16)) { terminalExpanded = true }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: stateSymbol)
+                        .foregroundStyle(stateColor)
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 6) {
+                            Text(teamName).font(.system(size: 10, weight: .bold))
+                            Text(state.title)
+                                .font(.system(size: 8, weight: .semibold))
+                                .foregroundStyle(stateColor)
+                        }
+                        Text(terminalSummary)
+                            .font(.system(size: 8))
+                            .foregroundStyle(LocusTheme.muted)
+                            .lineLimit(2)
+                    }
+                    Spacer(minLength: 8)
+                    Text("Expand")
+                        .font(.system(size: 8, weight: .semibold))
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8, weight: .bold))
+                }
+                .foregroundStyle(LocusTheme.ink)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(teamName), \(state.title). \(terminalSummary). Expand")
+            Button("Open Team Runs") { model.openTeamRun(runID) }
+                .buttonStyle(.borderless)
+                .font(.system(size: 8, weight: .semibold))
+                .accessibilityIdentifier("teamBoard.openRuns")
+        }
+        .padding(12)
+        .locusCard(radius: 10)
+        .accessibilityIdentifier("teamBoard.terminalSummary")
+    }
+
+    private func boardHeader(now: Date) -> some View {
+        HStack(spacing: 9) {
+            Image(systemName: stateSymbol)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(stateColor)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("TEAM RUN")
+                    .font(.system(size: 8, weight: .bold))
+                    .tracking(0.8)
+                    .foregroundStyle(LocusTheme.muted)
+                Text(teamName).font(.system(size: 12, weight: .bold))
+            }
+            Spacer()
+            if isActive, model.teamModelCalls > 0 || model.teamMeteredTokens > 0 {
+                Text("\(model.teamModelCalls) calls · \(model.teamMeteredTokens.formatted()) tokens")
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundStyle(LocusTheme.muted)
+            }
+            if isActive, let startedAt = model.activeWorkStartedAt {
+                Text(elapsedText(max(now.timeIntervalSince(startedAt), 0)))
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundStyle(LocusTheme.muted)
+            }
+            Text(state.title)
+                .font(.system(size: 8, weight: .bold))
+                .foregroundStyle(stateColor)
+            if state.isTerminal {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.16)) { terminalExpanded = false }
+                } label: { Image(systemName: "chevron.up") }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Collapse team result")
+            }
+        }
+        .padding(12)
+    }
+
+    private var phaseRail: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(request)
+                .font(.system(size: 9))
+                .foregroundStyle(LocusTheme.inkSoft)
+                .lineLimit(3)
+            HStack(spacing: 5) {
+                ForEach(Array(phases.enumerated()), id: \.offset) { index, phase in
+                    HStack(spacing: 4) {
+                        Image(systemName: phaseSymbol(index))
+                            .font(.system(size: 8, weight: .bold))
+                            .foregroundStyle(phaseColor(index))
+                        Text(phase)
+                            .font(.system(size: 7, weight: index == currentPhase ? .bold : .regular))
+                            .foregroundStyle(index <= currentPhase ? LocusTheme.inkSoft : LocusTheme.muted)
+                            .lineLimit(1)
+                        if index < phases.count - 1 {
+                            Rectangle().fill(index < currentPhase ? LocusTheme.success : LocusTheme.line)
+                                .frame(maxWidth: .infinity, maxHeight: 1)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func activityRow(_ activity: AgentActivity, now: Date) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: activity.state == .completed
+                ? "checkmark.circle.fill"
+                : activity.state == .paused ? "pause.circle.fill" : "circle.dotted")
+                .foregroundStyle(activity.state == .completed
+                    ? LocusTheme.success
+                    : activity.state == .paused ? LocusTheme.warning : LocusTheme.signalDeep)
+                .frame(width: 13)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 5) {
+                    Text(activity.writerPosition.map {
+                        "Coding job \($0) of \(activity.writerTotal ?? 1)"
+                    } ?? activity.agentName)
+                        .font(.system(size: 9, weight: .semibold))
+                    if activity.writerPosition != nil {
+                        Text("· \(activity.agentName)")
+                            .font(.system(size: 8))
+                            .foregroundStyle(LocusTheme.muted)
+                    }
+                }
+                Text([activity.provider, activity.model].filter { !$0.isEmpty }.joined(separator: " · "))
+                    .font(.system(size: 7, design: .monospaced))
+                    .foregroundStyle(LocusTheme.muted)
+                    .lineLimit(1)
+                Text(activity.output.isEmpty ? activity.goal : activity.output)
+                    .font(.system(size: 8))
+                    .foregroundStyle(LocusTheme.inkSoft)
+                    .lineLimit(3)
+            }
+            Spacer(minLength: 0)
+            if let startedAt = activity.startedAt {
+                let seconds = activity.state == .running
+                    ? max(now.timeIntervalSince(startedAt), 0)
+                    : Double(activity.elapsedMilliseconds) / 1_000
+                Text(elapsedText(seconds))
+                    .font(.system(size: 7, design: .monospaced))
+                    .foregroundStyle(LocusTheme.muted)
+            }
+        }
+    }
+
+    private func elapsedText(_ seconds: TimeInterval) -> String {
+        let total = max(Int(seconds), 0)
+        return total < 60 ? "\(total)s" : "\(total / 60)m \(total % 60)s"
+    }
+
+    private var actionRow: some View {
+        HStack(spacing: 9) {
+            if let run, run.recoverable, state != .completed {
+                Button("Resume") { model.resumeOrchestration(run) }
+                    .buttonStyle(.borderedProminent)
+                    .tint(LocusTheme.ink)
+                    .accessibilityIdentifier("teamBoard.resume")
+                Button("Discard", role: .destructive) { model.discardOrchestration(run.id) }
+                    .buttonStyle(.borderless)
+                    .accessibilityIdentifier("teamBoard.discard")
+            } else if isActive, model.isBusy, let activeID = model.orchestrationRunID {
+                Button("Pause at Safe Boundary") { model.pauseOrchestration(activeID) }
+                    .buttonStyle(.borderless)
+                    .accessibilityIdentifier("teamBoard.pause")
+                Button("Stop", role: .destructive) { model.cancelOrchestration(activeID) }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(LocusTheme.coral)
+                    .accessibilityIdentifier("teamBoard.stop")
+            }
+            if state == .completed, model.taskHasChanges, isActive {
+                Button("Apply to Workspace") { model.applyActiveTaskToWorkspace() }
+                    .buttonStyle(.borderedProminent)
+                    .tint(LocusTheme.ink)
+            }
+            Spacer()
+            Button("Open Team Runs") { model.openTeamRun(runID) }
+                .buttonStyle(.borderless)
+                .accessibilityIdentifier("teamBoard.openRuns")
+        }
+        .font(.system(size: 9, weight: .semibold))
+    }
+
+    private var run: OrchestrationRun? {
+        if model.selectedOrchestrationRun?.id == runID { return model.selectedOrchestrationRun }
+        return model.orchestrationRuns.first(where: { $0.id == runID })
+    }
+
+    private var isActive: Bool { model.orchestrationRunID == runID }
+    private var shouldCollapseTerminal: Bool {
+        state.isTerminal && run?.recoverable != true
+    }
+    private var state: TeamRunState {
+        if isActive, let state = model.orchestrationState { return state }
+        return run.flatMap { TeamRunState(rawValue: $0.state) } ?? .dispatching
+    }
+    private var teamName: String {
+        if isActive, let name = model.activeOrchestrationTeam?.name { return name }
+        return run?.teamName ?? "Team run"
+    }
+    private var visibleActivities: [AgentActivity] {
+        guard isActive else { return [] }
+        return model.agentActivities
+    }
+    private var phases: [String] { ["Plan", "Approve", "Specialists", "Coding", "Review", "Done"] }
+    private var currentPhase: Int {
+        return switch state {
+        case .queued, .dispatching: 0
+        case .waitingDispatchApproval: 1
+        case .running, .waitingPermission, .waitingComputer:
+            model.agentActivities.contains(where: { $0.writerPosition != nil }) ? 3 : 2
+        case .reviewing: 4
+        case .completed: 5
+        case .paused, .failed, .interrupted, .cancelled, .discarded: interruptedPhase
+        }
+    }
+    private var interruptedPhase: Int {
+        if model.pendingDispatchPlan != nil { return 1 }
+        if visibleActivities.contains(where: { $0.writerPosition != nil }) { return 3 }
+        if let kind = run?.checkpoint?.kind.lowercased() {
+            if kind.contains("synthesis") { return 5 }
+            if kind.contains("review") || kind.contains("revision") { return 4 }
+            if kind.contains("writer") { return 3 }
+            if kind.contains("dispatch") { return 2 }
+        }
+        return run?.plan == nil ? 0 : 2
+    }
+    private func phaseSymbol(_ index: Int) -> String {
+        index < currentPhase || state == .completed ? "checkmark.circle.fill"
+            : index == currentPhase ? "circle.inset.filled" : "circle"
+    }
+    private func phaseColor(_ index: Int) -> Color {
+        index < currentPhase || state == .completed ? LocusTheme.success
+            : index == currentPhase ? stateColor : LocusTheme.lineStrong
+    }
+    private var stateSymbol: String {
+        switch state {
+        case .completed: "checkmark.circle.fill"
+        case .interrupted where run?.recoverable == true: "pause.circle.fill"
+        case .failed, .interrupted, .cancelled, .discarded: "xmark.circle.fill"
+        case .paused: "pause.circle.fill"
+        case .waitingPermission, .waitingComputer, .waitingDispatchApproval: "clock.fill"
+        default: "person.3.sequence.fill"
+        }
+    }
+    private var stateColor: Color {
+        switch state {
+        case .completed: LocusTheme.success
+        case .interrupted where run?.recoverable == true: LocusTheme.warning
+        case .failed, .interrupted, .cancelled, .discarded: LocusTheme.coral
+        case .paused, .waitingPermission, .waitingComputer, .waitingDispatchApproval: LocusTheme.warning
+        default: LocusTheme.signalDeep
+        }
+    }
+    private var statusExplanation: String? {
+        if state == .paused {
+            return run?.recoveryReason
+                ?? visibleActivities.first(where: { $0.state == .paused })?.output
+                ?? "This run is saved at a safe checkpoint and can be resumed."
+        }
+        if state == .waitingPermission { return "A coding job is waiting for a tool permission decision below." }
+        if state == .waitingComputer { return "A coding job is waiting for computer control." }
+        if state == .failed || state == .interrupted { return run?.recoveryReason ?? "The team run stopped before completion." }
+        return nil
+    }
+    private var terminalSummary: String {
+        let completed = run?.completedJobCount
+            ?? (isActive ? model.agentActivities.filter { $0.state == .completed }.count : 0)
+        let total = run?.jobCount ?? (isActive ? model.agentActivities.count : 0)
+        let jobs = total > 0 ? "\(completed)/\(total) jobs" : "Run finished"
+        let duration: String
+        if let run {
+            let end = run.completedAt ?? run.updatedAt
+            let seconds = max(Int(end - run.createdAt), 0)
+            duration = seconds < 60 ? "\(seconds)s" : "\(seconds / 60)m \(seconds % 60)s"
+        } else {
+            duration = ""
+        }
+        let changes = isActive && model.taskHasChanges ? "changes ready" : ""
+        let failure = state == .completed ? "" : (run?.recoveryReason ?? "")
+        return [jobs, duration, changes, failure]
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+    }
+}
+
+/// Lives in the request's conversation board while the selected team's
+/// dispatcher is building a plan. It reports observable stages and validation
+/// diagnostics without presenting provider reasoning or raw structured output.
 struct TeamDispatchProgressView: View {
     @EnvironmentObject private var model: AppModel
 
@@ -169,7 +526,7 @@ struct TeamDispatchProgressView: View {
         if model.dispatcherActivity == nil {
             return "Opening the dispatcher route and preparing the team roster."
         }
-        return "Creating assignments, dependencies, and the single-writer boundary."
+        return "Creating assignments, dependencies, and the ordered coding sequence."
     }
 
     private var dispatcherProfile: AgentProfile? {
@@ -248,7 +605,6 @@ struct TeamDispatchApprovalPromptView: View {
             return .handled
         }
         .onTapGesture { panelFocused = true }
-        .onAppear { panelFocused = true }
         .accessibilityIdentifier("teamDispatch.approval")
     }
 
@@ -324,7 +680,11 @@ struct TeamDispatchApprovalPromptView: View {
             if let budget = plan.budget ?? model.activeOrchestrationTeam?.budget {
                 HStack(spacing: 8) {
                     budgetPill("\(budget.maxJobs) jobs max")
-                    budgetPill("\(budget.maxModelCalls) calls")
+                    budgetPill(
+                        budget.callBudgetMode == .automatic
+                            ? "Automatic · up to 100 calls"
+                            : "\(budget.maxModelCalls) calls fixed"
+                    )
                     budgetPill("\(budget.maxConcurrentCalls) concurrent")
                     if let cost = plan.maximumEstimatedCost, cost > 0 {
                         budgetPill(cost.formatted(.currency(code: "USD")))

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 struct WorkspaceView: View {
     @EnvironmentObject private var model: AppModel
     @State private var modelPickerPresented = false
-    @State private var teamProgressPresented = false
 
     private var sessionTitle: String {
         model.sessions.first(where: { $0.id == model.currentSessionID })?.displayTitle
@@ -32,11 +31,6 @@ struct WorkspaceView: View {
 
             ConversationView(streamingReply: model.streamingReply)
                 .frame(maxHeight: .infinity)
-
-            if !model.agentActivities.isEmpty || model.activeTaskRecord != nil {
-                TeamRunStatusBar()
-                    .environmentObject(model)
-            }
 
             WorkStatusStrip(streamingReply: model.streamingReply)
                 .environmentObject(model)
@@ -88,7 +82,7 @@ struct WorkspaceView: View {
 
             if model.selectedAgentTeam != nil {
                 Button {
-                    teamProgressPresented.toggle()
+                    model.focusActiveTeamBoard()
                 } label: {
                     ZStack(alignment: .topTrailing) {
                         Image(systemName: "waveform.path.ecg")
@@ -115,12 +109,6 @@ struct WorkspaceView: View {
                 .help("Team progress · \(teamProgressTitle)")
                 .accessibilityLabel("Team progress, \(teamProgressTitle)")
                 .accessibilityIdentifier("workspace.teamProgress")
-                .popover(isPresented: $teamProgressPresented, arrowEdge: .top) {
-                    TeamProgressPopover {
-                        teamProgressPresented = false
-                    }
-                    .environmentObject(model)
-                }
             }
 
             ContextUsageChip()
@@ -470,46 +458,6 @@ private struct ModelPickerPopover: View {
             .font(.system(size: 8, weight: .bold))
             .tracking(0.7)
             .foregroundStyle(LocusTheme.muted)
-    }
-}
-
-private struct TeamRunStatusBar: View {
-    @EnvironmentObject private var model: AppModel
-
-    var body: some View {
-        Button {
-            model.selectInspectorTab(.runs)
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "person.3.sequence.fill")
-                    .foregroundStyle(LocusTheme.signalDeep)
-                Text(model.orchestrationState?.title ?? "Team run")
-                    .font(.system(size: 9, weight: .semibold))
-                if !model.agentActivities.isEmpty {
-                    Text("\(model.agentActivities.filter { $0.state == .completed }.count)/\(model.agentActivities.count) jobs")
-                        .font(.system(size: 8, design: .monospaced))
-                        .foregroundStyle(LocusTheme.muted)
-                }
-                Spacer()
-                if let task = model.activeTaskRecord {
-                    Text(URL(fileURLWithPath: task.executionPath).lastPathComponent)
-                        .font(.system(size: 8, design: .monospaced))
-                        .foregroundStyle(LocusTheme.muted)
-                }
-                Text("Inspect Run")
-                    .font(.system(size: 8, weight: .bold))
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 8, weight: .bold))
-            }
-            .foregroundStyle(LocusTheme.ink)
-            .padding(.horizontal, 24)
-            .frame(height: 32)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .background(LocusTheme.paperDeep.opacity(0.75))
-        .overlay(alignment: .top) { Rectangle().fill(LocusTheme.line).frame(height: 1) }
-        .accessibilityIdentifier("teamRun.openInspector")
     }
 }
 
@@ -872,7 +820,7 @@ private struct ConversationView: View {
                             .environmentObject(model)
                     } else {
                         ForEach(model.blocks) { block in
-                            Group {
+                            VStack(alignment: .leading, spacing: 12) {
                                 if block.kind == .assistant,
                                    block.id == model.activeStreamingAssistantID
                                 {
@@ -894,6 +842,11 @@ private struct ConversationView: View {
                                         onRegenerate: { model.retryLastResponse() }
                                     )
                                     .equatable()
+                                }
+                                if block.kind == .user, let runID = block.teamRunID {
+                                    TeamRunBoardView(runID: runID, request: block.text)
+                                        .environmentObject(model)
+                                        .id("team-board-\(runID)")
                                 }
                             }
                             .overlay {
@@ -943,6 +896,15 @@ private struct ConversationView: View {
                     .buttonStyle(.plain)
                     .padding(.bottom, 12)
                     .accessibilityIdentifier("conversation.jumpToLatest")
+                }
+            }
+            .onChange(of: model.teamBoardFocusRequest) {
+                guard let runID = model.orchestrationRunID else {
+                    model.selectInspectorTab(.runs)
+                    return
+                }
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    proxy.scrollTo("team-board-\(runID)", anchor: .center)
                 }
             }
             .onChange(of: model.blocks.count) {
@@ -1684,7 +1646,7 @@ private struct TurnCompletionMarker: View {
     private var color: Color {
         switch completion.outcome {
         case .complete: LocusTheme.success
-        case .interrupted, .maxIterations: LocusTheme.warning
+        case .interrupted, .maxIterations, .modelCallBudget: LocusTheme.warning
         case .error: LocusTheme.coral
         }
     }
@@ -1693,7 +1655,7 @@ private struct TurnCompletionMarker: View {
         switch completion.outcome {
         case .complete: "checkmark.circle.fill"
         case .interrupted: "stop.circle.fill"
-        case .maxIterations: "exclamationmark.circle.fill"
+        case .maxIterations, .modelCallBudget: "exclamationmark.circle.fill"
         case .error: "xmark.circle.fill"
         }
     }

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -389,6 +389,9 @@ final class AppModelTests: XCTestCase {
         let teamPayload = try XCTUnwrap(manifest["team"] as? [String: Any])
         XCTAssertEqual(Set(profiles.compactMap { $0["id"] as? String }), Set(team.memberIDs.map(\.uuidString)))
         XCTAssertEqual(teamPayload["dispatch_approval_mode"] as? String, "preview")
+        let budget = try XCTUnwrap(teamPayload["budget"] as? [String: Any])
+        XCTAssertEqual(budget["call_budget_mode"] as? String, "automatic")
+        XCTAssertEqual(budget["max_model_calls"] as? Int, 100)
         XCTAssertTrue(JSONSerialization.isValidJSONObject(manifest))
         let encoded = try JSONSerialization.data(withJSONObject: manifest)
         XCTAssertFalse(String(decoding: encoded, as: UTF8.self).contains("api_key"))
@@ -441,6 +444,62 @@ final class AppModelTests: XCTestCase {
         XCTAssertFalse(model.shouldShowTeamDispatchProgress)
         XCTAssertTrue(model.shouldShowTeamDispatchApproval)
         XCTAssertEqual(model.pendingDispatchPlan?.jobs.count, 1)
+    }
+
+    @MainActor
+    func testMessagesEnteredDuringTeamPlanApprovalQueueForTheNextTurn() {
+        let model = AppModel(startImmediately: false)
+        model.isBusy = true
+        model.handleEventForTesting([
+            "type": "orchestration_state",
+            "state": "waiting_dispatch_approval",
+        ])
+        model.draftText = "Add documentation after this run"
+
+        model.submitDraft()
+
+        XCTAssertEqual(model.queuedMessages, ["Add documentation after this run"])
+        XCTAssertTrue(model.draftText.isEmpty)
+    }
+
+    @MainActor
+    func testIncompleteCodingJobBecomesPausedWithoutCompletion() {
+        let model = AppModel(startImmediately: false)
+        model.handleEventForTesting([
+            "type": "agent_job_started",
+            "run_id": "run-1",
+            "job_id": "writer",
+            "agent_id": "writer-agent",
+            "agent_name": "Backend Writer",
+            "role": "implementer",
+            "provider": "Kimi",
+            "model": "kimi-for-coding",
+            "goal": "Implement the backend",
+            "writer_job_id": "writer",
+            "writer_position": 1,
+            "writer_total": 2,
+        ])
+        model.handleEventForTesting([
+            "type": "agent_job_incomplete",
+            "run_id": "run-1",
+            "job_id": "writer",
+            "state": "paused",
+            "message": "Call budget reached before this coding job finished.",
+            "model_calls": 12,
+            "limit": 12,
+            "result": [
+                "job_id": "writer",
+                "elapsed_ms": 2_000,
+                "prompt_tokens": 20,
+                "completion_tokens": 10,
+            ],
+            "usage": ["model_calls": 12],
+        ])
+
+        XCTAssertEqual(model.orchestrationState, .paused)
+        XCTAssertEqual(model.agentActivities.first?.state, .paused)
+        XCTAssertEqual(model.agentActivities.first?.output, "Call budget reached before this coding job finished.")
+        XCTAssertEqual(model.teamModelCalls, 12)
     }
 
     func testWorkModeInstructionsAreDistinct() {

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -1583,6 +1583,12 @@ final class FeatureLogicTests: XCTestCase {
             outcome: .complete, mode: .build, durationMilliseconds: 1_000
         )
         XCTAssertEqual(finished.title, "Task finished")
+
+        let teamBudget = TurnCompletion(
+            outcome: .modelCallBudget, mode: .build, durationMilliseconds: 1_000,
+            iterationLimit: 24
+        )
+        XCTAssertEqual(teamBudget.title, "Team call budget reached (24 calls)")
     }
 
     func testLocusIdentifiesItselfHonestlyToProviders() {
@@ -1733,6 +1739,41 @@ final class FeatureLogicTests: XCTestCase {
         XCTAssertFalse(alreadyPreview.changed)
     }
 
+    func testFormerDefaultTeamBudgetMigratesToAutomaticButCustomBudgetStaysFixed() {
+        let legacyDefault = AgentTeam(
+            name: "Former default",
+            dispatcherID: nil,
+            fallbackDispatcherID: nil,
+            memberIDs: [],
+            defaultWriterID: nil,
+            budget: OrchestrationBudget(
+                maxJobs: 4, maxRounds: 3, maxModelCalls: 12,
+                maxConcurrentCalls: 3, maxMeteredTokens: 500_000,
+                callBudgetMode: .fixed
+            )
+        )
+        let custom = AgentTeam(
+            name: "Custom",
+            dispatcherID: nil,
+            fallbackDispatcherID: nil,
+            memberIDs: [],
+            defaultWriterID: nil,
+            budget: OrchestrationBudget(
+                maxJobs: 4, maxRounds: 3, maxModelCalls: 24,
+                maxConcurrentCalls: 3, maxMeteredTokens: 500_000,
+                callBudgetMode: .fixed
+            )
+        )
+
+        let migration = AgentTeamStore.migrateLegacyCallBudgets([legacyDefault, custom])
+
+        XCTAssertTrue(migration.changed)
+        XCTAssertEqual(migration.teams[0].budget.callBudgetMode, .automatic)
+        XCTAssertEqual(migration.teams[0].budget.maxModelCalls, 100)
+        XCTAssertEqual(migration.teams[1].budget.callBudgetMode, .fixed)
+        XCTAssertEqual(migration.teams[1].budget.maxModelCalls, 24)
+    }
+
     func testAgentTeamRejectsAModelTheSelectedProviderDoesNotReport() {
         let account = ProviderAccount(
             kind: .custom,
@@ -1828,15 +1869,34 @@ final class FeatureLogicTests: XCTestCase {
     func testOrchestrationBudgetDecodesLegacyAndProtocolKeys() throws {
         let legacy = Data(#"{"maxJobs":2,"maxRounds":1,"maxModelCalls":5,"maxConcurrentCalls":2,"maxMeteredTokens":9000}"#.utf8)
         let protocolValue = Data(#"{"max_jobs":3,"max_rounds":2,"max_model_calls":6,"max_concurrent_calls":3,"max_metered_tokens":12000}"#.utf8)
+        let automatic = Data(#"{"max_jobs":4,"max_rounds":3,"max_model_calls":12,"max_concurrent_calls":3,"max_metered_tokens":500000,"call_budget_mode":"automatic"}"#.utf8)
 
-        XCTAssertEqual(try JSONDecoder().decode(OrchestrationBudget.self, from: legacy).maxJobs, 2)
+        let legacyDecoded = try JSONDecoder().decode(OrchestrationBudget.self, from: legacy)
+        XCTAssertEqual(legacyDecoded.maxJobs, 2)
+        XCTAssertEqual(legacyDecoded.callBudgetMode, .fixed)
         let decoded = try JSONDecoder().decode(OrchestrationBudget.self, from: protocolValue)
         XCTAssertEqual(decoded.maxJobs, 3)
         XCTAssertEqual(decoded.maxMeteredTokens, 12_000)
+        let automaticDecoded = try JSONDecoder().decode(OrchestrationBudget.self, from: automatic)
+        XCTAssertEqual(automaticDecoded.callBudgetMode, .automatic)
+        XCTAssertEqual(automaticDecoded.maxModelCalls, 100)
 
         let encoded = String(decoding: try JSONEncoder().encode(decoded), as: UTF8.self)
         XCTAssertTrue(encoded.contains("max_model_calls"))
         XCTAssertFalse(encoded.contains("maxModelCalls"))
+    }
+
+    func testTeamRunIDSurvivesHistoryAndTranscriptSerialization() throws {
+        let historyData = Data(#"{"role":"user","content":"Build it","team_run_id":"run-42"}"#.utf8)
+        let history = try JSONDecoder().decode(HistoryMessage.self, from: historyData)
+        XCTAssertEqual(history.teamRunID, "run-42")
+
+        let block = ChatBlock(kind: .user, text: "Build it", teamRunID: "run-42")
+        let restored = try JSONDecoder().decode(
+            ChatBlock.self,
+            from: JSONEncoder().encode(block)
+        )
+        XCTAssertEqual(restored.teamRunID, "run-42")
     }
 
     func testSessionInfoDecodesManagedTaskMetadataTolerantly() throws {

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -506,13 +506,10 @@ final class LocusUITests: XCTestCase {
         let state = anyElement("runs.state")
         XCTAssertTrue(state.waitForExistence(timeout: 3))
         XCTAssertTrue((state.label + " \(state.value ?? "")").lowercased().contains("completed"))
-        XCTAssertTrue(anyElement("runs.recoveryExplanation").exists)
-        XCTAssertTrue(
-            app.staticTexts.matching(
-                NSPredicate(format: "value CONTAINS[c] %@ OR label CONTAINS[c] %@", "results were restored", "results were restored")
-            ).firstMatch.exists
-        )
+        XCTAssertFalse(anyElement("runs.recoveryExplanation").exists)
+        XCTAssertTrue(anyElement("teamBoard.terminalSummary").exists)
 
+        app.buttons["Activity"].firstMatch.click()
         let filter = app.textFields["runs.filter"]
         filter.click()
         filter.typeText("Team run completed")
@@ -528,7 +525,9 @@ final class LocusUITests: XCTestCase {
     func testForcedQuitRecoveryExplainsAResumableRun() {
         relaunchWithRunFixture("recoverable", uncleanRecovery: true)
 
-        XCTAssertTrue(anyElement("runs.recoveryExplanation").waitForExistence(timeout: 3))
+        XCTAssertFalse(anyElement("runs.recoveryExplanation").exists)
+        XCTAssertTrue(anyElement("teamBoard.resume").waitForExistence(timeout: 3))
+        XCTAssertTrue(anyElement("teamBoard.discard").exists)
         XCTAssertTrue(
             app.staticTexts.matching(
                 NSPredicate(format: "value CONTAINS[c] %@ OR label CONTAINS[c] %@", "can be resumed", "can be resumed")
@@ -554,7 +553,7 @@ final class LocusUITests: XCTestCase {
         let progress = anyElement("workspace.teamProgress")
         XCTAssertTrue(progress.waitForExistence(timeout: 3))
         progress.click()
-        XCTAssertTrue(anyElement("teamProgress.popover").waitForExistence(timeout: 3))
+        XCTAssertTrue(anyElement("teamBoard.seed-run").waitForExistence(timeout: 3))
         XCTAssertTrue(
             app.staticTexts.matching(
                 NSPredicate(
@@ -565,7 +564,6 @@ final class LocusUITests: XCTestCase {
             ).firstMatch.exists
         )
 
-        app.typeKey(.escape, modifierFlags: [])
         XCTAssertTrue(
             app.staticTexts.matching(
                 NSPredicate(
@@ -577,11 +575,11 @@ final class LocusUITests: XCTestCase {
         )
     }
 
-    func testTeamPlanAppearsOnceInComposerWithWholePlanActions() {
+    func testTeamPlanAppearsOnceInConversationWithWholePlanActions() {
         relaunchWithRunFixture("dispatch-plan")
 
         XCTAssertTrue(anyElement("teamDispatch.approval").waitForExistence(timeout: 3))
-        XCTAssertFalse(app.textViews["composer.input"].exists)
+        XCTAssertTrue(app.textViews["composer.input"].exists)
         XCTAssertTrue(anyElement("teamDispatch.jobs").exists)
         XCTAssertTrue(anyElement("teamDispatch.run").exists)
         XCTAssertTrue(anyElement("teamDispatch.redispatch").exists)

--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ like; macOS remembers the size you choose for later launches.
   local run store. Stop is routed to the worker that owns the run, waits for a
   terminal event, and leaves a cancelled run non-recoverable instead of
   replaying its last approval after reconnecting. Run updates are coalesced and
-  loaded incrementally so large timelines stay responsive at completion. After
-  an unexpected quit, Locus reopens the latest run and explains whether it
-  finished or can be resumed. A completed run no longer triggers the active-work
+  loaded incrementally so large histories stay responsive at completion. After
+  an unexpected quit, completed runs restore silently, while a genuinely
+  interrupted run offers Resume or Discard on its conversation board. A completed run no longer triggers the active-work
   warning when you quit just because an older in-memory status is still present.
-- **Live Team Progress in the header** sits immediately left of the context
-  meter and shows the active dispatcher and its
-  provider/model, elapsed time, delegated jobs, model calls, and hosted-token
-  usage. During dispatch, the composer itself explains the current stage and
-  any bounded validation repair. When the plan is ready, the composer asks for
-  one approval for the complete plan; individual models, jobs, and steps do not
-  ask again. Its Stop button remains available while a team is running. Common
+- **Live Team Run boards in the conversation** stay attached to the request
+  that started them. One board follows dispatch, whole-plan approval, read-only
+  work, ordered coding jobs, review, and completion without taking over the
+  composer. The header status button scrolls to the active board, and each
+  completed board collapses to a permanent result summary. The plan asks for
+  one approval for the complete run; individual models, jobs, and steps do not
+  ask again. Common
   Qwen/vLLM plan wrappers are normalized before validation; when correction is
-  needed, both Team Progress and Runs show the repair stage and exact bounded
+  needed, both the live board and Team Runs show the repair stage and exact bounded
   validation reason. If repair still fails, Locus explains why it is continuing
   safely with the Lead Writer instead of silently skipping specialists.
 - **Team-aware model controls** label the workspace with the selected team and
@@ -314,13 +314,23 @@ switch back to Solo, or manage the team. Agent profiles use a model dropdown
 filled from their selected provider; the refresh and **Test Connection** actions
 can wake a scaled-to-zero vLLM endpoint before its model catalog is available.
 
-The Team Progress button appears immediately left of the context meter. While
-the dispatcher is building a plan, the composer shows its route, elapsed time,
-observable stage, and validation status. The completed plan then replaces the
-composer with **Run Plan**, **Re-dispatch**, and **Cancel**. Run Plan is a
-single approval for the entire dependency graph; it is not repeated for each
-agent or step. Security-sensitive tool permissions still follow the permission
-mode selected separately.
+The Team Progress button appears immediately left of the context meter and
+scrolls to the active live board. The board is attached directly below the
+request that started the team run. It shows the dispatcher route, elapsed time,
+observable stage, validation status, the completed plan, ordered jobs, current
+model, permission waits, usage, and terminal result. **Run Plan** is a single
+approval for the entire dependency graph; it is not repeated for each agent or
+step. The composer remains available, and messages entered while approval is
+pending are queued for the next turn. Security-sensitive tool permissions
+still follow the permission mode selected separately.
+
+Team call budgets are **Automatic** by default. Locus allocates the 100-call
+pool in bounded slices, protects capacity for later writers, review, and final
+synthesis, and continues an unfinished coding job when its fair share allows.
+A model-call budget or 100-step writer guard never counts as success: the run
+pauses at a checkpoint and offers recovery instead of starting later jobs or
+synthesizing a false completion. Choose a Fixed limit only when a smaller hard
+ceiling is intentional; Solo keeps its 40-step safety limit.
 
 A team may include several write-capable coding profiles. The dispatcher must
 order every coding job through dependencies; Locus then runs them one at a time
@@ -601,7 +611,7 @@ xcodebuild \
 cd agent && .venv/bin/python -m pytest -q
 ```
 
-The repository currently contains 251 unit tests, 33 UI tests, and 398 backend
+The repository currently contains 255 unit tests, 33 UI tests, and 403 backend
 test cases.
 
 The unit suite covers work modes, lightweight context migration, session

--- a/agent/PROTOCOL.md
+++ b/agent/PROTOCOL.md
@@ -57,6 +57,9 @@ Every persisted event has immutable `event_id`, per-run monotonic `seq`,
 `occurred_at`, `schema_version`, and optional job/attempt identity. Clients
 deduplicate by `event_id`. The database uses WAL, foreign keys, transactional
 additive migrations, and reopens read-only if a migration cannot complete.
+Persisted user messages may carry an optional bounded `team_run_id`, allowing
+clients to restore the durable run surface beside the request that originated
+it. Older clients ignore the field.
 `dispatcher_plan_rejected` is an additive diagnostic event with `stage`
 (`initial` or `repair`), a bounded validation `reason`, `response_source`, and
 `will_retry`. It never contains the raw model response or provider credentials.
@@ -493,6 +496,11 @@ Endpoint: `/ws/chat`.
 | `terminal_cancel` | `run_id`, optional `force` | Sends a graceful cancel, or a force kill when requested. |
 | `ping` | — | Emits `pong`; used as an ordering sentinel. |
 
+A team budget may include `call_budget_mode: "automatic" | "fixed"`.
+`automatic` resolves to the bounded 100-call adaptive pool; `fixed` preserves
+the supplied `max_model_calls`. Missing mode remains fixed for compatibility
+with older clients.
+
 Any other `type` produces
 `command_error {operation: "<type>", message: "unknown message type: ..."}`.
 
@@ -613,6 +621,11 @@ for the session.
   the agent, exact provider/model, bounded goal, elapsed time, evidence, and
   usage. Only explicitly supplied `reasoning_text` is retained; signatures and
   redacted reasoning are never exposed. Stream chunks are not persisted.
+- Ordered writer attempts add `writer_job_id`, `writer_position`, and
+  `writer_total`. `agent_job_continuing` reports another bounded slice of the
+  same coding job. `agent_job_incomplete` reports a checkpointed, paused job
+  with its bounded reason, calls used, and applicable limit; it never counts as
+  completion.
 - `scheduler_lease_waiting`, `scheduler_lease_acquired`, and
   `scheduler_lease_released` expose the authenticated local model-call lease.
   Leases are shared across worker processes, round-robin by run, heartbeat
@@ -620,7 +633,9 @@ for the session.
 - `task_ready`, `task_changes`, `task_state`, and `task_applied` carry the
   managed checkout record and baseline-relative change state.
 - `orchestration_completed` is terminal for the orchestration but not the chat;
-  exactly one `turn_done` follows it. `interrupt` cancels every job in the run.
+  exactly one `turn_done` follows it. A recoverable budget boundary emits
+  `orchestration_paused` instead, followed by `turn_done` with the exact limit
+  reason. `interrupt` cancels every job in the run.
 
 Persisted variants add `event_id`, `seq`, `occurred_at`, `schema_version`, and
 when applicable `attempt_id`. `orchestration_checkpoint`,
@@ -629,9 +644,11 @@ when applicable `attempt_id`. `orchestration_checkpoint`,
 are additive. Older clients may ignore all unknown events and fields.
 
 Dispatchers and read-only specialists receive no mutation, MCP, extension, or
-computer schemas. Specialists cannot recursively delegate. Only the designated
-writer enters the existing permission-controlled agent loop, and Computer
-Control remains foreground-only and globally exclusive in the native broker.
+computer schemas. Specialists cannot recursively delegate. Only a write-capable
+member assigned to the current ordered coding job enters the existing
+permission-controlled agent loop. Coding jobs share a checkout but never
+overlap. Computer Control remains foreground-only and globally exclusive in the
+native broker.
 
 ### `tool_call_proposed`
 The model asked to run a tool. Always emitted before any `permission_request`
@@ -690,7 +707,10 @@ Clients render notes as inline system lines; they never change turn state.
 
 ### `turn_done`
 Ends a turn started by `user_message` (non-slash input).
-`reason` is `complete` | `interrupted` | `max_iterations` | `error`.
+`reason` is `complete` | `interrupted` | `max_iterations` |
+`model_call_budget` | `error`. Limit outcomes add `iteration_limit` and/or
+`model_call_limit`, plus the model calls used, so clients name the boundary that
+actually ended the turn.
 A `session_info` event follows immediately.
 
 ### `command_error`

--- a/agent/README.md
+++ b/agent/README.md
@@ -72,6 +72,14 @@ initial backend or UI assignment. Completed coding-job IDs and bounded results
 are checkpointed so recovery skips finished mutations and continues with the
 next ordered writer.
 
+Native teams use an adaptive model-call pool capped at 100 by default. Each
+writer receives bounded slices while the orchestrator reserves capacity for
+later writers, review, possible Lead Writer revision, and synthesis. Reaching a
+slice limit can continue the same writer automatically. Reaching the available
+allocation or the separate 100-iteration writer guard checkpoints the active
+job as incomplete and pauses the run; it is never reported as a successful
+coding job.
+
 Each running team chat owns a separate local worker process and WebSocket, so
 other chats and workspaces remain usable. Model calls obtain crash-recoverable,
 round-robin leases shared across workers (three by default). Git team chats use

--- a/agent/ollama_code/core.py
+++ b/agent/ollama_code/core.py
@@ -13,7 +13,7 @@ Event types emitted:
     permission_request                      {request_id, id, tool, preview}
     tool_result                             {id, tool, summary, result, ok, denied}
     todo_update                             {todos}
-    turn_done                               {reason: complete|interrupted|max_iterations|error,
+    turn_done                               {reason: complete|interrupted|max_iterations|model_call_budget|error,
                                              duration_ms}
     error                                   {message}
     session_info                            full session_info() dict
@@ -1684,7 +1684,16 @@ class AgentCore:
             if iteration >= iteration_limit and self._apply_final_steers_or_close():
                 iteration_limit += 1
         else:
-            reason = "max_iterations"
+            # A team writer can have a smaller per-job call allocation than
+            # the agent's general loop ceiling. Reporting both as
+            # ``max_iterations`` made the native app claim that the global
+            # 40-step setting was reached when the writer had actually used a
+            # much smaller team budget.
+            reason = (
+                "model_call_budget"
+                if hard_call_limit is not None and hard_call_limit <= iteration_limit
+                else "max_iterations"
+            )
         # Close steering before publishing the terminal boundary. Any steer
         # accepted before this point is either applied above or caused another
         # loop iteration; anything later belongs in Queue or Stop & Send.
@@ -1694,6 +1703,8 @@ class AgentCore:
             "reason": reason,
             "duration_ms": max(int((time.monotonic() - started_at) * 1000), 0),
             "model_calls": iteration,
+            "iteration_limit": iteration_limit,
+            "model_call_limit": hard_call_limit,
         }
         self.last_turn_result = terminal
         if not self._suppress_turn_done:
@@ -2282,6 +2293,9 @@ class AgentCore:
             if role == "user":
                 content = strip_prompt_decoration(content)
             item: dict[str, Any] = {"role": role, "content": content[:4000]}
+            team_run_id = str(m.get("team_run_id") or "")[:128]
+            if role == "user" and team_run_id:
+                item["team_run_id"] = team_run_id
             if role == "assistant":
                 # Resume only provider-supplied visible reasoning. Signatures
                 # and redacted-thinking payloads are intentionally omitted.

--- a/agent/ollama_code/orchestration.py
+++ b/agent/ollama_code/orchestration.py
@@ -36,7 +36,7 @@ DispatchApproval = Callable[[str, dict[str, Any]], dict[str, Any]]
 MAX_TEAM_PROFILES = 32
 MAX_TEAM_JOBS = 16
 MAX_TEAM_ROUNDS = 8
-MAX_TEAM_CALLS = 48
+MAX_TEAM_CALLS = 100
 MAX_TEAM_CONCURRENCY = 8
 MAX_TEAM_METERED_TOKENS = 2_000_000
 MAX_TEAM_ESTIMATED_COST = 100_000.0
@@ -55,16 +55,25 @@ class OrchestrationBudget:
     max_model_calls: int = 12
     max_concurrent_calls: int = 3
     max_metered_tokens: int = 500_000
+    call_budget_mode: str = "fixed"
 
     @classmethod
     def parse(cls, value: Any) -> OrchestrationBudget:
         raw = value if isinstance(value, dict) else {}
+        call_budget_mode = str(raw.get("call_budget_mode") or "fixed")
         budget = cls(
             max_jobs=_integer(raw.get("max_jobs"), 4),
             max_rounds=_integer(raw.get("max_rounds"), 3),
-            max_model_calls=_integer(raw.get("max_model_calls"), 12),
+            # Automatic is a bounded adaptive pool, not a second spelling for
+            # whatever fixed value happened to be saved previously.
+            max_model_calls=(
+                MAX_TEAM_CALLS
+                if call_budget_mode == "automatic"
+                else _integer(raw.get("max_model_calls"), 12)
+            ),
             max_concurrent_calls=_integer(raw.get("max_concurrent_calls"), 3),
             max_metered_tokens=_integer(raw.get("max_metered_tokens"), 500_000),
+            call_budget_mode=call_budget_mode,
         )
         limits = (
             ("max_jobs", budget.max_jobs, 1, MAX_TEAM_JOBS),
@@ -78,6 +87,8 @@ class OrchestrationBudget:
                 raise OrchestrationError(f"{name} must be between {lower} and {upper}")
         if budget.max_concurrent_calls > budget.max_model_calls:
             raise OrchestrationError("concurrent model calls cannot exceed the call budget")
+        if budget.call_budget_mode not in {"automatic", "fixed"}:
+            raise OrchestrationError("call_budget_mode must be automatic or fixed")
         return budget
 
 

--- a/agent/ollama_code/runstore.py
+++ b/agent/ollama_code/runstore.py
@@ -556,7 +556,7 @@ class RunStore:
                     now,
                 ),
             )
-        elif event_type == "agent_job_completed":
+        elif event_type in {"agent_job_completed", "agent_job_incomplete"}:
             result = event.get("result") if isinstance(event.get("result"), dict) else {}
             job_id = str(result.get("job_id") or event.get("job_id") or "")
             if not job_id:
@@ -583,7 +583,10 @@ class RunStore:
             connection.execute(
                 """UPDATE job_attempts SET state=?, result_json=?, completed_at=?
                    WHERE run_id=? AND job_id=? AND attempt=?""",
-                (str(event.get("state") or "completed"), _json(result), now,
+                (str(event.get("state") or (
+                    "paused" if event_type == "agent_job_incomplete" else "completed"
+                )), _json(result),
+                 now if event_type == "agent_job_completed" else None,
                  run_id, job_id, attempt),
             )
 
@@ -651,23 +654,60 @@ class RunStore:
         value = self._run_row(row)
         value["checkpoint"] = self.latest_checkpoint(run_id)
         value["attempts"] = self.attempts(run_id)
+        value.update(self._job_summary(value["attempts"]))
         if include_events:
             value["events"] = self.events(run_id, limit=MAX_EXPORT_EVENTS)
         return value
 
     def list_runs(self, *, session_id: str = "", limit: int = 100) -> list[dict[str, Any]]:
         limit = min(max(int(limit), 1), 500)
+        summary_query = """
+            SELECT runs.*,
+              (SELECT COUNT(DISTINCT attempts.job_id)
+                 FROM job_attempts AS attempts
+                WHERE attempts.run_id=runs.id) AS job_count,
+              (SELECT COUNT(*)
+                 FROM job_attempts AS latest
+                WHERE latest.run_id=runs.id
+                  AND latest.state='completed'
+                  AND latest.attempt=(
+                    SELECT MAX(candidate.attempt)
+                      FROM job_attempts AS candidate
+                     WHERE candidate.run_id=latest.run_id
+                       AND candidate.job_id=latest.job_id
+                  )) AS completed_job_count
+              FROM runs
+        """
         with self._connect(readonly=True) as connection:
             if session_id:
                 rows = connection.execute(
-                    "SELECT * FROM runs WHERE session_id=? ORDER BY updated_at DESC LIMIT ?",
+                    summary_query + " WHERE session_id=? ORDER BY updated_at DESC LIMIT ?",
                     (session_id, limit),
                 ).fetchall()
             else:
                 rows = connection.execute(
-                    "SELECT * FROM runs ORDER BY updated_at DESC LIMIT ?", (limit,)
+                    summary_query + " ORDER BY updated_at DESC LIMIT ?", (limit,)
                 ).fetchall()
-        return [self._run_row(row) for row in rows]
+        return [{
+            **self._run_row(row),
+            "job_count": int(row["job_count"] or 0),
+            "completed_job_count": int(row["completed_job_count"] or 0),
+        } for row in rows]
+
+    @staticmethod
+    def _job_summary(attempts: list[dict[str, Any]]) -> dict[str, int]:
+        latest: dict[str, dict[str, Any]] = {}
+        for attempt in attempts:
+            job_id = str(attempt.get("job_id") or "")
+            if job_id:
+                latest[job_id] = attempt
+        return {
+            "job_count": len(latest),
+            "completed_job_count": sum(
+                str(attempt.get("state") or "") == "completed"
+                for attempt in latest.values()
+            ),
+        }
 
     @staticmethod
     def _run_row(row: sqlite3.Row) -> dict[str, Any]:

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -214,7 +214,8 @@ class ChatService:
                 # damaged or temporarily locked history store must never stop
                 # an otherwise healthy agent turn.
                 event = {**event, "persistence_error": str(exc)}
-        if event_type in {"agent_job_started", "agent_job_completed", "dispatch_plan",
+        if event_type in {"agent_job_started", "agent_job_continuing",
+                          "agent_job_incomplete", "agent_job_completed", "dispatch_plan",
                           "dispatcher_plan_rejected"} \
                 or event_type.startswith("orchestration_") \
                 or event_type.startswith("scheduler_lease") \
@@ -2511,7 +2512,9 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
         # specialists. This makes a brand-new background task immediately
         # addressable in the sidebar. Internal writer prompts stay in memory.
         if not isinstance(manifest.get("_resume"), dict):
-            core._add_message({"role": "user", "content": text})
+            core._add_message({
+                "role": "user", "content": text, "team_run_id": run_id,
+            })
         workspace_root = core.workspace_root
         if team.use_managed_worktree and svc.current_task is None \
                 and _is_git_workspace(workspace_root):
@@ -2584,7 +2587,7 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
             ),
         )
         terminal_reason = str(core.last_turn_result.get("reason") or "complete")
-        if terminal_reason not in {"complete", "max_iterations"}:
+        if terminal_reason != "complete":
             raise InterruptedError(terminal_reason)
 
         try:
@@ -2639,25 +2642,101 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
             ):
                 lead = prepared.writer
                 route_snapshot = _install_writer_route(core, lead)
+                revision_result: AgentResult | None = None
+                revision_continuation = False
+                revision_calls = 0
                 try:
-                    _run_team_writer(
-                        svc,
-                        orchestrator,
-                        prepared,
-                        lead,
-                        "Team review found issues that must be resolved before handoff. Verify each finding "
-                        "against the workspace, make warranted revisions, and rerun focused tests.\n\n"
-                        + revision,
-                        persisted_user_text="[Team review requested a revision]",
-                        job_id="writer-revision",
-                        goal="Resolve verified reviewer findings and rerun focused tests",
-                        model_call_limit=max(
-                            orchestrator.remaining_model_calls(prepared.team.budget) - 1, 1,
-                        ),
-                    )
+                    while True:
+                        available = orchestrator.remaining_model_calls(
+                            prepared.team.budget,
+                        ) - 1
+                        if available <= 0:
+                            raise TeamWriterBudgetPause(
+                                "writer-revision",
+                                "model_call_budget",
+                                "The Lead Writer revision reached its model-call budget "
+                                "before it finished. The run was saved and can be resumed.",
+                            )
+                        revision_slice = _run_team_writer(
+                            svc,
+                            orchestrator,
+                            prepared,
+                            lead,
+                            (
+                                "Continue the Lead Writer revision from the current workspace "
+                                "state and finish verification."
+                                if revision_continuation else
+                                "Team review found issues that must be resolved before handoff. "
+                                "Verify each finding against the workspace, make warranted revisions, "
+                                "and rerun focused tests.\n\n" + revision
+                            ),
+                            persisted_user_text=(
+                                "[Team Lead Writer revision continuation]"
+                                if revision_continuation else
+                                "[Team review requested a revision]"
+                            ),
+                            job_id="writer-revision",
+                            goal="Resolve verified reviewer findings and rerun focused tests",
+                            model_call_limit=min(TEAM_WRITER_CALL_SLICE, available),
+                            continuation=revision_continuation,
+                            emit_completion=False,
+                        )
+                        revision_result = _merge_writer_results(
+                            revision_result, revision_slice,
+                        )
+                        revision_calls += int(
+                            core.last_turn_result.get("model_calls") or 0
+                        )
+                        terminal_reason = str(
+                            core.last_turn_result.get("reason") or "complete"
+                        )
+                        if terminal_reason == "complete":
+                            break
+                        if (
+                            terminal_reason == "model_call_budget"
+                            and orchestrator.remaining_model_calls(prepared.team.budget) > 1
+                        ):
+                            revision_continuation = True
+                            continue
+                        if terminal_reason not in {"model_call_budget", "max_iterations"}:
+                            raise InterruptedError(terminal_reason)
+                        message = (
+                            "The Lead Writer revision reached its "
+                            + ("model-call budget" if terminal_reason == "model_call_budget"
+                               else "100-step safety limit")
+                            + " before it finished. The run was saved and can be resumed."
+                        )
+                        svc.emit({
+                            "type": "agent_job_incomplete",
+                            "run_id": prepared.run_id,
+                            "job_id": "writer-revision",
+                            "agent_id": lead.id,
+                            "agent_name": lead.name,
+                            "state": "paused",
+                            "reason": terminal_reason,
+                            "message": message,
+                            "limit": core.last_turn_result.get(
+                                "model_call_limit" if terminal_reason == "model_call_budget"
+                                else "iteration_limit"
+                            ),
+                            "model_calls": revision_calls,
+                            "result": revision_result.structured(),
+                            "usage": orchestrator.usage(),
+                        })
+                        raise TeamWriterBudgetPause(
+                            "writer-revision", terminal_reason, message,
+                        )
                 finally:
                     _restore_writer_route(core, route_snapshot)
-                terminal_reason = str(core.last_turn_result.get("reason") or "complete")
+                assert revision_result is not None
+                svc.emit({
+                    "type": "agent_job_completed",
+                    "run_id": prepared.run_id,
+                    "job_id": "writer-revision",
+                    "state": "completed",
+                    "result": revision_result.structured(),
+                    "usage": orchestrator.usage(),
+                })
                 diff_text = _task_diff(svc, core.workspace_root, core.cwd)
                 svc.checkpoint(
                     "revision_complete",
@@ -2698,6 +2777,28 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
             "type": "orchestration_completed",
             "run_id": prepared.run_id,
             "state": "completed",
+            "duration_ms": max(int((time.monotonic() - started) * 1_000), 0),
+            "usage": orchestrator.usage(),
+        })
+    except TeamWriterBudgetPause as exc:
+        terminal_reason = exc.reason
+        if prepared is not None:
+            svc.checkpoint(
+                f"paused:{exc.job_id}",
+                _team_checkpoint_state(
+                    prepared, "paused", svc.current_task,
+                    usage=orchestrator.usage(),
+                ),
+            )
+        svc.run_store.set_state(
+            run_id, "paused", recoverable=True, reason=str(exc),
+        )
+        svc.emit({
+            "type": "orchestration_paused",
+            "run_id": run_id,
+            "state": "paused",
+            "reason": exc.reason,
+            "message": str(exc),
             "duration_ms": max(int((time.monotonic() - started) * 1_000), 0),
             "usage": orchestrator.usage(),
         })
@@ -2783,7 +2884,8 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
         if svc.current_task is not None:
             task_state = {
                 "complete": "completed",
-                "max_iterations": "completed",
+                "model_call_budget": "paused",
+                "max_iterations": "paused",
                 "interrupted": "interrupted",
                 "cancelled": "cancelled",
             }.get(terminal_reason, "failed")
@@ -2803,11 +2905,18 @@ def _run_team_turn(svc: ChatService, text: str, manifest: dict[str, Any]) -> Non
         core.end_steerable_turn()
         svc.active_orchestrator = None
         svc.active_team = None
-        svc.emit({
+        terminal_event = {
             "type": "turn_done",
             "reason": terminal_reason,
             "duration_ms": max(int((time.monotonic() - started) * 1_000), 0),
-        })
+        }
+        if terminal_reason in {"model_call_budget", "max_iterations"}:
+            terminal_event.update({
+                "model_calls": int(core.last_turn_result.get("model_calls") or 0),
+                "model_call_limit": core.last_turn_result.get("model_call_limit"),
+                "iteration_limit": core.last_turn_result.get("iteration_limit"),
+            })
+        svc.emit(terminal_event)
         core._emit_info()
         svc.active_run_id = None
         svc.cancel_requested_runs.discard(run_id)
@@ -2852,6 +2961,19 @@ def _review_call_count(prepared: TeamPreparation) -> int:
     ))
 
 
+TEAM_WRITER_ITERATION_LIMIT = 100
+TEAM_WRITER_CALL_SLICE = 12
+
+
+class TeamWriterBudgetPause(InterruptedError):
+    """A coding job reached a safety boundary and can resume from checkpoint."""
+
+    def __init__(self, job_id: str, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.job_id = job_id
+        self.reason = reason
+
+
 def _run_prepared_writers(
     svc: ChatService,
     orchestrator: TeamOrchestrator,
@@ -2860,6 +2982,7 @@ def _run_prepared_writers(
     first_persisted_user_text: str,
 ) -> None:
     """Run pending coding jobs serially and checkpoint each completed mutation scope."""
+    emit = getattr(svc, "emit", lambda _event: None)
     pending = [
         job for job in prepared.writer_jobs
         if job.id not in prepared.completed_writer_job_ids
@@ -2894,38 +3017,117 @@ def _run_prepared_writers(
             raise OrchestrationError(
                 "team model-call budget was exhausted before all coding jobs could run"
             )
-        # Each remaining writer receives an equal share. Calls it does not use
-        # remain in the global budget and are included when the next share is
-        # recalculated, so unused capacity rolls forward without letting the
-        # first model consume later writers' reservations.
-        call_limit = max(writer_pool // pending_count, 1)
+        # Each remaining writer receives an equal share. The share is consumed
+        # in bounded slices so a writer that is still making tool calls can
+        # continue automatically without taking the calls protected for later
+        # writers, review, revision, and synthesis.
+        writer_allowance = max(writer_pool // pending_count, 1)
         profile = prepared.profiles[job.agent_id]
         position = prepared.writer_jobs.index(job) + 1
         prompt = writer_prompt_for_job(prepared, job)
         route_snapshot = _install_writer_route(svc.core, profile)
+        accumulated: AgentResult | None = None
+        used_by_writer = 0
+        continuation = False
         try:
-            result = _run_team_writer(
-                svc,
-                orchestrator,
-                prepared,
-                profile,
-                prompt,
-                persisted_user_text=(
-                    first_persisted_user_text
-                    if first_pending else f"[Team coding job {position} of {total}]"
-                ),
-                job_id=job.id,
-                goal=job.goal,
-                model_call_limit=call_limit,
-                writer_position=position,
-                writer_total=total,
-            )
+            while True:
+                slice_limit = min(
+                    TEAM_WRITER_CALL_SLICE,
+                    max(writer_allowance - used_by_writer, 1),
+                )
+                slice_result = _run_team_writer(
+                    svc,
+                    orchestrator,
+                    prepared,
+                    profile,
+                    prompt if not continuation else (
+                        "Continue the same coding assignment from the current workspace state. "
+                        "Do not repeat completed exploration. Finish the requested edits and verification, "
+                        "then return a concise handoff."
+                    ),
+                    persisted_user_text=(
+                        first_persisted_user_text
+                        if first_pending and not continuation
+                        else f"[Team coding job {position} of {total} continuation]"
+                    ),
+                    job_id=job.id,
+                    goal=job.goal,
+                    model_call_limit=slice_limit,
+                    writer_position=position,
+                    writer_total=total,
+                    continuation=continuation,
+                    emit_completion=False,
+                )
+                used = int(svc.core.last_turn_result.get("model_calls") or 0)
+                used_by_writer += used
+                accumulated = _merge_writer_results(accumulated, slice_result)
+                terminal_reason = str(
+                    svc.core.last_turn_result.get("reason") or "complete"
+                )
+                if terminal_reason == "complete":
+                    result = accumulated
+                    emit({
+                        "type": "agent_job_completed",
+                        "run_id": prepared.run_id,
+                        "job_id": job.id,
+                        "state": "completed",
+                        "result": result.structured(),
+                        "writer_job_id": job.id,
+                        "writer_position": position,
+                        "writer_total": total,
+                        "usage": orchestrator.usage(),
+                    })
+                    break
+                if terminal_reason not in {"model_call_budget", "max_iterations"}:
+                    raise InterruptedError(terminal_reason)
+                can_continue = (
+                    terminal_reason == "model_call_budget"
+                    and used_by_writer < writer_allowance
+                    and orchestrator.remaining_model_calls(prepared.team.budget)
+                        > non_writer_reserve + (pending_count - 1)
+                )
+                if can_continue:
+                    continuation = True
+                    continue
+                limit = (
+                    svc.core.last_turn_result.get("model_call_limit")
+                    if terminal_reason == "model_call_budget"
+                    else svc.core.last_turn_result.get("iteration_limit")
+                )
+                message = (
+                    f"Coding job {position} of {total} reached its "
+                    + ("model-call budget" if terminal_reason == "model_call_budget"
+                       else "100-step safety limit")
+                    + " before it finished. The run was saved and can be resumed."
+                )
+                emit({
+                    "type": "agent_job_incomplete",
+                    "run_id": prepared.run_id,
+                    "job_id": job.id,
+                    "agent_id": profile.id,
+                    "agent_name": profile.name,
+                    "state": "paused",
+                    "reason": terminal_reason,
+                    "message": message,
+                    "limit": limit,
+                    "model_calls": used_by_writer,
+                    "result": accumulated.structured(),
+                    "writer_job_id": job.id,
+                    "writer_position": position,
+                    "writer_total": total,
+                    "usage": orchestrator.usage(),
+                })
+                svc.checkpoint(
+                    f"writer_incomplete:{job.id}",
+                    _team_checkpoint_state(
+                        prepared, "paused", svc.current_task,
+                        usage=orchestrator.usage(),
+                    ),
+                )
+                raise TeamWriterBudgetPause(job.id, terminal_reason, message)
         finally:
             _restore_writer_route(svc.core, route_snapshot)
         first_pending = False
-        terminal_reason = str(svc.core.last_turn_result.get("reason") or "complete")
-        if terminal_reason not in {"complete", "max_iterations"}:
-            raise InterruptedError(terminal_reason)
         prepared.writer_results.append(result)
         prepared.completed_writer_job_ids.add(job.id)
         svc.checkpoint(
@@ -2952,8 +3154,10 @@ def _run_team_writer(
     model_call_limit: int,
     writer_position: int | None = None,
     writer_total: int | None = None,
+    continuation: bool = False,
+    emit_completion: bool = True,
 ) -> AgentResult:
-    """Run one mutation-capable member under permission and call budgets."""
+    """Run one bounded slice of a mutation-capable member's coding job."""
     core = svc.core
     remaining = orchestrator.remaining_model_calls(prepared.team.budget)
     if remaining <= 0:
@@ -2963,8 +3167,9 @@ def _run_team_writer(
     prompt_before = core.total_prompt_tokens
     completion_before = core.total_completion_tokens
     route = writer.route
-    svc.emit({
-        "type": "agent_job_started",
+    emit = getattr(svc, "emit", lambda _event: None)
+    emit({
+        "type": "agent_job_continuing" if continuation else "agent_job_started",
         "run_id": prepared.run_id,
         "job_id": job_id,
         "agent_id": writer.id,
@@ -2977,16 +3182,26 @@ def _run_team_writer(
         "writer_job_id": job_id,
         "writer_position": writer_position,
         "writer_total": writer_total,
+        "message": "Continuing coding job with the saved workspace state"
+        if continuation else "Coding job started",
+        "slice_call_limit": model_call_limit,
     })
-    with orchestrator.writer_slot(prepared.run_id, writer):
-        core.run_turn(
-            prompt,
-            svc.decide,
-            allow_tools=True,
-            persisted_user_text=persisted_user_text,
-            model_call_limit=model_call_limit,
-            persist_user_message=False,
-        )
+    previous_iteration_limit = getattr(core, "max_iterations", None)
+    if previous_iteration_limit is not None:
+        core.max_iterations = TEAM_WRITER_ITERATION_LIMIT
+    try:
+        with orchestrator.writer_slot(prepared.run_id, writer):
+            core.run_turn(
+                prompt,
+                svc.decide,
+                allow_tools=True,
+                persisted_user_text=persisted_user_text,
+                model_call_limit=model_call_limit,
+                persist_user_message=False,
+            )
+    finally:
+        if previous_iteration_limit is not None:
+            core.max_iterations = previous_iteration_limit
     prompt_tokens = max(core.total_prompt_tokens - prompt_before, 0)
     completion_tokens = max(core.total_completion_tokens - completion_before, 0)
     model_calls = int(core.last_turn_result.get("model_calls") or 0)
@@ -3016,17 +3231,39 @@ def _run_team_writer(
         elapsed_ms=max(int((time.monotonic() - started) * 1_000), 0),
         error="",
     )
-    svc.emit({
-        "type": "agent_job_completed",
-        "run_id": prepared.run_id,
-        "state": "completed",
-        "result": result.structured(),
-        "writer_job_id": job_id,
-        "writer_position": writer_position,
-        "writer_total": writer_total,
-        "usage": orchestrator.usage(),
-    })
+    if emit_completion and str(core.last_turn_result.get("reason") or "complete") == "complete":
+        emit({
+            "type": "agent_job_completed",
+            "run_id": prepared.run_id,
+            "job_id": job_id,
+            "state": "completed",
+            "result": result.structured(),
+            "writer_job_id": job_id,
+            "writer_position": writer_position,
+            "writer_total": writer_total,
+            "usage": orchestrator.usage(),
+        })
     return result
+
+
+def _merge_writer_results(
+    previous: AgentResult | None, current: AgentResult
+) -> AgentResult:
+    if previous is None:
+        return current
+    return AgentResult(
+        job_id=current.job_id,
+        agent_id=current.agent_id,
+        agent_name=current.agent_name,
+        role=current.role,
+        output=current.output or previous.output,
+        reasoning_text=current.reasoning_text or previous.reasoning_text,
+        evidence=[*previous.evidence, *current.evidence][:128],
+        prompt_tokens=previous.prompt_tokens + current.prompt_tokens,
+        completion_tokens=previous.completion_tokens + current.completion_tokens,
+        elapsed_ms=previous.elapsed_ms + current.elapsed_ms,
+        error=current.error or previous.error,
+    )
 
 
 def _latest_assistant_output(core: AgentCore) -> str:

--- a/agent/ollama_code/sessions.py
+++ b/agent/ollama_code/sessions.py
@@ -322,7 +322,45 @@ class SessionStore:
                             "elapsed_milliseconds": 0,
                             "prompt_tokens": 0,
                             "completion_tokens": 0,
+                            "writer_job_id": event.get("writer_job_id"),
+                            "writer_position": event.get("writer_position"),
+                            "writer_total": event.get("writer_total"),
                         }
+                    elif event_type == "agent_job_continuing":
+                        job_id = str(event.get("job_id") or "")
+                        if job_id and job_id in activities:
+                            activities[job_id]["state"] = "running"
+                            activities[job_id]["output"] = str(
+                                event.get("message") or "Continuing coding job…"
+                            )[:2_000]
+                    elif event_type == "agent_job_incomplete":
+                        job_id = str(event.get("job_id") or "")
+                        if not job_id:
+                            continue
+                        result = event.get("result")
+                        if not isinstance(result, dict):
+                            result = {}
+                        current = activities.get(job_id, {})
+                        current.update({
+                            "id": job_id,
+                            "agent_name": str(event.get("agent_name") or current.get("agent_name") or "Agent"),
+                            "role": str(result.get("role") or current.get("role") or "implementer"),
+                            "provider": str(current.get("provider") or ""),
+                            "model": str(current.get("model") or ""),
+                            "goal": str(current.get("goal") or ""),
+                            "state": "paused",
+                            "output": str(event.get("message") or result.get("output") or "")[:120_000],
+                            "reasoning_text": None,
+                            "tool": None,
+                            "evidence": [str(item) for item in result.get("evidence") or []][:128],
+                            "elapsed_milliseconds": int(result.get("elapsed_ms") or 0),
+                            "prompt_tokens": int(result.get("prompt_tokens") or 0),
+                            "completion_tokens": int(result.get("completion_tokens") or 0),
+                            "writer_job_id": event.get("writer_job_id"),
+                            "writer_position": event.get("writer_position"),
+                            "writer_total": event.get("writer_total"),
+                        })
+                        activities[job_id] = current
                     elif event_type == "agent_job_completed":
                         result = event.get("result")
                         if not isinstance(result, dict):

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -688,11 +688,13 @@ def test_strip_prompt_decoration_passthrough():
 def test_sanitize_messages_drops_system_and_keeps_tools():
     out = AgentCore.sanitize_messages([
         {"role": "system", "content": "hidden"},
-        {"role": "user", "content": "[Locus mode: Ask]\nx\n\nUser request:\nhi"},
+        {"role": "user", "content": "[Locus mode: Ask]\nx\n\nUser request:\nhi",
+         "team_run_id": "run-42"},
         {"role": "tool", "name": "bash", "content": "output"},
     ])
     assert [m["role"] for m in out] == ["user", "tool"]
     assert out[0]["content"] == "hi"
+    assert out[0]["team_run_id"] == "run-42"
     assert out[1]["name"] == "bash"
 
 
@@ -2639,6 +2641,26 @@ def test_run_turn_emits_streaming_and_turn_done(tmp_path):
     assert core.messages[-1]["content"] == "Hello world"
 
 
+def test_run_turn_names_a_smaller_team_call_limit_instead_of_iteration_limit(tmp_path):
+    from ollama_code.ollama import ToolCall
+
+    core = _core(tmp_path, [
+        ChatResponse(tool_calls=[ToolCall("list_dir", {"path": "."})], done=True),
+        ChatResponse(tool_calls=[ToolCall("list_dir", {"path": "."})], done=True),
+    ])
+    events = []
+    core.on_event(events.append)
+
+    core.run_turn("inspect twice", model_call_limit=2)
+
+    done = next(event for event in events if event["type"] == "turn_done")
+    assert done["reason"] == "model_call_budget"
+    assert done["model_calls"] == 2
+    assert done["model_call_limit"] == 2
+    assert done["iteration_limit"] == 5
+    assert core.last_turn_result == done
+
+
 def test_submit_plan_emits_structured_plan_ready(tmp_path):
     from ollama_code.ollama import ToolCall
 
@@ -3108,6 +3130,164 @@ def test_ordered_coding_jobs_never_overlap_and_second_observes_first(monkeypatch
     ]
     assert prepared.completed_writer_job_ids == {"backend-job", "ui-job"}
     assert checkpoints[-1][1]["state"] == "reviewing"
+
+
+def test_coding_job_continues_in_bounded_slices_until_it_finishes(monkeypatch):
+    writer = SimpleNamespace(
+        id="backend", name="Backend", role="implementer", can_write=True,
+    )
+    job = SimpleNamespace(
+        id="backend-job", agent_id="backend", goal="Build API", kind="writer",
+    )
+    prepared = SimpleNamespace(
+        run_id="run",
+        writer_jobs=(job,),
+        completed_writer_job_ids=set(),
+        writer_results=[],
+        profiles={"backend": writer},
+        plan=SimpleNamespace(jobs=[job]),
+        team=SimpleNamespace(
+            budget=SimpleNamespace(max_rounds=1, max_model_calls=20),
+        ),
+    )
+    core = SimpleNamespace(_interrupt=threading.Event(), last_turn_result={})
+    emitted = []
+    checkpoints = []
+    service = SimpleNamespace(
+        core=core,
+        current_task=None,
+        emit=emitted.append,
+        checkpoint=lambda kind, state: checkpoints.append((kind, state)),
+    )
+
+    class Orchestrator:
+        calls = 0
+
+        def remaining_model_calls(self, budget):
+            return budget.max_model_calls - self.calls
+
+        def usage(self):
+            return {"model_calls": self.calls}
+
+    orchestrator = Orchestrator()
+    continuations = []
+
+    def run_writer(_svc, _orchestrator, _prepared, _writer, _prompt, **kwargs):
+        continuations.append(kwargs["continuation"])
+        used = 12 if len(continuations) == 1 else 1
+        orchestrator.calls += used
+        core.last_turn_result = {
+            "reason": "model_call_budget" if len(continuations) == 1 else "complete",
+            "model_calls": used,
+            "model_call_limit": kwargs["model_call_limit"],
+            "iteration_limit": 100,
+        }
+        return AgentResult(
+            kwargs["job_id"], writer.id, writer.name, writer.role,
+            "partial" if len(continuations) == 1 else "finished", [], 0, 0, 1,
+        )
+
+    monkeypatch.setattr(server_mod, "writer_prompt_for_job", lambda _value, value: value.goal)
+    monkeypatch.setattr(server_mod, "_install_writer_route", lambda _core, value: value.id)
+    monkeypatch.setattr(server_mod, "_restore_writer_route", lambda _core, _snapshot: None)
+    monkeypatch.setattr(server_mod, "_run_team_writer", run_writer)
+    monkeypatch.setattr(
+        server_mod,
+        "_team_checkpoint_state",
+        lambda value, state, _task, **_kwargs: {
+            "state": state,
+            "completed_writer_job_ids": sorted(value.completed_writer_job_ids),
+        },
+    )
+
+    server_mod._run_prepared_writers(
+        service, orchestrator, prepared, first_persisted_user_text="request",
+    )
+
+    assert continuations == [False, True]
+    assert prepared.completed_writer_job_ids == {"backend-job"}
+    assert prepared.writer_results[0].output == "finished"
+    assert [event["type"] for event in emitted] == ["agent_job_completed"]
+    assert checkpoints[-1][0] == "writer_complete:backend-job"
+
+
+def test_unfinished_coding_job_pauses_recoverably_without_false_completion(monkeypatch):
+    writer = SimpleNamespace(
+        id="backend", name="Backend", role="implementer", can_write=True,
+    )
+    job = SimpleNamespace(
+        id="backend-job", agent_id="backend", goal="Build API", kind="writer",
+    )
+    prepared = SimpleNamespace(
+        run_id="run",
+        writer_jobs=(job,),
+        completed_writer_job_ids=set(),
+        writer_results=[],
+        profiles={"backend": writer},
+        plan=SimpleNamespace(jobs=[job]),
+        team=SimpleNamespace(
+            budget=SimpleNamespace(max_rounds=1, max_model_calls=3),
+        ),
+    )
+    core = SimpleNamespace(_interrupt=threading.Event(), last_turn_result={})
+    emitted = []
+    checkpoints = []
+    service = SimpleNamespace(
+        core=core,
+        current_task=None,
+        emit=emitted.append,
+        checkpoint=lambda kind, state: checkpoints.append((kind, state)),
+    )
+
+    class Orchestrator:
+        calls = 0
+
+        def remaining_model_calls(self, budget):
+            return budget.max_model_calls - self.calls
+
+        def usage(self):
+            return {"model_calls": self.calls}
+
+    orchestrator = Orchestrator()
+
+    def run_writer(_svc, _orchestrator, _prepared, _writer, _prompt, **kwargs):
+        orchestrator.calls += 2
+        core.last_turn_result = {
+            "reason": "model_call_budget",
+            "model_calls": 2,
+            "model_call_limit": kwargs["model_call_limit"],
+            "iteration_limit": 100,
+        }
+        return AgentResult(
+            kwargs["job_id"], writer.id, writer.name, writer.role,
+            "unfinished", [], 0, 0, 1,
+        )
+
+    monkeypatch.setattr(server_mod, "writer_prompt_for_job", lambda _value, value: value.goal)
+    monkeypatch.setattr(server_mod, "_install_writer_route", lambda _core, value: value.id)
+    monkeypatch.setattr(server_mod, "_restore_writer_route", lambda _core, _snapshot: None)
+    monkeypatch.setattr(server_mod, "_run_team_writer", run_writer)
+    monkeypatch.setattr(
+        server_mod,
+        "_team_checkpoint_state",
+        lambda value, state, _task, **_kwargs: {
+            "state": state,
+            "completed_writer_job_ids": sorted(value.completed_writer_job_ids),
+        },
+    )
+
+    with pytest.raises(server_mod.TeamWriterBudgetPause) as paused:
+        server_mod._run_prepared_writers(
+            service, orchestrator, prepared, first_persisted_user_text="request",
+        )
+
+    assert paused.value.reason == "model_call_budget"
+    assert prepared.completed_writer_job_ids == set()
+    assert prepared.writer_results == []
+    assert [event["type"] for event in emitted] == ["agent_job_incomplete"]
+    assert emitted[0]["model_calls"] == 2
+    assert emitted[0]["limit"] == 2
+    assert checkpoints[-1][0] == "writer_incomplete:backend-job"
 
 
 def test_cancellation_after_first_coding_job_never_starts_the_next(monkeypatch):

--- a/agent/tests/test_orchestration.py
+++ b/agent/tests/test_orchestration.py
@@ -117,6 +117,19 @@ def test_manifest_and_dispatch_plan_require_a_writer_and_known_members():
         validate_dispatch_plan(no_writer, team, profiles)
 
 
+def test_automatic_call_budget_uses_the_bounded_adaptive_pool():
+    manifest = _manifest()
+    manifest["team"]["budget"].update({
+        "call_budget_mode": "automatic",
+        "max_model_calls": 12,
+    })
+
+    _, team, _, _ = parse_manifest(manifest)
+
+    assert team.budget.call_budget_mode == "automatic"
+    assert team.budget.max_model_calls == 100
+
+
 def test_multiple_coding_jobs_must_be_write_capable_and_transitively_ordered():
     manifest = _manifest()
     manifest["profiles"].append(

--- a/agent/tests/test_runstore.py
+++ b/agent/tests/test_runstore.py
@@ -50,6 +50,31 @@ def test_run_store_attempt_ids_are_scoped_to_each_run(tmp_path) -> None:
     assert attempt_ids == ["first-run:writer:1", "second-run:writer:1"]
 
 
+def test_incomplete_writer_attempt_is_paused_and_not_counted_as_completed(tmp_path) -> None:
+    store = RunStore(tmp_path / "runs.sqlite3")
+    store.start_run("run", state="running")
+    store.append_event("run", {
+        "type": "agent_job_started", "job_id": "writer",
+        "agent_id": "writer-agent", "agent_name": "Writer",
+        "role": "implementer", "goal": "implement",
+    })
+    store.append_event("run", {
+        "type": "agent_job_incomplete", "job_id": "writer",
+        "agent_id": "writer-agent", "state": "paused",
+        "reason": "model_call_budget", "message": "Saved for resume",
+    })
+
+    detail = store.run("run", include_events=True)
+
+    assert detail["attempts"][0]["state"] == "paused"
+    assert detail["attempts"][0]["completed_at"] is None
+    assert detail["job_count"] == 1
+    assert detail["completed_job_count"] == 0
+    summary = store.list_runs()[0]
+    assert summary["job_count"] == 1
+    assert summary["completed_job_count"] == 0
+
+
 def test_run_store_checkpoint_and_redacted_export(tmp_path) -> None:
     store = RunStore(tmp_path / "runs.sqlite3")
     store.start_run("run-1", request="secret request")


### PR DESCRIPTION
## What changed

- Anchors a durable live Team Run Board beneath each originating user request for dispatch, one-time approval, execution, recovery, and compact terminal results.
- Replaces Team Run Inspector with a clearer Team Runs Overview and phase-grouped Activity view, while preserving the technical log and recovery/checkout actions.
- Removes the completed Inspect Run bar and completed-run recovery banner; interrupted runs remain recoverable inline.
- Adds Automatic team call budgets capped at 100, bounded writer continuation, accurate budget-limit reasons, and safe checkpoints instead of false completion.
- Persists `team_run_id` through sanitized session history so multiple boards restore in the correct conversation position.
- Adds Custom role instructions and an Advanced Settings disclosure for timeout, token, cost, and MCP controls.
- Updates README, team guide, protocol docs, native fixtures, and regression coverage.

## Why

Team planning was occupying the composer, completion state was difficult to understand, and a smaller per-writer call allocation was being reported as the global 40-step limit. That combination made healthy runs look stuck or falsely complete. The new flow keeps the composer available, explains the run in place, and saves unfinished writers at a resumable checkpoint.

## Validation

- `403` backend tests passed.
- `255` native unit tests passed.
- Clean macOS Debug build succeeded.
- Acceptance bundle verified as `io.sparktales.locus`, version `1.11.0`.
- `git diff --check` passed.
- The macOS UI suite was intentionally not run per request; its fixtures/selectors were updated.
- The disabled vLLM endpoint was not contacted.
