### PR TITLE
Stabilize team runs, recovery controls, and local-service startup

### DIFF
--- a/Locus/AgentTeams.swift
+++ b/Locus/AgentTeams.swift
@@ -543,6 +543,19 @@ enum TeamRunState: String, Codable, CaseIterable, Hashable {
     }
 }
 
+/// One resolved view of a run's live and durable state. UI surfaces consume
+/// this instead of independently mixing websocket state with saved metadata.
+struct TeamRunPresentation: Equatable {
+    let state: TeamRunState
+    let isCurrent: Bool
+    let isActivelyOwned: Bool
+    let canPause: Bool
+    let canStop: Bool
+    let canRecover: Bool
+
+    var shouldCollapseTerminal: Bool { state.isTerminal && !canRecover }
+}
+
 struct AgentActivity: Identifiable, Codable, Hashable {
     let id: String
     var agentName: String

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -129,6 +129,7 @@ final class AppModel: ObservableObject {
     @Published private(set) var orchestrationRuns: [OrchestrationRun] = []
     @Published private(set) var selectedOrchestrationRun: OrchestrationRun?
     @Published private(set) var orchestrationEvents: [OrchestrationEvent] = []
+    @Published private(set) var isLoadingOrchestrationRuns = false
     @Published private(set) var pendingDispatchPlan: DispatchPlan?
     @Published private(set) var evaluationSuites: [EvaluationSuite] = []
     @Published private(set) var activeEvaluationID: String?
@@ -252,7 +253,6 @@ final class AppModel: ObservableObject {
     @Published var transcriptSearchSelection = 0
     @Published var previewReloadID = UUID()
     @Published var streamRevision = 0
-    @Published private(set) var teamBoardFocusRequest = 0
     @Published var toast: AppToast?
     var toastMessage: String? { toast?.message }
     @Published private(set) var lifecycleRecoveryMessage: String?
@@ -300,6 +300,46 @@ final class AppModel: ObservableObject {
     ) -> String? {
         if currentRunID == runID { return currentSessionID }
         return states.first(where: { $0.value.runID == runID })?.key
+    }
+
+    func teamRunPresentation(
+        for runID: String,
+        durable run: OrchestrationRun?
+    ) -> TeamRunPresentation {
+        Self.resolveTeamRunPresentation(
+            runID: runID,
+            currentRunID: orchestrationRunID,
+            liveState: orchestrationState,
+            isBusy: isBusy,
+            durableState: run.flatMap { TeamRunState(rawValue: $0.state) },
+            durableRecoverable: run?.recoverable == true
+        )
+    }
+
+    static func resolveTeamRunPresentation(
+        runID: String,
+        currentRunID: String?,
+        liveState: TeamRunState?,
+        isBusy: Bool,
+        durableState: TeamRunState?,
+        durableRecoverable: Bool
+    ) -> TeamRunPresentation {
+        let isCurrent = currentRunID == runID
+        let state = (isCurrent ? liveState : nil) ?? durableState ?? .dispatching
+        let hasLiveOwner = isCurrent && isBusy && !state.isTerminal && state != .paused
+        let hasRecoverableSavedState = durableRecoverable
+            && (durableState == .paused || durableState == .interrupted)
+        let canRecover = (!isCurrent || !isBusy)
+            && hasRecoverableSavedState
+            && (state == .paused || state == .interrupted)
+        return TeamRunPresentation(
+            state: state,
+            isCurrent: isCurrent,
+            isActivelyOwned: hasLiveOwner,
+            canPause: hasLiveOwner && state != .waitingDispatchApproval,
+            canStop: hasLiveOwner,
+            canRecover: canRecover
+        )
     }
     private let ollamaRuntime = OllamaRuntime()
     private let mcpAuthCoordinator = MCPAuthCoordinator()
@@ -1085,7 +1125,9 @@ final class AppModel: ObservableObject {
         }
 
         let message = lifecycleRecoveryExplanation(fallback: recovery)
-        if selectedOrchestrationRun?.recoverable == true {
+        if let run = selectedOrchestrationRun,
+           teamRunPresentation(for: run.id, durable: run).canRecover
+        {
             lifecycleRecoveryMessage = message
             showToast("A saved team run can be resumed", duration: 6)
         } else {
@@ -1100,7 +1142,7 @@ final class AppModel: ObservableObject {
         if run.state == TeamRunState.completed.rawValue {
             return "Locus was force quit after the team run completed. Its results were restored."
         }
-        if run.recoverable {
+        if teamRunPresentation(for: run.id, durable: run).canRecover {
             return "Locus closed unexpectedly. This team run can be resumed from its saved checkpoint."
         }
         if let state = TeamRunState(rawValue: run.state) {
@@ -3165,6 +3207,7 @@ final class AppModel: ObservableObject {
         } else {
             orchestrationRunsGeneration += 1
             let generation = orchestrationRunsGeneration
+            isLoadingOrchestrationRuns = true
             let query = sessionID.isEmpty
                 ? []
                 : [URLQueryItem(name: "session_id", value: sessionID)]
@@ -3186,19 +3229,28 @@ final class AppModel: ObservableObject {
             guard request.generation == orchestrationRunsGeneration,
                   currentSessionID == sessionID
             else { return }
+            isLoadingOrchestrationRuns = false
             if orchestrationRuns != response.runs {
                 orchestrationRuns = response.runs
             }
-            let selectedID = runID ?? selectedOrchestrationRun?.id
-                ?? orchestrationRunID ?? response.runs.first?.id
+            let selectedInCurrentSession = selectedOrchestrationRun.flatMap { selected in
+                selected.sessionID == nil || selected.sessionID == sessionID ? selected.id : nil
+            }
+            let selectedID = runID ?? orchestrationRunID
+                ?? selectedInCurrentSession ?? response.runs.first?.id
             if let selectedID {
                 await loadOrchestrationRun(selectedID, terminal: terminal)
+            } else if selectedOrchestrationRun?.sessionID != sessionID {
+                selectedOrchestrationRun = nil
+                orchestrationEvents = []
+                orchestrationEventIDs = []
             }
         } catch {
             if orchestrationRunsTasks[requestKey]?.generation == request.generation {
                 orchestrationRunsTasks.removeValue(forKey: requestKey)
             }
             guard !Task.isCancelled, request.generation == orchestrationRunsGeneration else { return }
+            isLoadingOrchestrationRuns = false
             showToast("Could not load team runs: \(error.localizedDescription)")
         }
     }
@@ -3206,7 +3258,9 @@ final class AppModel: ObservableObject {
     func loadOrchestrationRun(_ runID: String, terminal: Bool = false) async {
         let sameRun = selectedOrchestrationRun?.id == runID
         let afterSequence = sameRun ? orchestrationEvents.map(\.sequence).max() ?? 0 : 0
-        let loadKey = "\(runID)|\(afterSequence)|\(terminal ? "terminal" : "routine")"
+        let transport = orchestrationBackend(for: runID)
+        let transportKey = transport.currentBaseURL.absoluteString
+        let loadKey = "\(transportKey)|\(runID)|\(afterSequence)|\(terminal ? "terminal" : "routine")"
         let generation: Int
         if requestedOrchestrationLoadKey == loadKey {
             generation = orchestrationSelectionGeneration
@@ -3216,13 +3270,16 @@ final class AppModel: ObservableObject {
             requestedOrchestrationLoadKey = loadKey
             requestedOrchestrationRunID = runID
         }
-        let detailKey = "\(runID)|\(terminal ? "terminal" : "routine")"
-        let eventsKey = "\(runID)|\(afterSequence)|\(terminal ? "terminal" : "routine")"
-        let detailTask = orchestrationDetailTask(runID: runID, key: detailKey)
+        let detailKey = "\(transportKey)|\(runID)|\(terminal ? "terminal" : "routine")"
+        let eventsKey = "\(transportKey)|\(runID)|\(afterSequence)|\(terminal ? "terminal" : "routine")"
+        let detailTask = orchestrationDetailTask(
+            runID: runID, key: detailKey, transport: transport
+        )
         let eventsTask = orchestrationEventsTask(
             runID: runID,
             afterSequence: afterSequence,
-            key: eventsKey
+            key: eventsKey,
+            transport: transport
         )
         do {
             let detail = try await detailTask.value
@@ -3246,6 +3303,7 @@ final class AppModel: ObservableObject {
             }
             orchestrationEventIDs = Set(merged.map(\.id))
             if orchestrationRunID == runID,
+               orchestrationState == nil,
                let state = TeamRunState(rawValue: detail.state),
                orchestrationState != state
             {
@@ -3264,8 +3322,11 @@ final class AppModel: ObservableObject {
             .filter { $0.text("run_id") == runID }
             .map(\.sequence)
             .max() ?? 0
-        let key = "\(runID)|\(after)|routine"
-        let task = orchestrationEventsTask(runID: runID, afterSequence: after, key: key)
+        let transport = orchestrationBackend(for: runID)
+        let key = "\(transport.currentBaseURL.absoluteString)|\(runID)|\(after)|routine"
+        let task = orchestrationEventsTask(
+            runID: runID, afterSequence: after, key: key, transport: transport
+        )
         do {
             let response = try await task.value
             orchestrationEventTasks.removeValue(forKey: key)
@@ -3294,13 +3355,24 @@ final class AppModel: ObservableObject {
         }
     }
 
+    nonisolated static func orchestrationPickerRuns(
+        _ runs: [OrchestrationRun],
+        selected: OrchestrationRun?
+    ) -> [OrchestrationRun] {
+        guard let selected,
+              !runs.contains(where: { $0.id == selected.id })
+        else { return runs }
+        return [selected] + runs
+    }
+
     private func orchestrationDetailTask(
         runID: String,
-        key: String
+        key: String,
+        transport: BackendService
     ) -> Task<OrchestrationRun, Error> {
         if let existing = orchestrationDetailTasks[key] { return existing }
-        let task = Task { [backend] in
-            try await backend.get(
+        let task = Task {
+            try await transport.get(
                 "/api/orchestrations/\(runID)", as: OrchestrationRun.self
             )
         }
@@ -3311,11 +3383,12 @@ final class AppModel: ObservableObject {
     private func orchestrationEventsTask(
         runID: String,
         afterSequence: Int,
-        key: String
+        key: String,
+        transport: BackendService
     ) -> Task<OrchestrationEventsResponse, Error> {
         if let existing = orchestrationEventTasks[key] { return existing }
-        let task = Task { [backend] in
-            try await backend.get(
+        let task = Task {
+            try await transport.get(
                 "/api/orchestrations/\(runID)/events",
                 query: [URLQueryItem(name: "after_seq", value: String(afterSequence))],
                 as: OrchestrationEventsResponse.self
@@ -3450,6 +3523,10 @@ final class AppModel: ObservableObject {
     }
 
     func resumeOrchestration(_ run: OrchestrationRun) {
+        guard teamRunPresentation(for: run.id, durable: run).canRecover else {
+            showToast("That team run is not paused or interrupted")
+            return
+        }
         guard let teamID = run.teamID.flatMap(UUID.init(uuidString:)),
               let manifest = teamManifest(for: run.request, teamID: teamID)
         else {
@@ -3480,6 +3557,10 @@ final class AppModel: ObservableObject {
     }
 
     func retryOrchestrationJob(_ attempt: AgentJobAttempt, in run: OrchestrationRun) {
+        guard teamRunPresentation(for: run.id, durable: run).canRecover else {
+            showToast("Pause the team run before retrying a job")
+            return
+        }
         guard let teamID = run.teamID.flatMap(UUID.init(uuidString:)),
               let manifest = teamManifest(for: run.request, teamID: teamID)
         else {
@@ -3498,6 +3579,10 @@ final class AppModel: ObservableObject {
         in run: OrchestrationRun,
         to profile: AgentProfile
     ) {
+        guard teamRunPresentation(for: run.id, durable: run).canRecover else {
+            showToast("Pause the team run before reassigning a job")
+            return
+        }
         guard let teamID = run.teamID.flatMap(UUID.init(uuidString:)),
               let manifest = teamManifest(for: run.request, teamID: teamID)
         else {
@@ -5520,7 +5605,7 @@ final class AppModel: ObservableObject {
             + "\n… \(lines.count - maxLines) more lines — open the file to see the rest."
     }
 
-    func selectInspectorTab(_ tab: InspectorTab) {
+    func selectInspectorTab(_ tab: InspectorTab, selecting runID: String? = nil) {
         guard !justChatEnabled else { return }
         inspectorTab = tab
         if inspectorCollapsed {
@@ -5533,27 +5618,16 @@ final class AppModel: ObservableObject {
         }
         if tab == .files { refreshWorkspaceIndex() }
         if tab == .runs {
-            Task { @MainActor [weak self] in await self?.refreshOrchestrationRuns() }
+            Task { @MainActor [weak self] in
+                await self?.refreshOrchestrationRuns(select: runID)
+            }
         }
         if tab == .agents { refreshAgentInstructions() }
         settings.inspectorLastTab = tab.rawValue
     }
 
-    func focusActiveTeamBoard() {
-        guard let runID = orchestrationRunID,
-              blocks.contains(where: { $0.teamRunID == runID })
-        else {
-            selectInspectorTab(.runs)
-            return
-        }
-        teamBoardFocusRequest += 1
-    }
-
     func openTeamRun(_ runID: String) {
-        selectInspectorTab(.runs)
-        Task { @MainActor [weak self] in
-            await self?.loadOrchestrationRun(runID)
-        }
+        selectInspectorTab(.runs, selecting: runID)
     }
 
     private func refreshAnchoredTeamRunsIfNeeded() {
@@ -5739,7 +5813,10 @@ final class AppModel: ObservableObject {
     }
 
     private func backendIsHealthy() async -> Bool {
-        (try? await backend.get("/api/health", as: HealthResponse.self)) != nil
+        guard BackendProcess.loopbackPortIsListening(at: backend.currentBaseURL) else {
+            return false
+        }
+        return (try? await backend.get("/api/health", as: HealthResponse.self)) != nil
     }
 
     private func ensureTeamWorker(for requestedSessionID: String) async -> TaskWorkerRuntime? {
@@ -5773,19 +5850,50 @@ final class AppModel: ObservableObject {
         runtime.process.onUnexpectedExit = { [weak self, weak runtime] _, output in
             Task { @MainActor in
                 guard let self, let runtime else { return }
+                if let key = self.taskWorkers.first(where: { $0.value === runtime })?.key {
+                    self.taskWorkers.removeValue(forKey: key)
+                }
+                let previous = self.taskConversationStates[runtime.sessionID]
+                let runID = previous?.runID
+                var durableRun: OrchestrationRun?
+                if let runID {
+                    durableRun = try? await self.backend.post(
+                        "/api/orchestrations/\(runID)/reconcile-worker-exit",
+                        body: ["worker_id": previous?.workerID ?? ""],
+                        timeout: 5,
+                        as: OrchestrationRun.self
+                    )
+                    if let durableRun {
+                        self.orchestrationRuns.removeAll { $0.id == durableRun.id }
+                        self.orchestrationRuns.insert(durableRun, at: 0)
+                        if self.selectedOrchestrationRun?.id == durableRun.id {
+                            self.selectedOrchestrationRun = durableRun
+                        }
+                    }
+                }
+                let interruptedState = durableRun.flatMap {
+                    TeamRunState(rawValue: $0.state)
+                } ?? .interrupted
                 let state = TaskConversationState(
                     sessionID: runtime.sessionID,
                     taskID: runtime.sessionInfo?.task?.id,
-                    teamID: self.taskConversationStates[runtime.sessionID]?.teamID,
-                    workerID: self.taskConversationStates[runtime.sessionID]?.workerID,
-                    runID: self.taskConversationStates[runtime.sessionID]?.runID,
-                    state: .interrupted,
+                    teamID: previous?.teamID,
+                    workerID: previous?.workerID,
+                    runID: runID,
+                    state: interruptedState,
                     updatedAt: Date()
                 )
                 self.taskConversationStates[runtime.sessionID] = state
+                if let runID {
+                    self.lifecycleJournal?.record(
+                        sessionID: runtime.sessionID,
+                        runID: runID,
+                        state: interruptedState
+                    )
+                }
                 if self.currentSessionID == runtime.sessionID {
                     self.isBusy = false
-                    self.orchestrationState = .interrupted
+                    self.orchestrationState = interruptedState
                     let detail = output.trimmingCharacters(in: .whitespacesAndNewlines)
                     self.blocks.append(ChatBlock(
                         kind: .error,
@@ -5804,7 +5912,9 @@ final class AppModel: ObservableObject {
 
         var healthy = false
         for _ in 0..<60 {
-            if (try? await runtime.service.get("/api/health", as: HealthResponse.self)) != nil {
+            if BackendProcess.loopbackPortIsListening(at: endpoint),
+               (try? await runtime.service.get("/api/health", as: HealthResponse.self)) != nil
+            {
                 healthy = true
                 break
             }

--- a/Locus/BackendProcess.swift
+++ b/Locus/BackendProcess.swift
@@ -186,6 +186,31 @@ final class BackendProcess {
         boundLoopbackPort(requested: port) != nil
     }
 
+    /// A cheap loopback readiness probe used before URLSession health checks.
+    /// A server process can exist for a short time before it begins listening;
+    /// probing the socket keeps that normal startup window out of CFNetwork's
+    /// error log and avoids treating it as a runtime failure.
+    static func loopbackPortIsListening(at endpoint: URL) -> Bool {
+        guard let port = endpoint.port,
+              (1...Int(UInt16.max)).contains(port),
+              endpoint.host == "127.0.0.1" || endpoint.host == "localhost"
+        else { return true }
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return false }
+        defer { close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(UInt16(port).bigEndian)
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        return withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) == 0
+            }
+        }
+    }
+
     private static func availableLoopbackPort() -> Int? {
         boundLoopbackPort(requested: 0)
     }

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -237,8 +237,8 @@ struct InspectorRunsTab: View {
                 )
             }
         }
-        .task {
-            if model.orchestrationRuns.isEmpty, model.selectedOrchestrationRun == nil {
+        .task(id: model.currentSessionID) {
+            if !model.isLoadingOrchestrationRuns {
                 await model.refreshOrchestrationRuns()
             }
         }
@@ -261,21 +261,34 @@ struct InspectorRunsTab: View {
                     .buttonStyle(.plain)
                     .help("Refresh run history")
             }
-            if !model.orchestrationRuns.isEmpty {
+            if !runPickerRuns.isEmpty || model.isLoadingOrchestrationRuns {
                 Picker("Run", selection: Binding(
-                    get: { model.selectedOrchestrationRun?.id ?? "" },
-                    set: { id in Task { await model.loadOrchestrationRun(id) } }
+                    get: { model.selectedOrchestrationRun?.id },
+                    set: { id in
+                        guard let id else { return }
+                        Task { await model.loadOrchestrationRun(id) }
+                    }
                 )) {
-                    ForEach(model.orchestrationRuns) { run in
+                    Text(model.isLoadingOrchestrationRuns ? "Loading team runs…" : "Select a run")
+                        .tag(nil as String?)
+                    ForEach(runPickerRuns) { run in
                         Text("\(run.teamName ?? "Team") · \(run.state.replacingOccurrences(of: "_", with: " "))")
-                            .tag(run.id)
+                            .tag(Optional(run.id))
                     }
                 }
                 .labelsHidden()
+                .accessibilityIdentifier("runs.picker")
             }
         }
         .padding(13)
         .overlay(alignment: .bottom) { Rectangle().fill(LocusTheme.line).frame(height: 1) }
+    }
+
+    private var runPickerRuns: [OrchestrationRun] {
+        AppModel.orchestrationPickerRuns(
+            model.orchestrationRuns,
+            selected: model.selectedOrchestrationRun
+        )
     }
 
     private func runBody(_ run: OrchestrationRun) -> some View {
@@ -305,7 +318,8 @@ struct InspectorRunsTab: View {
                 Spacer()
                 runActions(run)
             }
-            if let reason = run.recoveryReason, run.recoverable {
+            let presentation = model.teamRunPresentation(for: run.id, durable: run)
+            if let reason = run.recoveryReason, presentation.canRecover {
                 Label(reason, systemImage: "arrow.clockwise.circle.fill")
                     .font(.system(size: 8))
                     .foregroundStyle(LocusTheme.warning)
@@ -334,11 +348,12 @@ struct InspectorRunsTab: View {
 
     @ViewBuilder
     private func runActions(_ run: OrchestrationRun) -> some View {
+        let presentation = model.teamRunPresentation(for: run.id, durable: run)
         Menu {
             Button(run.pinned ? "Unpin Run" : "Pin Run") {
                 model.setOrchestrationPinned(run, pinned: !run.pinned)
             }
-            if run.recoverable {
+            if presentation.canRecover {
                 Button("Resume") { model.resumeOrchestration(run) }
             }
             if run.taskID != nil && !run.legacy {
@@ -347,8 +362,10 @@ struct InspectorRunsTab: View {
             if !run.legacy {
                 Button("Duplicate from Current Workspace") { model.duplicateOrchestration(run) }
             }
-            if run.id == model.orchestrationRunID, model.isBusy {
+            if presentation.canPause {
                 Button("Pause at Safe Boundary") { model.pauseOrchestration(run.id) }
+            }
+            if presentation.canStop {
                 Button("Stop Run", role: .destructive) { model.cancelOrchestration(run.id) }
             }
             Menu("Export") {
@@ -361,7 +378,10 @@ struct InspectorRunsTab: View {
             }
             Divider()
             Button("Discard Run", role: .destructive) { model.discardOrchestration(run.id) }
-                .disabled(model.isBusy && run.id == model.orchestrationRunID)
+                .disabled(
+                    presentation.isActivelyOwned
+                        || (!presentation.state.isTerminal && !presentation.canRecover)
+                )
             if run.taskID != nil && ["discarded", "cancelled", "completed", "failed"].contains(run.state) {
                 Button("Clean Up Managed Checkout", role: .destructive) {
                     model.cleanupOrchestrationCheckout(run)
@@ -467,7 +487,10 @@ struct InspectorRunsTab: View {
                                             .font(.system(size: 7, design: .monospaced))
                                             .foregroundStyle(LocusTheme.muted)
                                         Spacer()
-                                        if attempt.state != "running"
+                                        if model.teamRunPresentation(
+                                            for: run.id, durable: run
+                                        ).canRecover,
+                                           attempt.state != "running"
                                             && !model.isCodingAttempt(attempt, in: run) {
                                             Menu {
                                                 Button("Retry with Same Agent") {
@@ -525,11 +548,16 @@ struct InspectorRunsTab: View {
                                 }
                             }
                         }
-                        if let reason = run.recoveryReason, !reason.isEmpty {
-                            Label(reason, systemImage: run.recoverable
+                        let presentation = model.teamRunPresentation(for: run.id, durable: run)
+                        if let reason = run.recoveryReason,
+                           !reason.isEmpty,
+                           presentation.canRecover || presentation.state.isTerminal
+                        {
+                            Label(reason, systemImage: presentation.canRecover
                                 ? "arrow.clockwise.circle.fill" : "exclamationmark.circle.fill")
                                 .font(.system(size: 8))
-                                .foregroundStyle(run.recoverable ? LocusTheme.warning : LocusTheme.coral)
+                                .foregroundStyle(presentation.canRecover
+                                    ? LocusTheme.warning : LocusTheme.coral)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                     }
@@ -699,7 +727,10 @@ struct InspectorRunsTab: View {
                                     .font(.system(size: 7, design: .monospaced))
                                     .foregroundStyle(LocusTheme.muted)
                                 Spacer()
-                                if attempt.state != "running"
+                                if model.teamRunPresentation(
+                                    for: run.id, durable: run
+                                ).canRecover,
+                                   attempt.state != "running"
                                     && !model.isCodingAttempt(attempt, in: run) {
                                     Menu {
                                         Button("Retry with Same Agent") {
@@ -1042,7 +1073,7 @@ struct InspectorRunsTab: View {
     }
 
     private func runPhases(_ run: OrchestrationRun) -> [RunPhase] {
-        let state = TeamRunState(rawValue: run.state) ?? .failed
+        let state = model.teamRunPresentation(for: run.id, durable: run).state
         let current: Int = switch state {
         case .queued, .dispatching: 0
         case .waitingDispatchApproval: 1
@@ -1073,8 +1104,7 @@ struct InspectorRunsTab: View {
     }
 
     private func runStateTitle(_ run: OrchestrationRun) -> String {
-        let state = TeamRunState(rawValue: run.state)?.title
-            ?? run.state.replacingOccurrences(of: "_", with: " ").capitalized
+        let state = model.teamRunPresentation(for: run.id, durable: run).state.title
         let total = run.jobCount ?? 0
         guard total > 0 else { return state }
         return "\(state) · \(run.completedJobCount ?? 0) of \(total) jobs"

--- a/Locus/PlanApprovalPromptView.swift
+++ b/Locus/PlanApprovalPromptView.swift
@@ -224,7 +224,7 @@ struct TeamRunBoardView: View {
 
     private var actionRow: some View {
         HStack(spacing: 9) {
-            if let run, run.recoverable, state != .completed {
+            if presentation.canRecover, let run {
                 Button("Resume") { model.resumeOrchestration(run) }
                     .buttonStyle(.borderedProminent)
                     .tint(LocusTheme.ink)
@@ -232,14 +232,18 @@ struct TeamRunBoardView: View {
                 Button("Discard", role: .destructive) { model.discardOrchestration(run.id) }
                     .buttonStyle(.borderless)
                     .accessibilityIdentifier("teamBoard.discard")
-            } else if isActive, model.isBusy, let activeID = model.orchestrationRunID {
-                Button("Pause at Safe Boundary") { model.pauseOrchestration(activeID) }
-                    .buttonStyle(.borderless)
-                    .accessibilityIdentifier("teamBoard.pause")
-                Button("Stop", role: .destructive) { model.cancelOrchestration(activeID) }
-                    .buttonStyle(.borderless)
-                    .foregroundStyle(LocusTheme.coral)
-                    .accessibilityIdentifier("teamBoard.stop")
+            } else if let activeID = model.orchestrationRunID {
+                if presentation.canPause {
+                    Button("Pause at Safe Boundary") { model.pauseOrchestration(activeID) }
+                        .buttonStyle(.borderless)
+                        .accessibilityIdentifier("teamBoard.pause")
+                }
+                if presentation.canStop {
+                    Button("Stop", role: .destructive) { model.cancelOrchestration(activeID) }
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(LocusTheme.coral)
+                        .accessibilityIdentifier("teamBoard.stop")
+                }
             }
             if state == .completed, model.taskHasChanges, isActive {
                 Button("Apply to Workspace") { model.applyActiveTaskToWorkspace() }
@@ -259,13 +263,15 @@ struct TeamRunBoardView: View {
         return model.orchestrationRuns.first(where: { $0.id == runID })
     }
 
-    private var isActive: Bool { model.orchestrationRunID == runID }
+    private var presentation: TeamRunPresentation {
+        model.teamRunPresentation(for: runID, durable: run)
+    }
+    private var isActive: Bool { presentation.isCurrent }
     private var shouldCollapseTerminal: Bool {
-        state.isTerminal && run?.recoverable != true
+        presentation.shouldCollapseTerminal
     }
     private var state: TeamRunState {
-        if isActive, let state = model.orchestrationState { return state }
-        return run.flatMap { TeamRunState(rawValue: $0.state) } ?? .dispatching
+        presentation.state
     }
     private var teamName: String {
         if isActive, let name = model.activeOrchestrationTeam?.name { return name }
@@ -309,7 +315,7 @@ struct TeamRunBoardView: View {
     private var stateSymbol: String {
         switch state {
         case .completed: "checkmark.circle.fill"
-        case .interrupted where run?.recoverable == true: "pause.circle.fill"
+        case .interrupted where presentation.canRecover: "pause.circle.fill"
         case .failed, .interrupted, .cancelled, .discarded: "xmark.circle.fill"
         case .paused: "pause.circle.fill"
         case .waitingPermission, .waitingComputer, .waitingDispatchApproval: "clock.fill"
@@ -319,7 +325,7 @@ struct TeamRunBoardView: View {
     private var stateColor: Color {
         switch state {
         case .completed: LocusTheme.success
-        case .interrupted where run?.recoverable == true: LocusTheme.warning
+        case .interrupted where presentation.canRecover: LocusTheme.warning
         case .failed, .interrupted, .cancelled, .discarded: LocusTheme.coral
         case .paused, .waitingPermission, .waitingComputer, .waitingDispatchApproval: LocusTheme.warning
         default: LocusTheme.signalDeep

--- a/Locus/SessionSidebarView.swift
+++ b/Locus/SessionSidebarView.swift
@@ -728,7 +728,7 @@ struct TeamProgressPopover: View {
             Text("\(model.teamModelCalls.formatted()) calls")
             Text("\(model.teamMeteredTokens.formatted()) hosted tokens")
             Spacer()
-            if runIsActive, let runID = model.orchestrationRunID {
+            if presentation?.canStop == true, let runID = model.orchestrationRunID {
                 Button("Stop", role: .destructive) {
                     model.cancelOrchestration(runID)
                 }
@@ -738,7 +738,11 @@ struct TeamProgressPopover: View {
                 .accessibilityIdentifier("teamProgress.stop")
             }
             Button("Open Runs") {
-                model.selectInspectorTab(.runs)
+                if let runID = model.orchestrationRunID {
+                    model.openTeamRun(runID)
+                } else {
+                    model.selectInspectorTab(.runs)
+                }
                 dismiss()
             }
             .buttonStyle(.borderless)
@@ -772,18 +776,18 @@ struct TeamProgressPopover: View {
     }
 
     private var runIsActive: Bool {
-        switch model.orchestrationState {
-        case .queued, .dispatching, .running, .waitingPermission, .waitingComputer,
-             .waitingDispatchApproval, .reviewing, .paused:
-            return true
-        case .completed, .failed, .interrupted, .cancelled, .discarded, nil:
-            return false
-        }
+        presentation?.isActivelyOwned == true
+    }
+
+    private var presentation: TeamRunPresentation? {
+        guard let runID = model.orchestrationRunID else { return nil }
+        let durable = model.orchestrationRuns.first(where: { $0.id == runID })
+        return model.teamRunPresentation(for: runID, durable: durable)
     }
 
     private var progressStateTitle: String {
         if model.selectedTeamRouteIssue != nil { return "Needs model setup" }
-        return model.orchestrationState?.title ?? "Ready"
+        return presentation?.state.title ?? "Ready"
     }
 
     private var progressStateColor: Color {

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct WorkspaceView: View {
     @EnvironmentObject private var model: AppModel
     @State private var modelPickerPresented = false
+    @State private var teamProgressPresented = false
 
     private var sessionTitle: String {
         model.sessions.first(where: { $0.id == model.currentSessionID })?.displayTitle
@@ -82,7 +83,7 @@ struct WorkspaceView: View {
 
             if model.selectedAgentTeam != nil {
                 Button {
-                    model.focusActiveTeamBoard()
+                    teamProgressPresented.toggle()
                 } label: {
                     ZStack(alignment: .topTrailing) {
                         Image(systemName: "waveform.path.ecg")
@@ -109,6 +110,12 @@ struct WorkspaceView: View {
                 .help("Team progress · \(teamProgressTitle)")
                 .accessibilityLabel("Team progress, \(teamProgressTitle)")
                 .accessibilityIdentifier("workspace.teamProgress")
+                .popover(isPresented: $teamProgressPresented, arrowEdge: .top) {
+                    TeamProgressPopover {
+                        teamProgressPresented = false
+                    }
+                    .environmentObject(model)
+                }
             }
 
             ContextUsageChip()
@@ -896,15 +903,6 @@ private struct ConversationView: View {
                     .buttonStyle(.plain)
                     .padding(.bottom, 12)
                     .accessibilityIdentifier("conversation.jumpToLatest")
-                }
-            }
-            .onChange(of: model.teamBoardFocusRequest) {
-                guard let runID = model.orchestrationRunID else {
-                    model.selectInspectorTab(.runs)
-                    return
-                }
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    proxy.scrollTo("team-board-\(runID)", anchor: .center)
                 }
             }
             .onChange(of: model.blocks.count) {

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -58,8 +58,11 @@ private final class OrchestrationURLProtocol: URLProtocol {
         let runID = parts.count >= 3 ? String(parts[2]) : "run-1"
         let run = runJSON(id: runID)
         if path == "/api/orchestrations" {
+            let sessionID = components?.queryItems?
+                .first(where: { $0.name == "session_id" })?.value
+            let runs = sessionID == "session-empty" ? [] : [runJSON(id: "run-1")]
             return try! JSONSerialization.data(withJSONObject: [
-                "runs": [runJSON(id: "run-1")],
+                "runs": runs,
                 "read_only": false,
             ])
         }
@@ -166,6 +169,107 @@ final class AppModelTests: XCTestCase {
         XCTAssertEqual(urls.filter { $0.path == "/api/orchestrations" }.count, 1)
         XCTAssertEqual(urls.filter { $0.path == "/api/orchestrations/run-1" }.count, 1)
         XCTAssertEqual(urls.filter { $0.path.hasSuffix("/events") }.count, 1)
+    }
+
+    @MainActor
+    func testOpenTeamRunUsesOneCoordinatedRefresh() async throws {
+        let model = orchestrationModel()
+
+        model.openTeamRun("run-1")
+        model.openTeamRun("run-1")
+        model.openTeamRun("run-1")
+
+        for _ in 0..<50 where OrchestrationURLProtocol.requests.count < 3 {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        let urls = OrchestrationURLProtocol.requests
+        XCTAssertEqual(urls.filter { $0.path == "/api/orchestrations" }.count, 1)
+        XCTAssertEqual(urls.filter { $0.path == "/api/orchestrations/run-1" }.count, 1)
+        XCTAssertEqual(urls.filter { $0.path.hasSuffix("/events") }.count, 1)
+    }
+
+    @MainActor
+    func testLiveRunningStateRejectsStaleDurableRecoveryControls() {
+        let presentation = AppModel.resolveTeamRunPresentation(
+            runID: "run-1",
+            currentRunID: "run-1",
+            liveState: .running,
+            isBusy: true,
+            durableState: .interrupted,
+            durableRecoverable: true
+        )
+
+        XCTAssertEqual(presentation.state, .running)
+        XCTAssertTrue(presentation.canPause)
+        XCTAssertTrue(presentation.canStop)
+        XCTAssertFalse(presentation.canRecover)
+    }
+
+    @MainActor
+    func testInterruptedLiveStateWaitsForDurableRecoveryConfirmation() {
+        let presentation = AppModel.resolveTeamRunPresentation(
+            runID: "run-1",
+            currentRunID: "run-1",
+            liveState: .interrupted,
+            isBusy: false,
+            durableState: .running,
+            durableRecoverable: true
+        )
+
+        XCTAssertFalse(presentation.canRecover)
+        XCTAssertFalse(presentation.canPause)
+        XCTAssertFalse(presentation.canStop)
+    }
+
+    @MainActor
+    func testPausedRunOffersRecoveryOnlyAfterWorkerStops() {
+        let stillStopping = AppModel.resolveTeamRunPresentation(
+            runID: "run-1",
+            currentRunID: "run-1",
+            liveState: .paused,
+            isBusy: true,
+            durableState: .paused,
+            durableRecoverable: true
+        )
+        let stopped = AppModel.resolveTeamRunPresentation(
+            runID: "run-1",
+            currentRunID: "run-1",
+            liveState: .paused,
+            isBusy: false,
+            durableState: .paused,
+            durableRecoverable: true
+        )
+
+        XCTAssertFalse(stillStopping.canRecover)
+        XCTAssertTrue(stopped.canRecover)
+        XCTAssertFalse(stopped.canPause)
+        XCTAssertFalse(stopped.canStop)
+    }
+
+    @MainActor
+    func testPickerOptionsRetainASelectedRunMissingFromTheLatestList() async {
+        let model = orchestrationModel()
+        await model.loadOrchestrationRun("run-missing")
+
+        let options = AppModel.orchestrationPickerRuns(
+            model.orchestrationRuns,
+            selected: model.selectedOrchestrationRun
+        )
+
+        XCTAssertEqual(options.map(\.id), ["run-missing"])
+    }
+
+    @MainActor
+    func testChangingSessionsClearsASelectionOwnedByThePreviousSession() async {
+        let model = orchestrationModel()
+        await model.loadOrchestrationRun("run-1")
+        XCTAssertEqual(model.selectedOrchestrationRun?.sessionID, "session-1")
+
+        model.currentSessionID = "session-empty"
+        await model.refreshOrchestrationRuns()
+
+        XCTAssertNil(model.selectedOrchestrationRun)
+        XCTAssertTrue(model.orchestrationEvents.isEmpty)
     }
 
     @MainActor

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -79,6 +79,36 @@ final class FeatureLogicTests: XCTestCase {
         XCTAssertTrue(BackendProcess.portIsAvailable(fallback))
     }
 
+    func testLoopbackReadinessDistinguishesListeningAndClosedPorts() throws {
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(descriptor, 0)
+        defer { close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        XCTAssertEqual(bound, 0)
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        XCTAssertEqual(withUnsafeMutablePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(descriptor, $0, &length)
+            }
+        }, 0)
+        let port = Int(UInt16(bigEndian: address.sin_port))
+        let endpoint = try XCTUnwrap(URL(string: "http://127.0.0.1:\(port)"))
+
+        XCTAssertFalse(BackendProcess.loopbackPortIsListening(at: endpoint))
+        XCTAssertEqual(listen(descriptor, 1), 0)
+        XCTAssertTrue(BackendProcess.loopbackPortIsListening(at: endpoint))
+    }
+
     func testLegacyAutomaticLaunchSettingIsIgnoredAndNotReencoded() throws {
         let legacy = #"{"backendURL":"http://127.0.0.1:8791","launchBackendAutomatically":false}"#
         let settings = try JSONDecoder().decode(AppSettings.self, from: Data(legacy.utf8))

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -553,6 +553,7 @@ final class LocusUITests: XCTestCase {
         let progress = anyElement("workspace.teamProgress")
         XCTAssertTrue(progress.waitForExistence(timeout: 3))
         progress.click()
+        XCTAssertTrue(anyElement("teamProgress.popover").waitForExistence(timeout: 3))
         XCTAssertTrue(anyElement("teamBoard.seed-run").waitForExistence(timeout: 3))
         XCTAssertTrue(
             app.staticTexts.matching(

--- a/agent/ollama_code/runstore.py
+++ b/agent/ollama_code/runstore.py
@@ -29,8 +29,14 @@ MAX_EXPORT_EVENTS = 50_000
 
 TERMINAL_STATES = {"completed", "failed", "interrupted", "cancelled", "discarded"}
 RECOVERABLE_STATES = {
-    "queued", "dispatching", "running", "reviewing", "paused",
-    "waiting_dispatch_approval", "waiting_permission", "waiting_computer",
+    "paused", "interrupted", "waiting_dispatch_approval",
+}
+
+# These states have a live owner.  A stale recovery bit from plan approval or
+# an earlier checkpoint must never survive once execution is moving again.
+ACTIVE_NONRECOVERABLE_STATES = {
+    "queued", "dispatching", "running", "reviewing", "pausing",
+    "waiting_permission", "waiting_computer",
 }
 
 _SECRET_KEY = re.compile(
@@ -512,8 +518,17 @@ class RunStore:
                 updates.append("state = ?")
                 values.append(state)
                 if state in TERMINAL_STATES:
-                    updates.extend(["completed_at = ?", "recoverable = 0"])
+                    updates.extend([
+                        "completed_at = ?", "recoverable = 0", "recovery_reason = NULL",
+                    ])
                     values.append(now)
+                elif state in ACTIVE_NONRECOVERABLE_STATES:
+                    updates.extend(["recoverable = 0", "recovery_reason = NULL"])
+            elif event_type in {"permission_request", "computer_action_request"}:
+                # These waits still have a live worker.  They must clear a
+                # stale approval/checkpoint recovery bit even though their
+                # durable event does not replace the orchestration state.
+                updates.extend(["recoverable = 0", "recovery_reason = NULL"])
             if isinstance(safe.get("usage"), dict):
                 updates.append("usage_json = ?")
                 values.append(_json(safe["usage"]))
@@ -753,11 +768,16 @@ class RunStore:
                   reason: str | None = None) -> None:
         if self.read_only:
             return
+        if state in ACTIVE_NONRECOVERABLE_STATES:
+            recoverable = False
+            reason = None
         values: list[Any] = [state, time.time()]
         fields = ["state=?", "updated_at=?"]
         if recoverable is not None:
             fields.append("recoverable=?")
             values.append(1 if recoverable else 0)
+            if not recoverable and reason is None:
+                fields.append("recovery_reason=NULL")
         if reason is not None:
             fields.append("recovery_reason=?")
             values.append(reason[:4_000])

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -1609,12 +1609,45 @@ def orchestration_cancel(run_id: str) -> dict[str, Any]:
 def orchestration_discard(run_id: str) -> dict[str, Any]:
     _require_capability("recovery_controls")
     svc = service()
+    record = svc.run_store.run(run_id)
+    if record is None:
+        raise HTTPException(404, f"orchestration not found: {run_id}")
+    if str(record.get("state") or "") in {
+        "queued", "dispatching", "running", "reviewing", "pausing",
+        "waiting_dispatch_approval", "waiting_permission", "waiting_computer",
+    }:
+        raise HTTPException(409, "stop the active orchestration before discarding it")
     if svc.active_run_id == run_id and svc.busy:
         raise HTTPException(409, "stop the active orchestration before discarding it")
     try:
         return {"ok": True, "run": svc.run_store.discard(run_id)}
     except RunStoreError as exc:
         raise HTTPException(404, str(exc)) from exc
+
+
+@app.post("/api/orchestrations/{run_id}/reconcile-worker-exit")
+def orchestration_reconcile_worker_exit(
+    run_id: str, body: dict[str, Any] = Body(default_factory=dict)
+) -> dict[str, Any]:
+    """Promote a run to recoverable only after its recorded worker exited."""
+    _require_capability("recovery_controls")
+    svc = service()
+    record = svc.run_store.run(run_id)
+    if record is None:
+        raise HTTPException(404, f"orchestration not found: {run_id}")
+    reported_worker = str(body.get("worker_id") or "")
+    recorded_worker = str(record.get("worker_id") or "")
+    if reported_worker and recorded_worker and reported_worker != recorded_worker:
+        return record
+    # This endpoint is called from the native Process termination handler.
+    # RunStore still verifies that the recorded owner PID is gone; once it is,
+    # a lease left behind by that dead process must not delay recovery for the
+    # scheduler's full expiry window.
+    svc.run_store.mark_abandoned()
+    updated = svc.run_store.run(run_id)
+    if updated is None:
+        raise HTTPException(404, f"orchestration not found: {run_id}")
+    return updated
 
 
 @app.post("/api/orchestrations/{run_id}/dispatch-decision")
@@ -1644,6 +1677,10 @@ async def _resume_orchestration(
     record = svc.run_store.run(run_id)
     if record is None:
         raise HTTPException(404, f"orchestration not found: {run_id}")
+    if not record.get("recoverable") or str(record.get("state") or "") not in {
+        "paused", "interrupted",
+    }:
+        raise HTTPException(409, "that orchestration is not in a recoverable state")
     if svc.busy:
         raise _busy_http()
     manifest = body.get("manifest")
@@ -1728,6 +1765,10 @@ def orchestration_recovery_assessment(
     if record is None:
         raise HTTPException(404, f"orchestration not found: {run_id}")
     repairs: list[str] = []
+    if not record.get("recoverable") or str(record.get("state") or "") not in {
+        "paused", "interrupted",
+    }:
+        repairs.append("This run is not paused or interrupted at a recoverable checkpoint.")
     checkpoint = record.get("checkpoint")
     state = checkpoint.get("state") if isinstance(checkpoint, dict) else None
     if record.get("legacy"):

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sqlite3
 import subprocess
 import threading
 import time
@@ -1975,6 +1976,90 @@ def test_cancel_interrupts_the_worker_that_owns_the_run(client, tmp_path):
         svc.active_run_id = None
         svc.cancel_requested_runs.discard(run_id)
         svc.core._interrupt.clear()
+
+
+def test_running_run_cannot_be_assessed_or_resumed_from_stale_recovery_flag(
+    client, tmp_path,
+):
+    svc = client.app.state.service
+    run_id = "stale-running-recovery"
+    svc.run_store.start_run(
+        run_id,
+        session_id=svc.core.session.session_id,
+        team_id="team-1",
+        team_name="Team",
+        worker_id=svc.worker_id,
+        workspace_root=str(tmp_path),
+        execution_path=str(tmp_path),
+        request="Build something",
+        manifest={},
+        state="running",
+    )
+    # Reproduce the pre-fix database combination loaded by Team Runs.
+    with sqlite3.connect(svc.run_store.path) as connection:
+        connection.execute(
+            "UPDATE runs SET recoverable=1, recovery_reason=? WHERE id=?",
+            ("Stale approval checkpoint.", run_id),
+        )
+
+    assessment = client.post(
+        f"/api/orchestrations/{run_id}/recovery-assessment",
+        json={"manifest": {}},
+    )
+    resume = client.post(
+        f"/api/orchestrations/{run_id}/resume",
+        json={"manifest": {}},
+    )
+    retry = client.post(
+        f"/api/orchestrations/{run_id}/jobs/job-1/retry",
+        json={"manifest": {}},
+    )
+    reassign = client.post(
+        f"/api/orchestrations/{run_id}/jobs/job-1/reassign",
+        json={"manifest": {}, "agent_id": "agent-2"},
+    )
+
+    assert assessment.status_code == 200
+    assert assessment.json()["can_resume"] is False
+    assert any(
+        "not paused or interrupted" in item
+        for item in assessment.json()["repair_checklist"]
+    )
+    assert resume.status_code == 409
+    assert retry.status_code == 409
+    assert reassign.status_code == 409
+    assert "not in a recoverable state" in resume.json()["detail"]
+    assert svc.run_store.run(run_id)["state"] == "running"
+
+
+def test_confirmed_worker_exit_makes_active_run_recoverable(client, tmp_path):
+    svc = client.app.state.service
+    run_id = "exited-worker-run"
+    svc.run_store.start_run(
+        run_id,
+        session_id=svc.core.session.session_id,
+        team_id="team-1",
+        team_name="Team",
+        worker_id="exited-worker",
+        workspace_root=str(tmp_path),
+        execution_path=str(tmp_path),
+        request="Build something",
+        manifest={},
+        state="running",
+    )
+    with sqlite3.connect(svc.run_store.path) as connection:
+        connection.execute(
+            "UPDATE runs SET owner_pid=? WHERE id=?", (999_999_999, run_id),
+        )
+
+    response = client.post(
+        f"/api/orchestrations/{run_id}/reconcile-worker-exit",
+        json={"worker_id": "exited-worker"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["state"] == "interrupted"
+    assert response.json()["recoverable"] is True
 
 
 def test_models_report_the_window_a_model_is_really_running_in(client, monkeypatch):

--- a/agent/tests/test_runstore.py
+++ b/agent/tests/test_runstore.py
@@ -5,6 +5,8 @@ import os
 import sqlite3
 import time
 
+import pytest
+
 from ollama_code.runstore import RunStore, sanitize_event
 
 
@@ -109,6 +111,63 @@ def test_live_owner_is_not_marked_abandoned(tmp_path) -> None:
     with sqlite3.connect(store.path) as connection:
         connection.execute("UPDATE runs SET owner_pid=? WHERE id='run-1'", (os.getpid(),))
     assert store.mark_abandoned() == []
+
+
+def test_live_state_event_clears_stale_recovery_metadata(tmp_path) -> None:
+    store = RunStore(tmp_path / "runs.sqlite3")
+    store.start_run("run-1", state="waiting_dispatch_approval")
+    store.set_state(
+        "run-1", "waiting_dispatch_approval", recoverable=True,
+        reason="Waiting for plan approval.",
+    )
+
+    store.append_event("run-1", {
+        "type": "orchestration_state", "state": "running",
+    })
+
+    run = store.run("run-1")
+    assert run["state"] == "running"
+    assert run["recoverable"] is False
+    assert run["recovery_reason"] is None
+
+    store.set_state(
+        "run-1", "running", recoverable=True,
+        reason="An older caller tried to restore stale recovery metadata.",
+    )
+    run = store.run("run-1")
+    assert run["recoverable"] is False
+    assert run["recovery_reason"] is None
+
+
+def test_pause_and_resume_transition_recovery_metadata(tmp_path) -> None:
+    store = RunStore(tmp_path / "runs.sqlite3")
+    store.start_run("run-1", state="running")
+    store.set_state("run-1", "paused", recoverable=True, reason="Saved checkpoint.")
+    assert store.run("run-1")["recoverable"] is True
+
+    store.append_event("run-1", {
+        "type": "orchestration_started", "state": "running", "resumed": True,
+    })
+
+    run = store.run("run-1")
+    assert run["recoverable"] is False
+    assert run["recovery_reason"] is None
+
+
+@pytest.mark.parametrize("event_type", ["permission_request", "computer_action_request"])
+def test_active_wait_clears_stale_recovery_metadata(tmp_path, event_type: str) -> None:
+    store = RunStore(tmp_path / "runs.sqlite3")
+    store.start_run("run-1", state="waiting_dispatch_approval")
+    store.set_state(
+        "run-1", "waiting_dispatch_approval", recoverable=True,
+        reason="Waiting for plan approval.",
+    )
+
+    store.append_event("run-1", {"type": event_type})
+
+    run = store.run("run-1")
+    assert run["recoverable"] is False
+    assert run["recovery_reason"] is None
 
 
 def test_active_scheduler_lease_prevents_abandoned_recovery(tmp_path) -> None:


### PR DESCRIPTION
## What changed

- made live worker state authoritative over stale durable recovery metadata
- restricted Resume, Retry, Reassign, and Discard to valid saved states
- coordinated Team Runs navigation and stabilized Picker selections
- routed active-run inspection through the owning worker
- restored the original header Team Progress popover
- added loopback readiness probing before health checks
- reconciled confirmed worker exits into durable, recoverable interruptions

## Root cause

Team Runs could combine a live running state with stale `recoverable` metadata from plan approval. Opening the inspector also triggered overlapping list/detail/event requests, while its Picker could temporarily select a run absent from the available tags. The observed `-1004` health error was normal startup timing before the local port began accepting connections.

## Validation

- backend: 409 tests passed
- native: 262 tests passed
- clean macOS build succeeded
- bundle: `io.sparktales.locus`, version `1.11.0`
- macOS UI scenarios updated but intentionally not executed
- disabled vLLM endpoint was not contacted
