### PR TITLE
Add managed ChatGPT plan support

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -31,14 +31,22 @@ mode `0600` inside a `0700` directory. In the sandboxed Mac App Store build the
 file lives in the app container instead. Earlier versions used the macOS login
 keychain.
 
+A ChatGPT-plan sign-in is separate. The bundled OpenAI Codex helper owns and
+refreshes its OAuth credentials in a file-backed, Locus-specific `CODEX_HOME`
+under `~/Library/Application Support/Locus/Codex` (or the app container).
+Locus does not copy those tokens into Swift state, `~/.locus/auth.json`, team
+manifests, transcripts, logs, or API-key provider routes.
+
 **File permissions keep those secrets from other user accounts on the Mac and
-from nothing else.** Any program running as you can read that file. There is no
-per-application access control and no authorization prompt — the keychain
-provided those and this deliberately does not. This is a known and accepted
-trade-off, not an oversight; please do not report it as a vulnerability. A
-report that Locus writes credentials somewhere *other* than that file, exposes
-them over the network, returns them from an API, or leaves them world-readable
-is very much in scope.
+from nothing else.** In the direct-download build, any program running as you
+can read either credential file. There is no per-application access control and
+no authorization prompt — the keychain provided those and these file-backed
+stores deliberately do not. This is a known and accepted trade-off, not an
+oversight; please do not report the documented storage choice alone as a
+vulnerability. A report that Locus exposes credentials over the network,
+returns them from an API, persists them outside the two documented stores, puts
+OAuth tokens into Locus-owned state, or leaves either file world-readable is
+very much in scope.
 
 ## Scope
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ artifacts/
 
 # Bundled agent runtime cache (downloaded standalone Python + deps)
 .agent-runtime/
+.codex-app-server/
 
 # Python (agent/)
 agent/.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@
 
 ### Added
 
+- **Use included ChatGPT-plan access without an API key.** A separate,
+  single-identity ChatGPT account opens OpenAI's managed browser sign-in,
+  discovers available models, routes solo chats, teams, and evaluations, and
+  shows plan rate limits plus token activity separately from API cost
+  estimates. The existing stored `codex` account remains backward compatible
+  and is now labelled **OpenAI API**. There is no dependency on an installed or
+  running ChatGPT/Codex app, and the managed route never falls back to a
+  billable API key.
+- **A pinned Codex App Server bridge that keeps Locus in control.** Locus builds
+  and signs OpenAI Codex `rust-v0.147.0` plus its companion code-mode host from
+  checksum-pinned source and V8 inputs, isolates file-backed OAuth state, and
+  exposes only Locus's current tools through dynamic tools and its existing
+  permission system. A primary-backend broker multiplexes team workers without
+  sharing OAuth credentials. Models, usage, interruptions, failures, thread
+  resume, and provider-supplied reasoning summaries map into Locus's existing
+  UI and transcript model; raw private reasoning is ignored.
+- **Account fields and Settings handoff now behave naturally.** Clicking
+  anywhere across Name, URL, API-key, or context-window rows focuses the field,
+  and typing or pasting starts at the left and advances left-to-right. Browse
+  Hugging Face Models dismisses either Settings presentation and opens the
+  library immediately. The Browser's compact control bar now sits above its
+  tabs, keeping tabs adjacent to the address bar they control.
+
 - **The browser got fast.** Three real defects made every page slow. Every
   navigation carried a forced hard-reload cache policy inherited from the old
   dev-server Preview pane — WebKit propagates it to every subresource, so each

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,11 @@ change will be overwritten.
 - **Never commit credentials.** API keys belong in `~/.locus/auth.json`, written
   mode `0600` through `CredentialStore`, and reach the agent in memory only.
   Nothing key-bearing may reach the agent's `config.json`, a session transcript,
-  `UserDefaults`, or any API response. That file is the *only* place a secret is
-  persisted — if you add a new kind of credential, put it there rather than
-  inventing a second store.
+  `UserDefaults`, or any API response. Managed ChatGPT OAuth is the only
+  exception: the bundled Codex helper owns it in Locus's isolated
+  file-backed `CODEX_HOME`; Locus code must never read, copy, log, or pass those
+  tokens through API-key routes. Any new credential store needs an explicit
+  threat-model and documentation update.
 
 ## Reporting a security issue
 

--- a/Config/CodexCodeModeHost.entitlements
+++ b/Config/CodexCodeModeHost.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+</dict>
+</plist>

--- a/Config/CodexCodeModeHostSandbox.entitlements
+++ b/Config/CodexCodeModeHostSandbox.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.inherit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+</dict>
+</plist>

--- a/Locus/AccountEditorView.swift
+++ b/Locus/AccountEditorView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Adds or edits one provider account.
@@ -20,10 +21,19 @@ struct AccountEditorView: View {
     @State private var testResult: String?
     @State private var testFailed = false
     @State private var contextWindow = ""
+    @State private var focusedField: FocusedField?
+
+    private enum FocusedField: Hashable {
+        case name
+        case baseURL
+        case apiKey
+        case contextWindow
+    }
 
     private var kind: ProviderKind { account.kind }
 
     private var canSave: Bool {
+        if kind == .chatGPT { return true }
         // A key is required to reach a provider; an endpoint that has one
         // saved already does not need it typed again.
         let hasKey = keyStored || !apiKey.trimmingCharacters(in: .whitespaces).isEmpty
@@ -49,7 +59,9 @@ struct AccountEditorView: View {
                     Text(isNew ? "Add \(kind.marketingName) Account" : "Edit \(account.displayName)")
                         .font(.system(size: 16, weight: .bold))
                     Text(
-                        kind.vendorName.isEmpty
+                        kind == .chatGPT
+                            ? "Use included usage from your ChatGPT plan"
+                            : kind.vendorName.isEmpty
                             ? "An OpenAI-compatible endpoint"
                             : "Models served by \(kind.vendorName)"
                     )
@@ -73,23 +85,36 @@ struct AccountEditorView: View {
 
             Form {
                 Section("Account") {
-                    TextField("Name (e.g. Work)", text: $name)
-                        .accessibilityIdentifier("accountEditor.name")
+                    inputRow(
+                        prompt: "Name (e.g. Work)",
+                        text: $name,
+                        field: .name,
+                        identifier: "accountEditor.name"
+                    )
 
                     Text("Names tell two accounts for the same provider apart in the model picker.")
                         .font(.system(size: 9))
                         .foregroundStyle(LocusTheme.muted)
 
-                    if kind.allowsBaseURLOverride {
-                        TextField("https://api.example.com/v1", text: $baseURL)
-                            .accessibilityIdentifier("accountEditor.baseURL")
-                    }
+                    if kind == .chatGPT {
+                        chatGPTControls
+                    } else {
+                        if kind.allowsBaseURLOverride {
+                            inputRow(
+                                prompt: "https://api.example.com/v1",
+                                text: $baseURL,
+                                field: .baseURL,
+                                identifier: "accountEditor.baseURL"
+                            )
+                        }
 
-                    SecureField(
-                        keyStored && apiKey.isEmpty ? "Saved on this Mac" : kind.keyPlaceholder,
-                        text: $apiKey
+                    inputRow(
+                        prompt: keyStored && apiKey.isEmpty ? "Saved on this Mac" : kind.keyPlaceholder,
+                        text: $apiKey,
+                        field: .apiKey,
+                        identifier: "accountEditor.apiKey",
+                        secure: true
                     )
-                    .accessibilityIdentifier("accountEditor.apiKey")
 
                     if !kind.keyDocsURL.isEmpty, let url = URL(string: kind.keyDocsURL) {
                         Link("Get an API key from \(kind.vendorName)", destination: url)
@@ -110,11 +135,12 @@ struct AccountEditorView: View {
                         }
                     }
 
-                    TextField(
-                        windowPlaceholder,
-                        text: $contextWindow
+                    inputRow(
+                        prompt: windowPlaceholder,
+                        text: $contextWindow,
+                        field: .contextWindow,
+                        identifier: "accountEditor.contextWindow"
                     )
-                    .accessibilityIdentifier("accountEditor.contextWindow")
 
                     Text(windowHelp)
                         .font(.system(size: 9))
@@ -151,6 +177,7 @@ struct AccountEditorView: View {
                         .font(.system(size: 9))
                         .foregroundStyle(LocusTheme.muted)
                         .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
             }
             .formStyle(.grouped)
@@ -177,7 +204,106 @@ struct AccountEditorView: View {
             baseURL = account.baseURLOverride ?? ""
             keyStored = account.hasKey
             contextWindow = account.contextWindow.map(String.init) ?? ""
+            if kind == .chatGPT {
+                Task { await model.refreshChatGPTAccount() }
+            }
         }
+    }
+
+    @ViewBuilder
+    private var chatGPTControls: some View {
+        let status = model.chatGPTAccount
+        VStack(alignment: .leading, spacing: 10) {
+            if let status, status.status == "signed_in" {
+                Label("Signed in", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(LocusTheme.success)
+                if let email = status.email, !email.isEmpty {
+                    Text(email).font(.system(size: 10, weight: .semibold))
+                }
+                if let plan = status.planType, !plan.isEmpty {
+                    Text("\(plan.replacingOccurrences(of: "_", with: " ").capitalized) plan")
+                        .font(.system(size: 9))
+                        .foregroundStyle(LocusTheme.muted)
+                }
+                HStack {
+                    Button("Refresh") {
+                        Task { await model.refreshChatGPTAccount(forceTokenRefresh: true) }
+                    }
+                    Button("Sign Out") {
+                        Task { await model.signOutChatGPT() }
+                    }
+                }
+            } else if model.chatGPTLoginID != nil {
+                Label("Finish signing in in your browser", systemImage: "safari")
+                    .font(.system(size: 10, weight: .semibold))
+                HStack {
+                    Button("Refresh Status") {
+                        Task { await model.refreshChatGPTAccount() }
+                    }
+                    Button("Cancel Login") {
+                        Task { await model.cancelChatGPTLogin() }
+                    }
+                }
+            } else {
+                if let message = status?.message, !message.isEmpty {
+                    Text(message)
+                        .font(.system(size: 9))
+                        .foregroundStyle(LocusTheme.muted)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Button("Sign in with ChatGPT") {
+                    Task { await model.startChatGPTLogin() }
+                }
+                .disabled(status?.runtimeAvailable == false)
+                .accessibilityIdentifier("accountEditor.chatGPT.signIn")
+            }
+
+            Text(
+                "Authentication is managed by OpenAI's bundled agent runtime. "
+                + "Locus never reads or stores its OAuth tokens, and this route never falls back to paid API usage."
+            )
+            .font(.system(size: 9))
+            .foregroundStyle(LocusTheme.muted)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// macOS `Form` treats a text field's title as a leading form label and
+    /// places the actual editor in the trailing column. Keep the prompt inside
+    /// one full-width editor and make the complete row focus it.
+    @ViewBuilder
+    private func inputRow(
+        prompt: String,
+        text: Binding<String>,
+        field: FocusedField,
+        identifier: String,
+        secure: Bool = false
+    ) -> some View {
+        HStack(spacing: 0) {
+            LeadingAccountTextField(
+                text: text,
+                prompt: prompt,
+                secure: secure,
+                isFocused: Binding(
+                    get: { focusedField == field },
+                    set: { wantsFocus in
+                        if wantsFocus {
+                            focusedField = field
+                        } else if focusedField == field {
+                            focusedField = nil
+                        }
+                    }
+                ),
+                identifier: identifier
+            )
+            .frame(maxWidth: .infinity, minHeight: 22, alignment: .leading)
+            .accessibilityLabel(prompt)
+            .accessibilityIdentifier(identifier)
+        }
+        .frame(maxWidth: .infinity, minHeight: 22, alignment: .leading)
+        .contentShape(Rectangle())
+        .onTapGesture { focusedField = field }
     }
 
     private var windowPlaceholder: String {
@@ -202,6 +328,18 @@ struct AccountEditorView: View {
     }
 
     private func save() {
+        if kind == .chatGPT {
+            var updated = account
+            updated.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if updated.preferredModel.isEmpty {
+                updated.preferredModel = kind.probeModel
+            }
+            updated.baseURLOverride = nil
+            updated.contextWindow = nil
+            model.saveProviderAccount(updated, apiKey: nil)
+            dismiss()
+            return
+        }
         let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         let effectiveKey = trimmedKey.isEmpty && keyStored ? "saved-key" : trimmedKey
         if let error = RemoteEndpointTester.securityError(
@@ -247,6 +385,94 @@ struct AccountEditorView: View {
             isTesting = false
             testFailed = !outcome.ok
             testResult = outcome.message
+        }
+    }
+}
+
+/// SwiftUI's macOS `Form` can hand its shared field editor the row's trailing
+/// alignment even when the `TextField` says `.leading`. Configure the native
+/// editor directly so the caret, typing, and pasted text always originate on
+/// the left and advance toward the right.
+private struct LeadingAccountTextField: NSViewRepresentable {
+    @Binding var text: String
+    let prompt: String
+    let secure: Bool
+    @Binding var isFocused: Bool
+    let identifier: String
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: LeadingAccountTextField
+
+        init(parent: LeadingAccountTextField) {
+            self.parent = parent
+        }
+
+        func controlTextDidBeginEditing(_ notification: Notification) {
+            parent.isFocused = true
+            guard let editor = notification.userInfo?["NSFieldEditor"] as? NSTextView else { return }
+            Self.configure(editor: editor)
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let field = notification.object as? NSTextField else { return }
+            parent.text = field.stringValue
+        }
+
+        func controlTextDidEndEditing(_ notification: Notification) {
+            guard let field = notification.object as? NSTextField else { return }
+            parent.text = field.stringValue
+            parent.isFocused = false
+        }
+
+        static func configure(editor: NSTextView) {
+            editor.alignment = .left
+            editor.baseWritingDirection = .leftToRight
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSTextField {
+        let field: NSTextField = secure ? NSSecureTextField() : NSTextField()
+        field.delegate = context.coordinator
+        field.isBezeled = false
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.usesSingleLineMode = true
+        field.lineBreakMode = .byClipping
+        field.alignment = .left
+        field.baseWritingDirection = .leftToRight
+        field.userInterfaceLayoutDirection = .leftToRight
+        field.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return field
+    }
+
+    func updateNSView(_ field: NSTextField, context: Context) {
+        context.coordinator.parent = self
+        field.placeholderString = prompt
+        field.setAccessibilityLabel(prompt)
+        field.setAccessibilityIdentifier(identifier)
+        field.alignment = .left
+        field.baseWritingDirection = .leftToRight
+        field.userInterfaceLayoutDirection = .leftToRight
+
+        if field.stringValue != text {
+            field.stringValue = text
+        }
+
+        if let editor = field.currentEditor() as? NSTextView {
+            Coordinator.configure(editor: editor)
+        } else if isFocused {
+            DispatchQueue.main.async { [weak field] in
+                guard let field, field.window?.makeFirstResponder(field) == true else { return }
+                if let editor = field.currentEditor() as? NSTextView {
+                    Coordinator.configure(editor: editor)
+                }
+            }
         }
     }
 }

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -93,6 +93,9 @@ final class AppModel: ObservableObject {
     @Published private(set) var providerAccounts: [ProviderAccount] = []
     @Published private(set) var accountModels: [UUID: [String]] = [:]
     @Published private(set) var accountStatus: [UUID: ProviderAccountStatus] = [:]
+    @Published private(set) var chatGPTAccount: ChatGPTAccountResponse?
+    @Published private(set) var chatGPTUsage: ChatGPTUsageResponse?
+    @Published private(set) var chatGPTLoginID: String?
     @Published private(set) var agentProfiles: [AgentProfile] = []
     @Published private(set) var agentTeams: [AgentTeam] = []
     @Published private(set) var teamRoutingConsentAccountIDs: Set<UUID> = []
@@ -266,6 +269,7 @@ final class AppModel: ObservableObject {
     @Published var usageSummary: UsageSummary?
     @Published var settingsPage: SettingsPage = .general
     @Published var modelLibraryPresented = false
+    private var modelLibraryPendingSettingsDismissal = false
     @Published var commandPalettePresented = false
     @Published var checkpointPresented = false
     @Published var clearChatConfirmationPresented = false
@@ -2265,8 +2269,23 @@ final class AppModel: ObservableObject {
         guard !due.isEmpty else { return }
         let now = Date()
         for account in due { accountCatalogFetchedAt[account.id] = now }
+        for account in due where account.kind == .chatGPT {
+            do {
+                let response = try await backend.get(
+                    "/api/chatgpt/models",
+                    as: ChatGPTModelsResponse.self
+                )
+                let names = response.models.map(\.id)
+                accountModels[account.id] = names.isEmpty ? account.kind.curatedModels : names
+                await refreshChatGPTAccount()
+            } catch {
+                accountModels[account.id] = account.kind.curatedModels
+                accountStatus[account.id] = .runtimeUnavailable(error.localizedDescription)
+            }
+        }
+        let endpointAccounts = due.filter { $0.kind != .chatGPT }
         await withTaskGroup(of: (UUID, ProviderModelCatalog.Result).self) { group in
-            for account in due {
+            for account in endpointAccounts {
                 group.addTask { (account.id, await ProviderModelCatalog.fetch(for: account)) }
             }
             for await (id, result) in group {
@@ -3270,14 +3289,22 @@ final class AppModel: ObservableObject {
                 guard let account = providerAccounts.first(where: { $0.id == accountID }),
                       account.hasKey
                 else { return nil }
-                route = [
-                    "provider": "remote",
-                    "base_url": account.resolvedBaseURL,
-                    "api_key": CredentialStore.get(account: account.keychainAccount) ?? "",
-                    "auth_style": account.kind.authStyle,
-                    "lists_models": account.kind.listsModels,
-                    "account_label": account.displayName,
-                ]
+                if account.kind == .chatGPT {
+                    route = [
+                        "provider": "chatgpt",
+                        "account_id": account.id.uuidString,
+                        "account_label": account.displayName,
+                    ]
+                } else {
+                    route = [
+                        "provider": "remote",
+                        "base_url": account.resolvedBaseURL,
+                        "api_key": CredentialStore.get(account: account.keychainAccount) ?? "",
+                        "auth_style": account.kind.authStyle,
+                        "lists_models": account.kind.listsModels,
+                        "account_label": account.displayName,
+                    ]
+                }
             }
             var entry: [String: Any] = [
                 "id": profile.id.uuidString,
@@ -3289,7 +3316,9 @@ final class AppModel: ObservableObject {
                 "access_ceiling": profile.accessCeiling.rawValue,
                 "timeout_seconds": profile.timeoutSeconds,
                 "token_limit": profile.tokenLimit,
-                "metering": profile.metering.rawValue,
+                "metering": route["provider"] as? String == "chatgpt"
+                    ? AgentMetering.selfHosted.rawValue
+                    : profile.metering.rawValue,
                 "route": route,
             ]
             if let rate = profile.inputCostPerMillion { entry["input_cost_per_million"] = rate }
@@ -4340,13 +4369,20 @@ final class AppModel: ObservableObject {
     /// editor so an abandoned sheet leaves nothing behind; `apiKey` nil means
     /// "keep the saved one".
     func saveProviderAccount(_ account: ProviderAccount, apiKey: String?) {
-        let effectiveKey = apiKey ?? CredentialStore.get(account: account.keychainAccount) ?? ""
-        if let error = RemoteEndpointTester.securityError(
-            baseURL: account.resolvedBaseURL,
-            apiKey: effectiveKey
-        ) {
-            showToast(error)
-            return
+        if account.kind == .chatGPT {
+            if providerAccounts.contains(where: { $0.kind == .chatGPT && $0.id != account.id }) {
+                showToast("Only one ChatGPT plan account can be added")
+                return
+            }
+        } else {
+            let effectiveKey = apiKey ?? CredentialStore.get(account: account.keychainAccount) ?? ""
+            if let error = RemoteEndpointTester.securityError(
+                baseURL: account.resolvedBaseURL,
+                apiKey: effectiveKey
+            ) {
+                showToast(error)
+                return
+            }
         }
         var updated = account
         updated.name = ProviderAccountStore.uniqueName(
@@ -4360,7 +4396,7 @@ final class AppModel: ObservableObject {
         } else {
             providerAccounts.append(updated)
         }
-        if let apiKey {
+        if let apiKey, updated.kind.requiresAPIKey {
             CredentialStore.set(apiKey, account: updated.keychainAccount)
         }
         persistProviderAccounts()
@@ -4374,6 +4410,122 @@ final class AppModel: ObservableObject {
             }
         }
         showToast("Saved \(updated.displayName)")
+    }
+
+    func refreshChatGPTAccount(forceTokenRefresh: Bool = false) async {
+        let query = forceTokenRefresh
+            ? [URLQueryItem(name: "refresh", value: "true")]
+            : []
+        do {
+            let state = try await backend.get(
+                "/api/chatgpt/account",
+                query: query,
+                as: ChatGPTAccountResponse.self
+            )
+            chatGPTAccount = state
+            let status: ProviderAccountStatus = switch state.status {
+            case "signed_in": .signedIn(email: state.email, plan: state.planType)
+            case "runtime_unavailable":
+                .runtimeUnavailable(state.message ?? "The ChatGPT runtime is unavailable")
+            case "signing_in": .signingIn
+            default: .signedOut
+            }
+            for account in providerAccounts where account.kind == .chatGPT {
+                accountStatus[account.id] = status
+            }
+            if state.status == "signed_in" {
+                chatGPTLoginID = nil
+                await refreshChatGPTUsage()
+            }
+        } catch {
+            let status = ProviderAccountStatus.runtimeUnavailable(error.localizedDescription)
+            for account in providerAccounts where account.kind == .chatGPT {
+                accountStatus[account.id] = status
+            }
+        }
+    }
+
+    func startChatGPTLogin() async {
+        do {
+            let response = try await backend.post(
+                "/api/chatgpt/login/start",
+                body: [:],
+                as: ChatGPTLoginResponse.self
+            )
+            chatGPTLoginID = response.loginID
+            for account in providerAccounts where account.kind == .chatGPT {
+                accountStatus[account.id] = .signingIn
+            }
+            guard let url = URL(string: response.authURL), NSWorkspace.shared.open(url) else {
+                showToast("Could not open the ChatGPT sign-in page")
+                return
+            }
+        } catch {
+            showToast("Could not start ChatGPT sign-in: \(error.localizedDescription)")
+            await refreshChatGPTAccount()
+        }
+    }
+
+    func cancelChatGPTLogin() async {
+        guard let loginID = chatGPTLoginID else { return }
+        do {
+            let state = try await backend.post(
+                "/api/chatgpt/login/cancel",
+                body: ["login_id": loginID],
+                as: ChatGPTAccountResponse.self
+            )
+            chatGPTLoginID = nil
+            chatGPTAccount = state
+            await refreshChatGPTAccount()
+        } catch {
+            showToast("Could not cancel ChatGPT sign-in: \(error.localizedDescription)")
+        }
+    }
+
+    func signOutChatGPT() async {
+        do {
+            let state = try await backend.post(
+                "/api/chatgpt/logout",
+                body: [:],
+                as: ChatGPTAccountResponse.self
+            )
+            chatGPTAccount = state
+            chatGPTLoginID = nil
+            for account in providerAccounts where account.kind == .chatGPT {
+                accountStatus[account.id] = .signedOut
+            }
+            if activeAccount?.kind == .chatGPT {
+                settings.activeAccountID = nil
+                await applyProvider(announce: false)
+            }
+        } catch {
+            showToast("Could not sign out of ChatGPT: \(error.localizedDescription)")
+        }
+    }
+
+    func refreshChatGPTUsage() async {
+        guard providerAccounts.contains(where: { $0.kind == .chatGPT }) else {
+            chatGPTUsage = nil
+            return
+        }
+        do {
+            let usage = try await backend.get(
+                "/api/chatgpt/usage",
+                as: ChatGPTUsageResponse.self
+            )
+            chatGPTUsage = usage
+            if let window = usage.rateLimits.rateLimits?.primary,
+               window.usedPercent >= 100
+            {
+                let reset = window.resetsAt.map { Date(timeIntervalSince1970: Double($0)) }
+                for account in providerAccounts where account.kind == .chatGPT {
+                    accountStatus[account.id] = .rateLimited(resetAt: reset)
+                }
+            }
+        } catch {
+            // Usage is supplementary; the account and working providers stay
+            // available when this one read fails.
+        }
     }
 
     /// Removes an account, its key, and — if it was the one in use — the
@@ -5385,6 +5537,14 @@ final class AppModel: ObservableObject {
             body["context_window"] = settings.localContextWindow ?? 0
             return body
         }
+        if account.kind == .chatGPT {
+            return [
+                "provider": "chatgpt",
+                "account_id": account.id.uuidString,
+                "account_label": account.displayName,
+                "model": account.preferredModel,
+            ]
+        }
         return [
             "provider": "remote",
             "base_url": account.resolvedBaseURL,
@@ -5417,7 +5577,7 @@ final class AppModel: ObservableObject {
     /// writes it to its own config, so it is re-sent on every launch.
     func applyProvider(verify: Bool = false, announce: Bool = true) async {
         let account = activeAccount
-        if let account, account.resolvedBaseURL.isEmpty {
+        if let account, account.kind != .chatGPT, account.resolvedBaseURL.isEmpty {
             if announce {
                 showToast("Add the endpoint URL for \(account.displayName) in Settings")
             }
@@ -5450,7 +5610,7 @@ final class AppModel: ObservableObject {
             }
             guard announce else { return }
             showToast(
-                state.provider == "remote"
+                state.provider == "remote" || state.provider == "chatgpt"
                     ? "Using \(account?.displayName ?? shortHost(state.host))"
                     : "Using local Ollama"
             )
@@ -6421,6 +6581,19 @@ final class AppModel: ObservableObject {
         handle(event)
     }
 
+    /// SwiftUI queues a sibling sheet while Settings is still visible. Record
+    /// the destination and complete the handoff from the dismissal callback.
+    func openModelLibraryFromSettings() {
+        modelLibraryPendingSettingsDismissal = true
+        settingsPresented = false
+    }
+
+    func completeSettingsDismissal() {
+        guard modelLibraryPendingSettingsDismissal else { return }
+        modelLibraryPendingSettingsDismissal = false
+        modelLibraryPresented = true
+    }
+
     static func migrateLegacyBuildProfiles(_ profiles: [WorkspaceProfile]) -> [WorkspaceProfile] {
         profiles.map { profile in
             guard profile.mode == .build else { return profile }
@@ -6445,6 +6618,16 @@ final class AppModel: ObservableObject {
             ollamaHost: lastOllamaHost
         )
         workerEnvironment["LOCUS_MODEL_CALL_LIMIT"] = String(globalAgentConcurrency)
+        var brokerComponents = URLComponents(
+            url: backend.currentBaseURL,
+            resolvingAgainstBaseURL: false
+        )
+        brokerComponents?.scheme = backend.currentBaseURL.scheme == "https" ? "wss" : "ws"
+        brokerComponents?.path = "/ws/internal/codex"
+        if let brokerURL = brokerComponents?.url?.absoluteString {
+            workerEnvironment["LOCUS_CODEX_BROKER_URL"] = brokerURL
+            workerEnvironment["LOCUS_CODEX_BROKER_TOKEN"] = BackendSecurity.launchToken
+        }
         let launch = process.start(
             root: settings.backendRoot,
             port: 0,
@@ -6799,6 +6982,15 @@ final class AppModel: ObservableObject {
             orchestrationEvents.sort { $0.sequence < $1.sequence }
         }
         switch type {
+        case "chatgpt_account_updated":
+            Task {
+                await refreshChatGPTAccount()
+                await refreshAccountCatalogs(force: true)
+            }
+
+        case "chatgpt_usage_updated":
+            Task { await refreshChatGPTUsage() }
+
         case "worker_identity":
             activeWorkerID = event["worker_id"] as? String
 

--- a/Locus/BackendProcess.swift
+++ b/Locus/BackendProcess.swift
@@ -85,20 +85,30 @@ final class BackendProcess {
         // written there at import time would invalidate the code signature,
         // so byte-code writing must stay off no matter where we run from.
         environment["PYTHONDONTWRITEBYTECODE"] = "1"
-        if WorkspaceAccess.isSandboxed,
-           let support = FileManager.default.urls(
+        if let support = FileManager.default.urls(
                for: .applicationSupportDirectory,
                in: .userDomainMask
            ).first
         {
-            let agentHome = support
-                .appending(path: "Locus", directoryHint: .isDirectory)
-                .appending(path: "Agent", directoryHint: .isDirectory)
+            let locusSupport = support.appending(path: "Locus", directoryHint: .isDirectory)
+            let agentHome = locusSupport.appending(path: "Agent", directoryHint: .isDirectory)
+            let codexHome = locusSupport.appending(path: "Codex", directoryHint: .isDirectory)
             try? FileManager.default.createDirectory(
                 at: agentHome,
                 withIntermediateDirectories: true
             )
-            environment["OLLAMA_CODE_HOME"] = agentHome.path
+            try? FileManager.default.createDirectory(
+                at: codexHome,
+                withIntermediateDirectories: true
+            )
+            if WorkspaceAccess.isSandboxed {
+                environment["OLLAMA_CODE_HOME"] = agentHome.path
+            }
+            environment["LOCUS_CODEX_HOME"] = codexHome.path
+        }
+        let helper = Bundle.main.bundleURL.appending(path: "Contents/Helpers/codex")
+        if FileManager.default.isExecutableFile(atPath: helper.path) {
+            environment["LOCUS_CODEX_APP_SERVER_PATH"] = helper.path
         }
         if let packages = launch.packages {
             environment["PYTHONPATH"] = [

--- a/Locus/InspectorBrowserTab.swift
+++ b/Locus/InspectorBrowserTab.swift
@@ -65,8 +65,8 @@ struct BrowserPanel: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            tabChips
             controlsBar
+            tabChips
             toolbar
             progressLine
             content
@@ -389,8 +389,8 @@ struct BrowserPanel: View {
     }
 
     /// Viewport, capture, drawer, open-external and expand — one compact bar
-    /// between the tab chips and the address bar, so all of the browser's
-    /// chrome lives at the top and the page owns everything below it.
+    /// at the very top, above the tab chips, so the chips sit directly on the
+    /// address bar they steer and the page owns everything below.
     private var controlsBar: some View {
         HStack(spacing: 8) {
             Menu {

--- a/Locus/InspectorChangesTab.swift
+++ b/Locus/InspectorChangesTab.swift
@@ -489,6 +489,14 @@ private struct GitChangeRow: View {
                             .foregroundStyle(LocusTheme.blue)
                             .lineLimit(1)
                             .truncationMode(.tail)
+                            // Keep the list marker on one leaf. Applying it to
+                            // the outer VStack makes AppKit inherit that ID onto
+                            // every hunk button and hides their stage/discard IDs.
+                            .accessibilityIdentifier(
+                                position == 0
+                                    ? "changes.file.\(index).hunks"
+                                    : "changes.file.\(index).hunk.\(position).header"
+                            )
                         Spacer(minLength: 4)
                         if model.selectedChangeShowsStaged {
                             hunkButton(
@@ -526,7 +534,6 @@ private struct GitChangeRow: View {
             }
         }
         .disabled(model.isPerformingGitAction)
-        .accessibilityIdentifier("changes.file.\(index).hunks")
     }
 
     private func hunkButton(

--- a/Locus/LocusApp.swift
+++ b/Locus/LocusApp.swift
@@ -124,7 +124,7 @@ struct LocusApp: App {
         }
 
         Settings {
-            SettingsView()
+            SettingsView(presentationContext: .settingsWindow)
                 .environmentObject(model)
         }
     }
@@ -332,8 +332,10 @@ struct RootView: View {
             CheckpointSheet()
                 .environmentObject(model)
         }
-        .sheet(isPresented: $model.settingsPresented) {
-            SettingsView()
+        .sheet(isPresented: $model.settingsPresented, onDismiss: {
+            model.completeSettingsDismissal()
+        }) {
+            SettingsView(presentationContext: .sheet)
                 .environmentObject(model)
         }
         .sheet(isPresented: $model.usageDashboardPresented) {

--- a/Locus/Models.swift
+++ b/Locus/Models.swift
@@ -1755,6 +1755,96 @@ struct ProviderStateResponse: Codable {
     }
 }
 
+struct ChatGPTAccountResponse: Codable, Hashable {
+    let status: String
+    let runtimeAvailable: Bool
+    let runtimeVersion: String?
+    let email: String?
+    let planType: String?
+    let message: String?
+
+    enum CodingKeys: String, CodingKey {
+        case status, email, message
+        case runtimeAvailable = "runtime_available"
+        case runtimeVersion = "runtime_version"
+        case planType = "plan_type"
+    }
+}
+
+struct ChatGPTLoginResponse: Codable, Hashable {
+    let status: String
+    let loginID: String
+    let authURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case loginID = "login_id"
+        case authURL = "auth_url"
+    }
+}
+
+struct ChatGPTModelsResponse: Codable, Hashable {
+    struct Model: Codable, Hashable, Identifiable {
+        let id: String
+        let displayName: String
+        let description: String
+        let isDefault: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case id, description
+            case displayName = "display_name"
+            case isDefault = "is_default"
+        }
+    }
+
+    let status: String
+    let models: [Model]
+    let message: String?
+}
+
+struct ChatGPTUsageResponse: Codable, Hashable {
+    struct Window: Codable, Hashable {
+        let usedPercent: Int
+        let resetsAt: Int?
+        let windowDurationMins: Int?
+    }
+
+    struct Snapshot: Codable, Hashable {
+        let planType: String?
+        let primary: Window?
+        let secondary: Window?
+        let spendControlReached: Bool?
+    }
+
+    struct RateLimits: Codable, Hashable {
+        let rateLimits: Snapshot?
+    }
+
+    struct ActivitySummary: Codable, Hashable {
+        let lifetimeTokens: Int?
+        let peakDailyTokens: Int?
+        let longestRunningTurnSec: Int?
+        let currentStreakDays: Int?
+        let longestStreakDays: Int?
+    }
+
+    struct Activity: Codable, Hashable {
+        let summary: ActivitySummary?
+    }
+
+    let status: String
+    let planType: String?
+    let rateLimits: RateLimits
+    let activity: Activity
+    let message: String?
+
+    enum CodingKeys: String, CodingKey {
+        case status, activity, message
+        case planType = "plan_type"
+        case rateLimits = "rate_limits"
+    }
+}
+
 struct WorkspaceProfile: Identifiable, Codable, Hashable {
     var id: String { path }
     let path: String

--- a/Locus/ProviderAccounts.swift
+++ b/Locus/ProviderAccounts.swift
@@ -6,6 +6,10 @@ import Foundation
 /// protocol. The agent adapter hides that difference from the rest of the app.
 enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     case claude
+    /// OpenAI-managed ChatGPT subscription access. Authentication and model
+    /// traffic stay inside the bundled Codex App Server helper; this is never
+    /// interchangeable with an API key account.
+    case chatGPT = "chatgpt"
     case codex
     case kimi
     /// Moonshot's coding service, billed through a Kimi membership rather than
@@ -23,7 +27,8 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var marketingName: String {
         switch self {
         case .claude: "Claude"
-        case .codex: "Codex"
+        case .chatGPT: "ChatGPT plan"
+        case .codex: "OpenAI API"
         case .kimi: "Kimi"
         case .kimiCode: "Kimi Code"
         case .custom: "Custom endpoint"
@@ -34,7 +39,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var vendorName: String {
         switch self {
         case .claude: "Anthropic"
-        case .codex: "OpenAI"
+        case .chatGPT, .codex: "OpenAI"
         case .kimi, .kimiCode: "Moonshot AI"
         case .custom: ""
         }
@@ -47,6 +52,9 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var defaultBaseURL: String {
         switch self {
         case .claude: "https://api.anthropic.com/v1"
+        // A display/documentation origin only. Managed ChatGPT traffic never
+        // uses this as an inference endpoint.
+        case .chatGPT: "https://chatgpt.com"
         case .codex: "https://api.openai.com/v1"
         case .kimi: "https://api.moonshot.ai/v1"
         case .kimiCode: "https://api.kimi.com/coding/v1"
@@ -58,6 +66,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var keyDocsURL: String {
         switch self {
         case .claude: "https://console.anthropic.com/settings/keys"
+        case .chatGPT: "https://learn.chatgpt.com/docs/auth#openai-authentication"
         case .codex: "https://platform.openai.com/api-keys"
         case .kimi: "https://platform.moonshot.ai/console/api-keys"
         case .kimiCode: "https://www.kimi.com/code/docs/en/"
@@ -68,6 +77,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var keyPlaceholder: String {
         switch self {
         case .claude: "sk-ant-…"
+        case .chatGPT: ""
         case .codex, .kimi: "sk-…"
         // Moonshot documents no prefix for these; guessing one would contradict
         // what the user is about to paste.
@@ -81,9 +91,14 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var authStyle: String {
         switch self {
         case .claude: "anthropic"
+        case .chatGPT: "managed"
         case .codex, .kimi, .kimiCode, .custom: "bearer"
         }
     }
+
+    var requiresAPIKey: Bool { self != .chatGPT }
+
+    var usesManagedChatGPTAuthentication: Bool { self == .chatGPT }
 
     /// Whether `GET {base}/models` is a route this provider actually serves.
     ///
@@ -102,6 +117,8 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .claude:
             ["claude-opus-5", "claude-sonnet-5", "claude-fable-5", "claude-haiku-4-5"]
+        case .chatGPT:
+            ["gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-max"]
         case .codex:
             ["gpt-5.6", "gpt-5", "gpt-5-mini", "gpt-4.1", "o3"]
         case .kimi:
@@ -140,7 +157,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
             if name.contains("haiku-4-5") { return 200_000 }
             if name.hasPrefix("claude-") && name.contains("-4") { return 200_000 }
             return nil
-        case .codex:
+        case .chatGPT, .codex:
             if name == "gpt-5.6" || name.hasPrefix("gpt-5.6-") { return 1_050_000 }
             if name == "gpt-5" || name.hasPrefix("gpt-5-") { return 400_000 }
             if name.hasPrefix("gpt-4.1") { return 1_047_576 }
@@ -199,7 +216,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
                 linkTitle: "",
                 linkURL: ""
             )
-        case .codex, .custom:
+        case .chatGPT, .codex, .custom:
             nil
         }
     }
@@ -242,7 +259,7 @@ enum ProviderModelFilter {
         switch kind {
         case .claude:
             return lowered.hasPrefix("claude")
-        case .codex:
+        case .chatGPT, .codex:
             return codexPrefixes.contains { lowered.hasPrefix($0) }
         case .kimi:
             return lowered.hasPrefix("kimi") || lowered.hasPrefix("moonshot")
@@ -340,7 +357,10 @@ struct ProviderAccount: Identifiable, Codable, Hashable {
         legacyKeychainAccount ?? CredentialStore.providerAccountKey(id)
     }
 
-    var hasKey: Bool { CredentialStore.has(account: keychainAccount) }
+    var hasKey: Bool {
+        kind.usesManagedChatGPTAuthentication
+            || CredentialStore.has(account: keychainAccount)
+    }
 
     /// The window to budget this account against: what the user set, else
     /// the provider's published figure for the selected model, else none.
@@ -448,6 +468,11 @@ enum ProviderAccountStore {
 
 /// How an account is doing, for the Settings row and the picker.
 enum ProviderAccountStatus: Equatable {
+    case signingIn
+    case signedIn(email: String?, plan: String?)
+    case signedOut
+    case runtimeUnavailable(String)
+    case rateLimited(resetAt: Date?)
     /// A key is saved but nothing has confirmed it yet.
     case keySaved
     /// The provider answered — `models` is what it offered.
@@ -461,6 +486,20 @@ enum ProviderAccountStatus: Equatable {
 
     var summary: String {
         switch self {
+        case .signingIn: "Waiting for ChatGPT sign-in"
+        case let .signedIn(email, plan):
+            {
+                let details = [email, plan?.capitalized]
+                    .compactMap { $0 }
+                    .filter { !$0.isEmpty }
+                    .joined(separator: " · ")
+                return details.isEmpty ? "Signed in" : details
+            }()
+        case .signedOut: "Not signed in"
+        case let .runtimeUnavailable(message): message
+        case let .rateLimited(resetAt):
+            resetAt.map { "Limit reached · resets \($0.formatted(.relative(presentation: .named)))" }
+                ?? "ChatGPT plan limit reached"
         case .keySaved: "Key saved"
         case let .connected(models):
             models == 1 ? "Connected · 1 model" : "Connected · \(models) models"
@@ -472,8 +511,9 @@ enum ProviderAccountStatus: Equatable {
 
     var isHealthy: Bool {
         switch self {
-        case .connected, .keySaved: true
-        case .keyRejected, .failed, .noKey: false
+        case .connected, .keySaved, .signedIn: true
+        case .signingIn, .signedOut, .runtimeUnavailable, .rateLimited,
+             .keyRejected, .failed, .noKey: false
         }
     }
 }

--- a/Locus/Resources/ThirdPartyNotices.md
+++ b/Locus/Resources/ThirdPartyNotices.md
@@ -78,6 +78,20 @@ Each package's complete license text is retained in its installed
 The SOCKS proxy packages' license texts are additionally retained at
 `ThirdPartyLicenses/pysocks-1.7.1/` and `ThirdPartyLicenses/socksio-1.0.0/`.
 
+## OpenAI Codex App Server
+
+Locus includes the `codex app-server` helper built from OpenAI Codex release
+`rust-v0.147.0`. It is used only for OpenAI-managed ChatGPT authentication and
+agent turns selected by the user.
+
+- Source: https://github.com/openai/codex/releases/tag/rust-v0.147.0
+- Version: 0.147.0
+- License: Apache License 2.0
+- License and upstream notice: `ThirdPartyLicenses/openai-codex-0.147.0/`
+
+The app bundle also contains `CodexAppServerProvenance.txt`, recording the
+pinned source archive, Cargo lockfile, and helper binary SHA-256 digests.
+
 Ollama, Hugging Face services, hosted models, and model weights are not
 distributed with Locus. Locus only connects to services configured by the
 user.

--- a/Locus/Sheets.swift
+++ b/Locus/Sheets.swift
@@ -944,6 +944,11 @@ struct CheckpointSheet: View {
     }
 }
 
+enum SettingsPresentationContext {
+    case sheet
+    case settingsWindow
+}
+
 struct SettingsView: View {
     @EnvironmentObject private var model: AppModel
     @Environment(\.dismiss) private var dismiss
@@ -959,6 +964,11 @@ struct SettingsView: View {
     @State private var addingAccount: ProviderAccount?
     @State private var editingAccount: ProviderAccount?
     @State private var accountPendingRemoval: ProviderAccount?
+    let presentationContext: SettingsPresentationContext
+
+    init(presentationContext: SettingsPresentationContext = .sheet) {
+        self.presentationContext = presentationContext
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1083,6 +1093,11 @@ struct SettingsView: View {
         .onExitCommand {
             dismiss()
             model.settingsPresented = false
+        }
+        .onDisappear {
+            if presentationContext == .settingsWindow {
+                model.completeSettingsDismissal()
+            }
         }
         // Accounts are saved as they are edited rather than with the rest of
         // the draft: they write the credential file, and Cancel cannot un-write it.
@@ -1448,11 +1463,15 @@ struct SettingsView: View {
                         Button(kind.title) {
                             addingAccount = ProviderAccount(kind: kind)
                         }
+                        .disabled(
+                            kind == .chatGPT
+                                && model.providerAccounts.contains { $0.kind == .chatGPT }
+                        )
                     }
                 }
                 .accessibilityIdentifier("settings.accounts.add")
 
-                Text("Each account keeps its API key in \(CredentialStore.displayPath), a file readable only by your macOS user account. Keys are passed to the local agent in memory and only ever sent to their own provider. Any program running as you can read that file.")
+                Text("API accounts keep their keys in \(CredentialStore.displayPath), readable only by your macOS user account. ChatGPT plan sign-in is isolated in OpenAI's managed runtime and its tokens never enter Locus account files.")
                     .font(.system(size: 9))
                     .foregroundStyle(LocusTheme.muted)
                     .fixedSize(horizontal: false, vertical: true)
@@ -1467,7 +1486,8 @@ struct SettingsView: View {
                 .foregroundStyle(LocusTheme.muted)
 
                 Button("Browse Hugging Face Models…") {
-                    model.modelLibraryPresented = true
+                    model.openModelLibraryFromSettings()
+                    dismiss()
                 }
                 .accessibilityIdentifier("settings.accounts.browseHuggingFace")
             }
@@ -1613,6 +1633,20 @@ struct SettingsView: View {
     private func accountDetail(_ account: ProviderAccount) -> String {
         let status = model.accountStatus[account.id]
             ?? (account.hasKey ? .keySaved : .noKey)
+        if account.kind == .chatGPT,
+           let window = model.chatGPTUsage?.rateLimits.rateLimits?.primary
+        {
+            let reset = window.resetsAt.map {
+                "resets " + Date(timeIntervalSince1970: Double($0))
+                    .formatted(.relative(presentation: .named))
+            }
+            let activity = model.chatGPTUsage?.activity.summary?.lifetimeTokens.map {
+                $0.formatted(.number.notation(.compactName)) + " activity tokens"
+            }
+            return [status.summary, "\(window.usedPercent)% used", reset, activity]
+                .compactMap { $0 }
+                .joined(separator: " · ")
+        }
         let host = URL(string: RemoteEndpointTester.normalizeBaseURL(account.resolvedBaseURL))?.host
         return [host, status.summary].compactMap { $0 }.joined(separator: " · ")
     }

--- a/Locus/UsageDashboardView.swift
+++ b/Locus/UsageDashboardView.swift
@@ -183,7 +183,10 @@ struct UsageDashboardView: View {
         }
         .frame(width: 780, height: 620)
         .background(LocusTheme.panel)
-        .onAppear { model.refreshUsageSummary(since: window.since) }
+        .onAppear {
+            model.refreshUsageSummary(since: window.since)
+            Task { await model.refreshChatGPTUsage() }
+        }
         .onChange(of: window) {
             model.refreshUsageSummary(since: window.since)
         }
@@ -227,6 +230,9 @@ struct UsageDashboardView: View {
     private func content(_ summary: UsageSummary) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
+                if let usage = model.chatGPTUsage, usage.status == "signed_in" {
+                    chatGPTPlanUsage(usage)
+                }
                 totals(summary)
                 if !summary.expensiveRuns.isEmpty {
                     expensiveRuns(summary.expensiveRuns)
@@ -256,6 +262,45 @@ struct UsageDashboardView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(16)
+        }
+    }
+
+    private func chatGPTPlanUsage(_ usage: ChatGPTUsageResponse) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionLabel("CHATGPT PLAN USAGE")
+            HStack(spacing: 10) {
+                let primary = usage.rateLimits.rateLimits?.primary
+                totalTile(
+                    "Plan window used",
+                    primary.map { "\($0.usedPercent)%" } ?? "Unavailable",
+                    id: "usage.chatgpt.primary"
+                )
+                totalTile(
+                    "Resets",
+                    primary?.resetsAt.map {
+                        Date(timeIntervalSince1970: Double($0))
+                            .formatted(.relative(presentation: .named))
+                    } ?? "Unavailable",
+                    id: "usage.chatgpt.reset"
+                )
+                totalTile(
+                    "Lifetime activity",
+                    usage.activity.summary?.lifetimeTokens.map {
+                        $0.formatted(.number.notation(.compactName)) + " tokens"
+                    } ?? "Unavailable",
+                    id: "usage.chatgpt.tokens"
+                )
+                totalTile(
+                    "Plan",
+                    usage.planType?
+                        .replacingOccurrences(of: "_", with: " ")
+                        .capitalized ?? "ChatGPT",
+                    id: "usage.chatgpt.plan"
+                )
+            }
+            Text("Subscription limits are reported by OpenAI and are kept separate from API and local cost estimates below.")
+                .font(.system(size: 8))
+                .foregroundStyle(LocusTheme.muted)
         }
     }
 

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -1211,6 +1211,39 @@ final class AppModelTests: XCTestCase {
     }
 
     @MainActor
+    func testChatGPTProviderRequestBodyContainsOnlyManagedAccountMetadata() {
+        let model = AppModel(startImmediately: false)
+        let account = ProviderAccount(
+            kind: .chatGPT,
+            name: "Personal",
+            preferredModel: "gpt-5.3-codex"
+        )
+        model.saveProviderAccount(account, apiKey: "must-not-be-used")
+        model.settings.activeAccountID = account.id.uuidString
+
+        let body = model.providerRequestBody()
+
+        XCTAssertEqual(body["provider"] as? String, "chatgpt")
+        XCTAssertEqual(body["account_id"] as? String, account.id.uuidString)
+        XCTAssertEqual(body["account_label"] as? String, "ChatGPT plan — Personal")
+        XCTAssertEqual(body["model"] as? String, "gpt-5.3-codex")
+        XCTAssertNil(body["api_key"])
+        XCTAssertNil(body["base_url"])
+        XCTAssertNil(body["context_window"])
+        XCTAssertFalse(CredentialStore.has(account: account.keychainAccount))
+    }
+
+    @MainActor
+    func testOnlyOneChatGPTPlanAccountCanBeSaved() {
+        let model = AppModel(startImmediately: false)
+        model.saveProviderAccount(ProviderAccount(kind: .chatGPT, name: "First"), apiKey: nil)
+        model.saveProviderAccount(ProviderAccount(kind: .chatGPT, name: "Second"), apiKey: nil)
+
+        XCTAssertEqual(model.providerAccounts.filter { $0.kind == .chatGPT }.count, 1)
+        XCTAssertEqual(model.providerAccounts.first?.name, "First")
+    }
+
+    @MainActor
     func testProviderRequestBodySendsTheUsersWindowAndThePublishedOneSeparately() {
         // The regression test for the bug at the layer that caused it. These two
         // facts used to be collapsed into one field, so our own table's figure

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -1210,6 +1210,32 @@ final class FeatureLogicTests: XCTestCase {
         XCTAssertEqual(restored[0].kind, .codex)
     }
 
+    func testLegacyCodexAccountRemainsAnOpenAIAPIAccount() throws {
+        let id = UUID()
+        let json = """
+        [{"id":"\(id.uuidString)","kindRaw":"codex","name":"Existing",
+          "preferredModel":"gpt-5","createdAt":0}]
+        """
+
+        let account = try XCTUnwrap(ProviderAccountStore.decode(Data(json.utf8)).first)
+
+        XCTAssertEqual(account.kind, .codex)
+        XCTAssertEqual(account.kindRaw, "codex", "the stored raw value remains backward compatible")
+        XCTAssertEqual(account.kind.marketingName, "OpenAI API")
+        XCTAssertEqual(account.displayName, "OpenAI API — Existing")
+        XCTAssertTrue(account.kind.requiresAPIKey)
+    }
+
+    func testChatGPTPlanIsASeparateManagedAccountKind() {
+        let account = ProviderAccount(kind: .chatGPT, name: "Personal")
+
+        XCTAssertEqual(account.kindRaw, "chatgpt")
+        XCTAssertEqual(account.displayName, "ChatGPT plan — Personal")
+        XCTAssertFalse(account.kind.requiresAPIKey)
+        XCTAssertTrue(account.kind.usesManagedChatGPTAuthentication)
+        XCTAssertFalse(account.kind.allowsBaseURLOverride)
+    }
+
     func testLegacyRemoteEndpointMigratesIntoACustomAccount() {
         var settings = AppSettings()
         settings.provider = .remote

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -292,6 +292,96 @@ final class LocusUITests: XCTestCase {
         app.buttons["modelLibrary.close"].click()
     }
 
+    func testHuggingFaceModelLibraryHandsOffFromSettings() {
+        anyElement("workspace.modelPicker").click()
+        anyElement("workspace.modelPicker.manageAccounts").click()
+
+        let browse = anyElement("settings.accounts.browseHuggingFace")
+        XCTAssertTrue(browse.waitForExistence(timeout: 3))
+        browse.click()
+
+        XCTAssertTrue(app.textFields["modelLibrary.search"].waitForExistence(timeout: 3))
+        XCTAssertFalse(anyElement("settings.accounts.browseHuggingFace").exists)
+        app.buttons["modelLibrary.close"].click()
+    }
+
+    func testHuggingFaceModelLibraryHandsOffFromNativeSettingsWindow() {
+        app.typeKey(",", modifierFlags: .command)
+        let accounts = anyElement("settings.page.accounts")
+        XCTAssertTrue(accounts.waitForExistence(timeout: 3))
+        accounts.click()
+
+        let browse = anyElement("settings.accounts.browseHuggingFace")
+        XCTAssertTrue(browse.waitForExistence(timeout: 3))
+        browse.click()
+
+        XCTAssertTrue(app.textFields["modelLibrary.search"].waitForExistence(timeout: 3))
+        XCTAssertFalse(anyElement("settings.page.accounts").exists)
+        app.buttons["modelLibrary.close"].click()
+    }
+
+    func testAccountInputRowsFocusAcrossTheirWidthAndPasteLeftToRight() {
+        anyElement("workspace.modelPicker").click()
+        anyElement("workspace.modelPicker.manageAccounts").click()
+        anyElement("settings.accounts.add").click()
+        app.menuItems["Custom endpoint"].click()
+
+        let name = anyElement("accountEditor.name")
+        let baseURL = anyElement("accountEditor.baseURL")
+        let apiKey = anyElement("accountEditor.apiKey")
+        let context = anyElement("accountEditor.contextWindow")
+        XCTAssertTrue(name.waitForExistence(timeout: 3))
+
+        func focusAndReplace(
+            _ field: XCUIElement,
+            with value: String,
+            horizontalOffset: CGFloat,
+            paste: Bool = false
+        ) {
+            field.coordinate(
+                withNormalizedOffset: CGVector(dx: horizontalOffset, dy: 0.5)
+            ).click()
+            app.typeKey("a", modifierFlags: .command)
+            if paste {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(value, forType: .string)
+                app.typeKey("v", modifierFlags: .command)
+            } else {
+                app.typeText(value)
+            }
+        }
+
+        // The far-left hit target must focus every row, even though the old
+        // Form layout put the actual editor only in a trailing column.
+        focusAndReplace(name, with: "Left", horizontalOffset: 0.02)
+        XCTAssertEqual(name.value as? String, "Left")
+        focusAndReplace(name, with: "Work", horizontalOffset: 0.5, paste: true)
+        XCTAssertEqual(name.value as? String, "Work")
+
+        focusAndReplace(baseURL, with: "h", horizontalOffset: 0.02)
+        focusAndReplace(
+            baseURL,
+            with: "https://api.example.com/v1",
+            horizontalOffset: 0.5,
+            paste: true
+        )
+        XCTAssertEqual(baseURL.value as? String, "https://api.example.com/v1")
+
+        focusAndReplace(apiKey, with: "x", horizontalOffset: 0.02)
+        focusAndReplace(apiKey, with: "sk-test-secret", horizontalOffset: 0.5, paste: true)
+        let masked = apiKey.value as? String ?? ""
+        XCTAssertFalse(masked.isEmpty)
+        XCTAssertNotEqual(masked, "sk-test-secret")
+
+        focusAndReplace(context, with: "8", horizontalOffset: 0.02)
+        focusAndReplace(context, with: "8192", horizontalOffset: 0.5, paste: true)
+        XCTAssertEqual(context.value as? String, "8192")
+        XCTAssertTrue(app.buttons["accountEditor.save"].isEnabled)
+
+        // Avoid leaving a test credential in the developer's account file.
+        app.buttons["accountEditor.cancel"].click()
+    }
+
     func testModelPickerStaysResponsiveWithLongVLLMModelName() {
         app.terminate()
         app.launchEnvironment["LOCUS_UI_TESTING_LONG_MODEL"] = "1"
@@ -561,7 +651,9 @@ final class LocusUITests: XCTestCase {
         discard.click()
 
         XCTAssertTrue(app.buttons["changes.discardHunk.confirm"].waitForExistence(timeout: 3))
-        app.buttons.matching(NSPredicate(format: "title == 'Cancel'")).firstMatch.click()
+        // Escape targets the active confirmation reliably on macOS 26. A title
+        // query can resolve to the mirrored Touch Bar cancel button instead.
+        app.typeKey(.escape, modifierFlags: [])
     }
 
     func testRemoteButtonsFollowTheSeededAvailability() {

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Locus for macOS
 
-Locus 1.11 is a native workspace for building with local Ollama models. It combines
-conversation, planning, file context, change review, a console, and a built-in
-browser the agent can drive in one calm SwiftUI interface. Local Ollama is the default; hosted providers are
-used only after you explicitly add and select an account.
+Locus is a native workspace for building with local and hosted models. It
+combines conversation, planning, file context, change review, a console, and a
+built-in browser the agent can drive in one calm SwiftUI interface. Local
+Ollama is the default; a ChatGPT plan or an API-backed provider is used only
+after you explicitly add and select that account.
 
 **[locushost.co](https://locushost.co)**
 
@@ -13,7 +14,28 @@ Locus opens in a 1250×760 workspace by default, keeping the sidebar, conversati
 and inspector visible without clipping the right edge. Resize it whenever you
 like; macOS remembers the size you choose for later launches.
 
-## What's new in 1.11
+## Highlights
+
+- **Use your ChatGPT plan without an API key.** Add the single **ChatGPT plan**
+  account, choose **Sign in with ChatGPT**, and finish OpenAI's managed sign-in
+  in your browser. Locus then discovers the models available to that account,
+  routes normal chats, teams, and evaluations through included plan usage, and
+  shows rate-limit windows plus token activity separately from API/local cost
+  estimates. The ChatGPT and Codex apps do not need to be installed or open,
+  and this route never silently falls back to billable API usage.
+- **Locus stays in charge of tools and permissions.** ChatGPT-plan turns use a
+  pinned, bundled OpenAI Codex App Server over local JSONL/stdio, but expose
+  only Locus's current tools through App Server dynamic tools. File, shell,
+  browser, Computer Control, MCP, and extension calls still pass through the
+  same Locus permission manager, budgets, and user-visible activity. OpenAI's
+  readable reasoning summaries can stream into the existing Thinking cards;
+  raw private reasoning is neither requested for display nor persisted.
+- **Account and model-library interactions behave like native controls.** Every
+  account input row is a full-width click target, and its caret, typing, and
+  pasted text start at the left and advance left-to-right. Choosing **Browse
+  Hugging Face Models…** from Settings dismisses Settings first and opens the
+  model library immediately. In the Browser inspector, the compact controls
+  sit above the tab strip so each tab stays next to the address bar it drives.
 
 - **Adaptive Work and explicit agent teams** can route a request across local or
   hosted specialists and multiple coding models. Coding jobs share one isolated
@@ -76,9 +98,10 @@ for setup, examples, permission boundaries, recovery, and troubleshooting.
   its state across launches.
 - **Workspaces** open from a folder picker that can create folders, or with
   **New Workspace…**, which names a folder, creates it, and opens it.
-- **Local or rented GPU.** Point Locus at local Ollama, or at any
-  OpenAI-compatible endpoint — a Hugging Face Inference Endpoint, vLLM, or TGI
-  on a rented box — with an API key kept in a file only you can read.
+- **Local, subscription, or API-backed models.** Use local Ollama, sign in to
+  use included ChatGPT plan access, or point Locus at an API provider or an
+  OpenAI-compatible endpoint such as a Hugging Face Inference Endpoint, vLLM,
+  or TGI on a rented GPU.
 - **Proxy support** for networks that require one. **Settings ▸ Network**
   follows the macOS proxy configuration or takes an explicit HTTP/HTTPS or
   SOCKS5 proxy, with optional sign-in and a bypass list, and covers both the
@@ -107,14 +130,18 @@ for setup, examples, permission boundaries, recovery, and troubleshooting.
   by agent, model, and workspace with the most expensive runs one click from
   their timelines. Estimates come from the per-agent rates you entered;
   local Ollama is free, and the sheet says plainly that it is not a bill.
+  **ChatGPT plan usage** has its own section for OpenAI-reported rate-limit
+  windows, reset times, and token activity, never mixed into cost estimates.
 - **Slash commands** (`/clear`, `/model`, `/plan`, `/checkpoint`, `/export`,
   `/help`, …) with an autocomplete popup; unknown commands pass through to the
   local agent.
 - **`@` file mentions** fuzzy-search the workspace and attach the chosen file
   to the context pack as they complete.
-- **Thinking blocks** render reasoning-model `<think>` output as collapsible
-  cards; finished responses get full markdown with copyable code blocks, and
-  tool output that looks like a diff is colored line by line. A transcript-wide
+- **Thinking blocks** render local reasoning-model `<think>` output and
+  OpenAI-provided ChatGPT reasoning summaries as collapsible cards; raw private
+  reasoning from the managed runtime is ignored. Finished responses get full
+  markdown with copyable code blocks, and tool output that looks like a diff is
+  colored line by line. A transcript-wide
   view mode — `/thinking hidden|collapsed|expanded`, also in the workspace
   `…` menu — hides reasoning entirely, keeps the collapsed cards, or pins
   every card open.
@@ -174,7 +201,9 @@ for setup, examples, permission boundaries, recovery, and troubleshooting.
   whatever you set on the account.
 - **Local Model Library** searches GGUF repositories on Hugging Face, scans
   available quantizations and sizes, then downloads the selected build through
-  Ollama with native progress, cancellation, refresh, and selection.
+  Ollama with native progress, cancellation, refresh, and selection. Opening it
+  from Settings cleanly hands off from the Settings sheet or native Settings
+  window instead of leaving the library hidden behind it.
 
 ## The inspector
 
@@ -235,10 +264,12 @@ deny list below applies to what you type, too.
 
 ![Console tab](Docs/locus-console.jpg)
 
-**Browser** shows the same live pages the agent drives, with real tabs: an
-always-visible strip with favicons, loading spinners, URL tooltips, and a
-right-click menu (close, close others, copy URL, open in the default
-browser); ⌘T, ⌘W, and ⇧⌘]/⇧⌘[ work while the panel is showing. Ordinary
+**Browser** shows the same live pages the agent drives, with compact viewport,
+capture, drawer, external-browser, and expand controls at the top. Directly
+below is an always-visible tab strip with favicons, loading spinners, URL
+tooltips, and a right-click menu (close, close others, copy URL, open in the
+default browser), followed by the address bar each tab controls; ⌘T, ⌘W, and
+⇧⌘]/⇧⌘[ work while the panel is showing. Ordinary
 navigation browses through the HTTP cache — only loopback dev servers hard
 reload, where a stale asset would hide the edit you just made — and the
 camera button captures the visible page into an annotation sheet (crop, pen,
@@ -279,13 +310,17 @@ sandbox: the agent runs with your privileges by design.
 
 - Apple Silicon Mac
 - macOS 14 or newer
-- [Ollama](https://ollama.com) installed locally (the app or command-line tool)
-- At least one installed, tool-capable model
+- One model source:
+  - [Ollama](https://ollama.com) and an installed, tool-capable local model;
+  - an eligible ChatGPT plan; or
+  - an API key for a supported hosted provider or custom endpoint.
 
-That is the whole list — the app bundles its own agent runtime, so there is
-nothing else to install. No Python, no Homebrew. Locus starts its agent and
-local Ollama automatically; the selected model remains unloaded until the first
-prompt.
+That is the whole end-user list. The app bundles its Python agent runtime,
+OpenAI Codex App Server, and the companion code-mode host, so there is no
+Python, Homebrew, Rust, Codex CLI, Codex app, or ChatGPT app dependency. Locus
+starts the local services it needs. When you use a ChatGPT plan, sign-in opens
+your default browser once; neither OpenAI desktop app needs to open or remain
+running afterward.
 
 New models can also be installed without leaving Locus: open the model picker,
 choose **Browse Hugging Face Models…**, search or paste a repository URL,
@@ -294,25 +329,45 @@ as the balanced default when a repository provides it.
 
 Ollama and model weights are not bundled.
 
-## Hosted models: Claude, Codex, Kimi
+## Model accounts: ChatGPT plan, OpenAI API, Claude, and Kimi
 
 **Local Ollama is the default and stays the default.** A fresh install talks to
 your own machine and nothing else; hosted providers only ever come into play
 once you add an account, and removing the last one drops you straight back to
 local. The model picker always opens with the local section first.
 
-Every hosted provider here is authenticated with an **API key you supply**.
-Locus does not sign in to anyone's account and does not carry OAuth
-credentials. In **Settings ▸ Accounts** — or **Manage Accounts** in the
-sidebar — choose **Add Account…** and pick a provider:
+In **Settings ▸ Accounts** — or **Manage Accounts** in the sidebar — choose
+**Add Account…** and pick one of these distinct routes:
 
-| Provider | Endpoint | Where the key comes from |
+| Account | Authentication | Service |
 | --- | --- | --- |
-| Claude (Anthropic) | `https://api.anthropic.com/v1` | console.anthropic.com |
-| Codex (OpenAI) | `https://api.openai.com/v1` | platform.openai.com |
-| Kimi (Moonshot AI) | `https://api.moonshot.ai/v1` | platform.moonshot.ai |
-| Kimi Code (Moonshot AI) | `https://api.kimi.com/coding/v1` | Kimi Code Console |
-| Custom endpoint | whatever you paste | your own host |
+| ChatGPT plan | OpenAI-managed browser sign-in; no API key | Included usage and limits from the signed-in ChatGPT workspace |
+| OpenAI API | API key from [platform.openai.com](https://platform.openai.com/api-keys) | `https://api.openai.com/v1` |
+| Claude (Anthropic) | API key from [console.anthropic.com](https://console.anthropic.com/settings/keys) | `https://api.anthropic.com/v1` |
+| Kimi (Moonshot AI) | API key from [platform.moonshot.ai](https://platform.moonshot.ai/console/api-keys) | `https://api.moonshot.ai/v1` |
+| Kimi Code (Moonshot AI) | Key from the Kimi Code Console | `https://api.kimi.com/coding/v1` |
+| Custom endpoint | API key from your host | Whatever OpenAI-compatible URL you paste |
+
+**ChatGPT plan** and **OpenAI API** are deliberately separate. ChatGPT sign-in
+uses subscription access; API-key use is billed by the OpenAI Platform. Locus
+never converts one into the other and never falls back from ChatGPT-plan usage
+to an API key. Existing accounts stored under the historical `codex` value
+continue to work unchanged and now appear as **OpenAI API**.
+
+Choose **Sign in with ChatGPT** and complete OpenAI's browser flow. The bundled
+helper refreshes that session, lists the account's available models, and reports
+plan status and usage. Locus supports one signed-in ChatGPT identity in this
+release; it can be selected for ordinary chats, agent-team roles, and
+evaluations. Sign-out visibly returns active ChatGPT routes to local Ollama and
+does not delete Locus transcripts.
+
+The integration uses OpenAI's official [Codex App
+Server](https://learn.chatgpt.com/docs/app-server) over local JSONL/stdio and
+the official [ChatGPT authentication
+flow](https://learn.chatgpt.com/docs/auth#openai-authentication). Some of the
+tool-bridging interface is experimental, so Locus pins OpenAI Codex
+`rust-v0.147.0` and treats version or protocol mismatches as visible errors
+instead of trying another paid route.
 
 **Kimi Code** is the one whose key bills against a subscription rather than
 per token: its keys come from the Kimi Code Console and draw on a Kimi
@@ -320,18 +375,16 @@ membership. It is still a key you paste, just a differently billed one. It is a
 separate account type from **Kimi** — different host, different key, different
 models — and the two keys are not interchangeable.
 
-There is no equivalent for Claude or Codex, and this is a rule rather than a
-gap. Anthropic does not permit third-party apps to sign in with a Claude.ai
-account or to route requests through Pro or Max plan credentials, so Claude
-accounts need a console API key; the account editor says so and links to their
-terms. Codex accounts likewise use an OpenAI API key.
+There is no managed Claude.ai sign-in here. Claude accounts use Anthropic
+console API keys; the account editor says so and links to their terms.
 
-Give the account a name — "Work", "Personal" — paste its API key, and it joins
-the model picker as its own section. **You can add as many accounts as you
+Give an API account a name — "Work", "Personal" — paste its key, and it joins
+the model picker as its own section. **You can add as many API accounts as you
 like, including several for the same provider**: two Claude keys appear as
 "Claude — Work" and "Claude — Personal", each with its own models, and the
 picker's checkmark tracks the account as well as the model, so identically
-named models never blur together.
+named models never blur together. The ChatGPT-plan identity remains the one
+single-account exception.
 
 Choosing a model routes the session through that account. Choosing one during a
 turn is held until the turn finishes rather than refused, because the agent
@@ -379,16 +432,18 @@ and any combined fix requested after review. Each coding profile keeps its own
 provider, model, MCP policy, and access ceiling, while the global Ask / Accept
 Edits / Bypass permission choice remains in force.
 
-**Test Connection** confirms the account answers before you send a message,
+**Test Connection** confirms an API account answers before you send a message,
 and reports the actual reason when it does not — a rejected key, a wrong URL,
 or a scaled-to-zero GPU that is still waking up. For providers that publish no
 model listing, it sends a one-token completion instead, which is the only thing
-that really proves a key works.
+that really proves a key works. The ChatGPT-plan editor instead shows managed
+sign-in status with Refresh, Cancel Login, and Sign Out controls.
 
-Claude uses Anthropic's native Messages protocol; the other built-in hosted
-providers and custom endpoints use their documented OpenAI-compatible routes.
+Claude uses Anthropic's native Messages protocol; the API-key-backed OpenAI,
+Kimi, and custom providers use their documented OpenAI-compatible routes.
 Authenticated non-loopback endpoints must use HTTPS, and provider redirects are
-refused so credentials can never follow a response to a different URL.
+refused so credentials can never follow a response to a different URL. The
+ChatGPT-plan route uses App Server rather than either raw inference protocol.
 
 Locus identifies itself as `Locus/<version>` on every request it makes,
 including the pages the model browses. That is a fixed value rather than a
@@ -427,25 +482,35 @@ Windows measured on one host are remembered for that host alone, so a model
 served at 32K on the LAN box does not report 32K when the same model is served
 at 4K here.
 
-### About the keys
+### Credential storage
 
-Each account keeps its key in `~/.locus/auth.json`, in its own entry, and passes
-it to the local agent process in memory. The file is mode `0600` inside a `0700`
-directory, so no other account on the Mac can read it; in the sandboxed App
-Store build it lives in the app container instead. A key is never written to the
-agent's config, never returned by any API, and only ever sent to its own
-provider. Removing an account deletes its key with it.
+Each API account keeps its key in `~/.locus/auth.json`, in its own entry, and
+passes it to the local agent process in memory. The file is mode `0600` inside a
+`0700` directory, so no other user account on the Mac can read it; in the
+sandboxed App Store build it lives in the app container instead. A key is never
+written to the agent's config, never returned by any API, and only ever sent to
+its own provider. Removing an API account deletes its key with it.
+
+ChatGPT-plan OAuth credentials are different. OpenAI's bundled helper owns and
+refreshes them in a separate file-backed `CODEX_HOME` under
+`~/Library/Application Support/Locus/Codex` (or the app container). Swift
+models, Locus's API-key store, team manifests, transcripts, logs, and provider
+routes never receive those token values. Locus writes only the helper's local
+policy file; it does not read or rewrite `auth.json`. Signing out asks the
+helper to clear its managed session.
 
 Be clear about what that does and does not buy you. File permissions keep the
-keys away from *other users* of the machine. They do not keep them away from
-anything running as **you** — any program you launch can read that file. Earlier
+credentials away from *other users* of the machine. They do not keep them away
+from anything running as **you** — any program you launch can read those files
+in the direct-download build. Earlier
 releases used the login keychain, which added per-application access control and
-an authorization prompt; this does not. That is the same trade Codex makes with
-`~/.codex/auth.json`, and it is a real reduction in protection, not a wash. If no key is passed that way, the
-agent falls back to the first of `LOCUS_REMOTE_API_KEY`, `OLLAMA_CODE_API_KEY`,
-`HF_TOKEN`, `HUGGING_FACE_HUB_TOKEN`, or `OPENAI_API_KEY` in its own
-environment — that is how you supply one when running the agent from a
-terminal.
+an authorization prompt; these file-backed stores do not. That is a real
+reduction in protection, not a wash. If no API key is passed from Locus, the
+agent falls back to the first of `LOCUS_REMOTE_API_KEY`,
+`OLLAMA_CODE_API_KEY`, `HF_TOKEN`, `HUGGING_FACE_HUB_TOKEN`, or
+`OPENAI_API_KEY` in its own environment — that is how you supply an API key
+when running the agent from a terminal. Those variables are deliberately
+removed from the managed ChatGPT helper's environment.
 
 The local REST/WebSocket service is loopback-only, rejects browser origins, and
 the app protects each launch with a fresh capability header shared only with
@@ -521,6 +586,15 @@ service does not validate `Host`, so a DNS-rebinding page could still reach
 some read endpoints. The real boundary is that the service is local-only and
 the permission system gates anything that touches your files.
 
+For a ChatGPT-plan route, that Python service lazily starts one bundled
+`codex app-server` process and communicates with it over JSONL/stdio. The
+primary service is the only helper owner; authenticated local worker brokers
+multiplex team and evaluation threads back through it. Locus disables the
+helper's native shell, file, web, apps, plugins, skills, multi-agent, analytics,
+and update surfaces, supplies Locus's system instructions, and publishes only
+the active Locus tool registry through dynamic tools. Unexpected built-in tool
+or approval requests fail the route as a protocol mismatch.
+
 The build embeds that service together with a **relocatable CPython** from
 [python-build-standalone](https://github.com/astral-sh/python-build-standalone)
 and the service's dependencies. The interpreter resolves its dylib and
@@ -539,9 +613,9 @@ folder**. The bundled copy wins whenever its files are present.
 
 Download `Locus-macOS.zip` from [locushost.co](https://locushost.co) or this
 repository's Releases page, move Locus to Applications, and open it. The agent
-runtime and its Python are inside the app, so there is nothing else to install —
-you only need [Ollama](https://ollama.com) (or a remote endpoint) for the
-models. Releases up to 1.5.1 were published from the old `locus-macos`
+runtime, Python, and managed ChatGPT helpers are inside the app, so there is
+nothing else to install — choose Ollama, a ChatGPT plan, or an API-backed
+endpoint for models. Releases up to 1.5.1 were published from the old `locus-macos`
 repository and required Homebrew's `python@3.14`; builds from this repository
 do not.
 
@@ -575,6 +649,7 @@ Everything the app needs lives in this repository:
 ```text
 locus/
 ├── project.yml     # xcodegen spec — regenerate after adding/removing files
+├── Config/         # app and helper signing entitlements
 ├── Locus/          # the SwiftUI app
 ├── LocusTests/     # unit tests
 ├── LocusUITests/   # UI tests
@@ -593,11 +668,30 @@ cd ~/Documents/locus && xcodegen generate
 ```
 
 Open `Locus.xcodeproj`, select the Locus scheme, and run **My Mac**. The
-project was built and verified with Xcode 26. The first build downloads a
-relocatable CPython (~26 MB, from python-build-standalone) into
-`.agent-runtime/`, installs the agent's dependencies into it, and embeds the
-result; later builds — including offline ones — reuse that cache. No Python
-needs to be installed for this.
+project was built and verified with Xcode 26. Source builds require
+[Rust through rustup](https://rustup.rs/) because Locus builds its pinned Codex
+App Server instead of trusting an installed Codex or ChatGPT app:
+
+```bash
+rustup toolchain install 1.95.0 --profile minimal --component rust-src
+rustup target add aarch64-apple-darwin x86_64-apple-darwin --toolchain 1.95.0
+```
+
+The OpenAI source includes `rust-toolchain.toml`, so the build automatically
+uses Rust/Cargo 1.95 even if a newer stable toolchain is your default. The first
+build downloads a relocatable CPython (~26 MB), the checksum-pinned OpenAI
+Codex `rust-v0.147.0` source, and OpenAI's pinned V8 artifacts, then compiles
+`codex` and `codex-code-mode-host` for the requested architectures. That first
+Rust compile can take tens of minutes per architecture. Later builds reuse
+`.agent-runtime/` and `.codex-app-server/`; when inputs and architectures have
+not changed, helper preparation is effectively immediate and works offline.
+No system Python needs to be installed.
+
+Build both helper architectures up front when preparing a universal artifact:
+
+```bash
+LOCUS_CODEX_ARCHS="arm64 x86_64" Tools/PrepareCodexAppServer.sh
+```
 
 The bundling step takes environment overrides:
 
@@ -611,6 +705,9 @@ LOCUS_BUNDLE_MODE=skip xcodebuild -project Locus.xcodeproj -scheme Locus
 
 # Bundle an agent checkout from another location:
 LOCUS_BACKEND_ROOT=/path/to/agent xcodebuild -project Locus.xcodeproj -scheme Locus
+
+# Skip only the managed ChatGPT helper for a quick UI-only development build:
+LOCUS_BUNDLE_CODEX=skip xcodebuild -project Locus.xcodeproj -scheme Locus
 ```
 
 Working on the agent itself needs a venv (any Python 3.10 or newer):
@@ -651,8 +748,8 @@ xcodebuild \
 cd agent && .venv/bin/python -m pytest -q
 ```
 
-The repository currently contains 255 unit tests, 33 UI tests, and 403 backend
-test cases.
+The repository currently contains 376 Swift unit tests, 42 UI tests, and 458
+collected backend test cases.
 
 The unit suite covers work modes, lightweight context migration, session
 acknowledgements and retry branches, recoverable session clearing, Hugging Face
@@ -664,19 +761,26 @@ local execution, thinking-block and markdown-fragment parsing, diff detection,
 inspector width clamping and settings round-trips, agent/team validation,
 orchestration-budget compatibility, managed-run state, MCP callback validation,
 telemetry defaults, console output assembly and its bounded buffer, and the rule
-that a run badges a tab instead of switching to it. The UI suite checks Clear
+that a run badges a tab instead of switching to it. It also covers legacy
+OpenAI-account decoding, managed ChatGPT provider payloads, the one-account
+rule, and usage/status formatting. The UI suite checks Clear
 Chat, Clear Saved Sessions, the Local Model Library, message actions and rewind,
 session organization, archived filtering,
 recent workspaces, context controls, prompt history, the slash command popup,
 the shortcuts sheet, command-palette keyboard navigation, and the inspector —
 collapse and restore, `⌘1`–`⌘8`, the Changes, Files, Checkpoints, Runs, and
-AGENTS.md tabs, and the console — through accessibility identifiers. The backend
-suite covers the tools,
+AGENTS.md tabs, and the console — through accessibility identifiers. It also
+clicks the left and center of every account row, types and pastes exact values,
+and verifies both Settings-to-Hugging-Face presentation paths. The backend suite
+covers the tools,
 permission modes and the deny list, streaming, session metadata and trash
 recovery, most HTTP endpoints, the git status and diff endpoints, the console
 protocol, the WebSocket handshake, durable run storage, capabilities, recovery,
 evaluations, routing telemetry, local knowledge, modern MCP behavior, and the
-agent loop end to end against a scripted model.
+agent loop end to end against a scripted model. A deterministic fake App Server
+additionally exercises JSONL correlation, managed authentication, models and
+usage, dynamic tools, permission denial, interruption, restart, thread resume,
+reasoning-summary mapping, protocol rejection, and transcript deduplication.
 
 UI tests drive a real window, so run them from a terminal with UI automation
 permission — not from a sandboxed shell, where the app launches without a
@@ -695,9 +799,11 @@ LOCUS_NOTARIZE=1 Tools/PackageRelease.sh /path/to/Locus.app artifacts/direct/Loc
 ```
 
 `PackageRelease.sh` signs in an order that cannot ship a broken seal: every
-Mach-O in the bundled runtime first, then the app, verify, exercise the runtime,
-verify again — so a bundle dirtied by its own import check fails the build
-rather than the user's launch. With `LOCUS_NOTARIZE=1` it submits to Apple,
+Mach-O in the bundled runtime and both Codex helpers first, then the app,
+verify, exercise the runtime, verify again — so a bundle dirtied by its own
+import check fails the build rather than the user's launch. The companion
+code-mode host receives the JIT entitlements V8 requires; App Store helpers
+also inherit the app sandbox. With `LOCUS_NOTARIZE=1` it submits to Apple,
 waits, staples the ticket into the `.app`, rebuilds the zip, and then checks
 that a fresh extraction still passes `spctl` and carries the ticket. Signing
 identity comes from `LOCUS_SIGN_IDENTITY`, else the first Developer ID
@@ -746,7 +852,10 @@ than a confusing authentication error later.
 
 Every archive runs `Tools/AuditDistribution.sh` before export. The audit
 rejects unused GPL-licensed GNU gdbm content, the broken Tk extension, and
-missing third-party license materials. The component inventory is in
+missing third-party license materials. It also verifies the pinned Codex
+source, normalized Cargo lockfile, V8 inputs, helper architecture and SHA-256
+provenance, signatures, sandbox inheritance, and code-mode JIT entitlements.
+The component inventory is in
 `Locus/Resources/ThirdPartyNotices.md`; release history and remaining App
 Store work are documented in `Docs/APP-STORE-RELEASE-2026-07-29.md`.
 
@@ -759,6 +868,14 @@ communicates with that service through REST and WebSocket endpoints on
 one WebSocket for the turn — streamed tokens, proposed tool calls, permission
 requests, and plan updates — and for the console, which shares that socket but
 runs outside the turn, so a command keeps streaming while the model works.
+
+The managed ChatGPT path adds one lazily started, version-checked Codex App
+Server child process over JSONL/stdio. OAuth state remains in its isolated
+Locus `CODEX_HOME`; Locus persists only helper thread IDs, protocol/history
+revisions, and tool-schema fingerprints. If helper history is missing or no
+longer compatible, the Python service rebuilds it from the canonical Locus
+transcript. Dedicated team workers use the launch-scoped authenticated local
+broker instead of starting helpers or receiving OAuth credentials themselves.
 
 Conversations are append-only JSONL under `~/.ollama-code/sessions`. Titles,
 pins, and archive flags live in a sidecar manifest, so renaming a conversation
@@ -782,8 +899,10 @@ not grant rights to the project's trademarks. The name *Locus* and the SparkTale
 identity are not part of what the license gives away.
 
 The app bundles third-party components — CPython and its statically linked
-libraries, and 41 pinned Python packages — which remain under their own licenses.
-The inventory, versions and licenses are in
+libraries, 41 pinned Python packages, and OpenAI Codex App Server plus its
+companion code-mode host — which remain under their own licenses. The Codex
+helpers are built from checksum-pinned Apache-2.0 source and ship with upstream
+license, notice, and build provenance. The inventory, versions and licenses are in
 [Locus/Resources/ThirdPartyNotices.md](Locus/Resources/ThirdPartyNotices.md), the
 full texts ship inside the app, and `Tools/AuditDistribution.sh` fails a release
 that omits them. Ollama, hosted models and model weights are not distributed with

--- a/Tools/AuditDistribution.sh
+++ b/Tools/AuditDistribution.sh
@@ -7,6 +7,8 @@ setopt null_glob
 app="${1:?usage: AuditDistribution.sh <Locus.app>}"
 resources="${app}/Contents/Resources"
 runtime="${resources}/AgentRuntime"
+codex_helper="${app}/Contents/Helpers/codex"
+code_mode_host="${app}/Contents/Helpers/codex-code-mode-host"
 licenses="${resources}/ThirdPartyLicenses/python-build-standalone-20260728"
 
 [[ -d "${runtime}" ]] || {
@@ -23,6 +25,73 @@ licenses="${resources}/ThirdPartyLicenses/python-build-standalone-20260728"
 }
 [[ -f "${resources}/BuildProvenance.txt" ]] || {
     echo "error: BuildProvenance.txt is missing from the app" >&2
+    exit 1
+}
+[[ -x "${codex_helper}" ]] || {
+    echo "error: bundled Codex App Server helper is missing" >&2
+    exit 1
+}
+[[ -x "${code_mode_host}" ]] || {
+    echo "error: bundled Codex code-mode host is missing" >&2
+    exit 1
+}
+[[ -f "${resources}/CodexAppServerProvenance.txt" ]] || {
+    echo "error: Codex App Server provenance is missing" >&2
+    exit 1
+}
+[[ -f "${resources}/ThirdPartyLicenses/openai-codex-0.147.0/LICENSE" ]] || {
+    echo "error: Codex App Server Apache license is missing" >&2
+    exit 1
+}
+[[ -f "${resources}/ThirdPartyLicenses/openai-codex-0.147.0/NOTICE" ]] || {
+    echo "error: Codex App Server upstream notice is missing" >&2
+    exit 1
+}
+for pin in \
+    "tag=rust-v0.147.0" \
+    "version=0.147.0" \
+    "source_sha256=355bde4b40d5ba6deea2e469d36f91708315729f3e84c9c69cce6b041a5ba593" \
+    "upstream_cargo_lock_sha256=eeab4e9d3466da54037032251e2f13ad1ed11eae18bb8ee7dd2c89dbb86f645d" \
+    "cargo_lock_normalization=workspace_versions_0.0.0_to_0.147.0" \
+    "cargo_lock_sha256=bc4fe450de929afe82928734f860ca83e5f9dc5f9f1211b0974ea47b57af77ca" \
+    "v8_version=150.4.0" \
+    "v8_aarch64_archive_sha256=00adbb48798848c77550441c68673a5e8529b8e1b73eabcdee232cb39b40f4a1" \
+    "v8_aarch64_binding_sha256=ca5adf0cf89c9a70ad460ae73648b2fe89b74aa113b3cb7f757b6a02b758394f" \
+    "v8_x86_64_archive_sha256=e0d9bb64e8b3a034c2930c83972f3f35760211148342fa0407b38250ef330856" \
+    "v8_x86_64_binding_sha256=ca5adf0cf89c9a70ad460ae73648b2fe89b74aa113b3cb7f757b6a02b758394f"
+do
+    /usr/bin/grep -Fq -- "${pin}" "${resources}/CodexAppServerProvenance.txt" || {
+        echo "error: Codex helper provenance is missing ${pin}" >&2
+        exit 1
+    }
+done
+expected_helper_sha="$(/usr/bin/awk -F= '$1 == "binary_sha256" { print $2 }' \
+    "${resources}/CodexAppServerProvenance.txt")"
+actual_helper_sha="$(/usr/bin/shasum -a 256 "${codex_helper}" | /usr/bin/awk '{print $1}')"
+[[ -n "${expected_helper_sha}" && "${expected_helper_sha}" == "${actual_helper_sha}" ]] || {
+    echo "error: bundled Codex helper checksum does not match provenance" >&2
+    exit 1
+}
+expected_code_mode_host_sha="$(/usr/bin/awk -F= '$1 == "code_mode_host_sha256" { print $2 }' \
+    "${resources}/CodexAppServerProvenance.txt")"
+actual_code_mode_host_sha="$(/usr/bin/shasum -a 256 "${code_mode_host}" | /usr/bin/awk '{print $1}')"
+[[ -n "${expected_code_mode_host_sha}" \
+    && "${expected_code_mode_host_sha}" == "${actual_code_mode_host_sha}" ]] || {
+    echo "error: bundled Codex code-mode host checksum does not match provenance" >&2
+    exit 1
+}
+expected_archs="$(/usr/bin/awk -F= '$1 == "architectures" { print $2 }' \
+    "${resources}/CodexAppServerProvenance.txt")"
+actual_archs="$(/usr/bin/lipo -archs "${codex_helper}" | /usr/bin/tr ' ' '\n' \
+    | /usr/bin/sort -u | /usr/bin/tr '\n' ' ' | /usr/bin/sed 's/ $//')"
+[[ -n "${expected_archs}" && "${expected_archs}" == "${actual_archs}" ]] || {
+    echo "error: bundled Codex helper architectures do not match provenance" >&2
+    exit 1
+}
+actual_code_mode_host_archs="$(/usr/bin/lipo -archs "${code_mode_host}" | /usr/bin/tr ' ' '\n' \
+    | /usr/bin/sort -u | /usr/bin/tr '\n' ' ' | /usr/bin/sed 's/ $//')"
+[[ "${expected_archs}" == "${actual_code_mode_host_archs}" ]] || {
+    echo "error: bundled Codex code-mode host architectures do not match provenance" >&2
     exit 1
 }
 
@@ -105,5 +174,35 @@ if /usr/bin/codesign -d --entitlements "${entitlements}" "${app}" >/dev/null 2>&
         }
     done
 fi
+
+for sealed_helper in "${codex_helper}" "${code_mode_host}"; do
+    helper_entitlements="$(/usr/bin/mktemp "${TMPDIR:-/tmp}/locus-helper-entitlements.XXXXXX")"
+    if /usr/bin/codesign -d --entitlements "${helper_entitlements}" \
+        "${sealed_helper}" >/dev/null 2>&1; then
+        if /usr/bin/plutil -extract com.apple.security.app-sandbox raw -o - \
+            "${entitlements}" >/dev/null 2>&1; then
+            inherit="$(/usr/bin/plutil -extract com.apple.security.inherit raw -o - \
+                "${helper_entitlements}" 2>/dev/null || true)"
+            [[ "${inherit}" == "true" ]] || {
+                echo "error: sandboxed Codex helper is not signed with inherit: ${sealed_helper:t}" >&2
+                exit 1
+            }
+        fi
+        if [[ "${sealed_helper}" == "${code_mode_host}" ]]; then
+            for required_jit_entitlement in \
+                com.apple.security.cs.allow-jit \
+                com.apple.security.cs.allow-unsigned-executable-memory
+            do
+                enabled="$(/usr/bin/plutil -extract "${required_jit_entitlement}" raw -o - \
+                    "${helper_entitlements}" 2>/dev/null || true)"
+                [[ "${enabled}" == "true" ]] || {
+                    echo "error: Codex code-mode host is missing ${required_jit_entitlement}" >&2
+                    exit 1
+                }
+            done
+        fi
+    fi
+    /bin/rm -f "${helper_entitlements}"
+done
 
 echo "Distribution audit passed: notices present; gdbm and tkinter absent."

--- a/Tools/BundleBackend.sh
+++ b/Tools/BundleBackend.sh
@@ -22,6 +22,7 @@ mode="${LOCUS_BUNDLE_MODE:-standalone}"
 resources="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 runtime="${resources}/AgentRuntime"
 source_package="${backend_root}/ollama_code"
+codex_cache="${LOCUS_CODEX_CACHE:-${repo_root}/.codex-app-server}"
 
 if [[ "${mode}" == "skip" ]]; then
     echo "note: LOCUS_BUNDLE_MODE=skip — agent runtime not bundled."
@@ -55,6 +56,62 @@ write_provenance() {
 }
 
 write_provenance
+
+bundle_codex_helper() {
+    [[ "${LOCUS_BUNDLE_CODEX:-build}" != "skip" ]] || return 0
+    LOCUS_CODEX_ARCHS="${ARCHS:-$(/usr/bin/uname -m)}" \
+        "${script_dir}/PrepareCodexAppServer.sh"
+    local helpers="${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Helpers"
+    local helper="${helpers}/codex"
+    local code_mode_host_helper="${helpers}/codex-code-mode-host"
+    /bin/mkdir -p "${helpers}"
+    /usr/bin/ditto "${codex_cache}/bin/codex" "${helper}"
+    /usr/bin/ditto "${codex_cache}/bin/codex-code-mode-host" "${code_mode_host_helper}"
+    /usr/bin/ditto "${codex_cache}/PROVENANCE" "${resources}/CodexAppServerProvenance.txt"
+    /bin/mkdir -p "${resources}/ThirdPartyLicenses/openai-codex-0.147.0"
+    /usr/bin/ditto "${codex_cache}/source-rust-v0.147.0/LICENSE" \
+        "${resources}/ThirdPartyLicenses/openai-codex-0.147.0/LICENSE"
+    /usr/bin/ditto "${codex_cache}/source-rust-v0.147.0/NOTICE" \
+        "${resources}/ThirdPartyLicenses/openai-codex-0.147.0/NOTICE"
+    /bin/chmod 755 "${helper}" "${code_mode_host_helper}"
+
+    local identity="${EXPANDED_CODE_SIGN_IDENTITY:-}"
+    if [[ "${CODE_SIGNING_ALLOWED:-NO}" == "YES" && -n "${identity}" ]]; then
+        local hardened=()
+        [[ "${ENABLE_HARDENED_RUNTIME:-NO}" == "YES" ]] && hardened=(--options runtime)
+        local sealed_helper identifier
+        for sealed_helper in "${helper}" "${code_mode_host_helper}"; do
+            identifier="io.sparktales.locus.${sealed_helper:t}"
+            if [[ "${ENABLE_APP_SANDBOX:-NO}" == "YES" ]]; then
+                local entitlements="${repo_root}/Config/AgentRuntime.entitlements"
+                if [[ "${sealed_helper}" == "${code_mode_host_helper}" ]]; then
+                    entitlements="${repo_root}/Config/CodexCodeModeHostSandbox.entitlements"
+                fi
+                /usr/bin/codesign --force "${hardened[@]}" \
+                    --identifier "${identifier}" \
+                    --entitlements "${entitlements}" \
+                    --sign "${identity}" "${sealed_helper}"
+            elif [[ "${sealed_helper}" == "${code_mode_host_helper}" ]]; then
+                /usr/bin/codesign --force "${hardened[@]}" \
+                    --identifier "${identifier}" \
+                    --entitlements "${repo_root}/Config/CodexCodeModeHost.entitlements" \
+                    --sign "${identity}" "${sealed_helper}"
+            else
+                /usr/bin/codesign --force "${hardened[@]}" --sign "${identity}" "${sealed_helper}"
+            fi
+        done
+    fi
+    # Signing changes Mach-O bytes. Record the exact sealed helper shipped in
+    # this app, while the source and lockfile hashes remain from the build cache.
+    local shipped_sha
+    shipped_sha="$(/usr/bin/shasum -a 256 "${helper}" | /usr/bin/awk '{print $1}')"
+    /usr/bin/sed -i '' "s/^binary_sha256=.*/binary_sha256=${shipped_sha}/" \
+        "${resources}/CodexAppServerProvenance.txt"
+    shipped_sha="$(/usr/bin/shasum -a 256 "${code_mode_host_helper}" | /usr/bin/awk '{print $1}')"
+    /usr/bin/sed -i '' \
+        "s/^code_mode_host_sha256=.*/code_mode_host_sha256=${shipped_sha}/" \
+        "${resources}/CodexAppServerProvenance.txt"
+}
 
 bundle_source() {
     /bin/rm -rf "${runtime}"
@@ -191,6 +248,7 @@ if [[ "${mode}" == "venv" ]]; then
     if ! bundle_venv; then
         echo "warning: venv bundling failed; runtime not bundled."
     fi
+    bundle_codex_helper
     exit 0
 fi
 
@@ -199,3 +257,4 @@ if ! bundle_standalone; then
     echo "error: use LOCUS_BUNDLE_MODE=venv explicitly for a local-only venv build" >&2
     exit 1
 fi
+bundle_codex_helper

--- a/Tools/PrepareCodexAppServer.sh
+++ b/Tools/PrepareCodexAppServer.sh
@@ -1,0 +1,183 @@
+#!/bin/zsh
+# Reproducibly builds the OpenAI Codex helper used for ChatGPT-plan accounts.
+# The source archive, lockfile, and resulting cache provenance are pinned; an
+# upgrade is an intentional edit to all three constants below.
+set -euo pipefail
+
+script_dir="${0:A:h}"
+repo_root="${script_dir:h}"
+tag="rust-v0.147.0"
+version="0.147.0"
+source_sha256="355bde4b40d5ba6deea2e469d36f91708315729f3e84c9c69cce6b041a5ba593"
+upstream_lock_sha256="eeab4e9d3466da54037032251e2f13ad1ed11eae18bb8ee7dd2c89dbb86f645d"
+normalized_lock_sha256="bc4fe450de929afe82928734f860ca83e5f9dc5f9f1211b0974ea47b57af77ca"
+v8_version="150.4.0"
+v8_aarch64_archive_sha256="00adbb48798848c77550441c68673a5e8529b8e1b73eabcdee232cb39b40f4a1"
+v8_aarch64_binding_sha256="ca5adf0cf89c9a70ad460ae73648b2fe89b74aa113b3cb7f757b6a02b758394f"
+v8_x86_64_archive_sha256="e0d9bb64e8b3a034c2930c83972f3f35760211148342fa0407b38250ef330856"
+v8_x86_64_binding_sha256="ca5adf0cf89c9a70ad460ae73648b2fe89b74aa113b3cb7f757b6a02b758394f"
+cache="${LOCUS_CODEX_CACHE:-${repo_root}/.codex-app-server}"
+archive="${cache}/codex-${tag}.tar.gz"
+source="${cache}/source-${tag}"
+source_marker="${source}/.locus-source-sha256"
+binary="${cache}/bin/codex"
+code_mode_host_binary="${cache}/bin/codex-code-mode-host"
+provenance="${cache}/PROVENANCE"
+requested_archs="${LOCUS_CODEX_ARCHS:-$(/usr/bin/uname -m)}"
+normalized_archs="$(
+    for architecture in ${=requested_archs}; do
+        print -r -- "${architecture}"
+    done | /usr/bin/sort -u | /usr/bin/tr '\n' ' ' | /usr/bin/sed 's/ $//'
+)"
+
+if [[ -x "${binary}" && -x "${code_mode_host_binary}" && -f "${provenance}" ]] \
+    && /usr/bin/grep -Fq "source_sha256=${source_sha256}" "${provenance}" \
+    && /usr/bin/grep -Fq "cargo_lock_sha256=${normalized_lock_sha256}" "${provenance}" \
+    && /usr/bin/grep -Fq "code_mode_host_sha256=" "${provenance}" \
+    && /usr/bin/grep -Fq "v8_version=${v8_version}" "${provenance}" \
+    && /usr/bin/grep -Fq "v8_aarch64_archive_sha256=${v8_aarch64_archive_sha256}" "${provenance}" \
+    && /usr/bin/grep -Fq "v8_aarch64_binding_sha256=${v8_aarch64_binding_sha256}" "${provenance}" \
+    && /usr/bin/grep -Fq "v8_x86_64_archive_sha256=${v8_x86_64_archive_sha256}" "${provenance}" \
+    && /usr/bin/grep -Fq "v8_x86_64_binding_sha256=${v8_x86_64_binding_sha256}" "${provenance}" \
+    && /usr/bin/grep -Fq "architectures=${normalized_archs}" "${provenance}"; then
+    exit 0
+fi
+
+/bin/mkdir -p "${cache}" "${cache}/bin"
+if [[ ! -f "${archive}" ]]; then
+    /usr/bin/curl --fail --location --proto '=https' --tlsv1.2 \
+        "https://github.com/openai/codex/archive/refs/tags/${tag}.tar.gz" \
+        --output "${archive}.partial"
+    /bin/mv "${archive}.partial" "${archive}"
+fi
+
+actual="$(/usr/bin/shasum -a 256 "${archive}" | /usr/bin/awk '{print $1}')"
+[[ "${actual}" == "${source_sha256}" ]] || {
+    echo "error: Codex source checksum mismatch (${actual})" >&2
+    exit 1
+}
+
+cached_source_sha="$(/bin/cat "${source_marker}" 2>/dev/null || true)"
+if [[ "${cached_source_sha}" != "${source_sha256}" ]]; then
+    /bin/rm -rf "${source}"
+    /bin/mkdir -p "${source}"
+    /usr/bin/tar -xzf "${archive}" --strip-components=1 -C "${source}"
+    print -r -- "${source_sha256}" > "${source_marker}"
+fi
+
+lockfile="${source}/codex-rs/Cargo.lock"
+actual_lock_sha="$(/usr/bin/shasum -a 256 "${lockfile}" | /usr/bin/awk '{print $1}')"
+if [[ "${actual_lock_sha}" == "${upstream_lock_sha256}" ]]; then
+    # OpenAI's release automation changes every workspace manifest from the
+    # development version 0.0.0 to the release version, but the GitHub source
+    # archive retains those 0.0.0 entries in Cargo.lock. Cargo 1.95 therefore
+    # refuses a --locked build until the same deterministic version rewrite is
+    # reflected in the lockfile. No dependencies or checksums are changed.
+    /usr/bin/sed -i '' \
+        "s/^version = \"0.0.0\"$/version = \"${version}\"/" "${lockfile}"
+    actual_lock_sha="$(/usr/bin/shasum -a 256 "${lockfile}" | /usr/bin/awk '{print $1}')"
+fi
+[[ "${actual_lock_sha}" == "${normalized_lock_sha256}" ]] || {
+    echo "error: normalized Codex Cargo.lock checksum mismatch (${actual_lock_sha})" >&2
+    exit 1
+}
+
+command -v cargo >/dev/null || {
+    echo "error: Rust cargo is required to build the pinned Codex App Server" >&2
+    exit 1
+}
+
+export CARGO_HOME="${LOCUS_CODEX_CARGO_HOME:-${cache}/cargo-home}"
+export CARGO_TARGET_DIR="${cache}/target-${version}"
+export SOURCE_DATE_EPOCH="0"
+outputs=()
+code_mode_host_outputs=()
+for architecture in ${=normalized_archs}; do
+    case "${architecture}" in
+        arm64)
+            rust_target="aarch64-apple-darwin"
+            expected_v8_archive_sha="${v8_aarch64_archive_sha256}"
+            expected_v8_binding_sha="${v8_aarch64_binding_sha256}"
+            ;;
+        x86_64)
+            rust_target="x86_64-apple-darwin"
+            expected_v8_archive_sha="${v8_x86_64_archive_sha256}"
+            expected_v8_binding_sha="${v8_x86_64_binding_sha256}"
+            ;;
+        *) echo "error: unsupported Codex helper architecture ${architecture}" >&2; exit 1 ;;
+    esac
+    # The code-mode host links V8. OpenAI publishes its own verified V8 pair
+    # because Deno's upstream crate release does not carry these macOS
+    # ptr-compression+sandbox archives. These are the same URLs used by the
+    # pinned source's scripts/codex_package/v8.py release builder.
+    v8_release_url="https://github.com/openai/codex/releases/download/rusty-v8-v${v8_version}"
+    v8_cache="${cache}/v8/rusty-v8-${v8_version}-${rust_target}"
+    v8_archive="${v8_cache}/librusty_v8_ptrcomp_sandbox_release_${rust_target}.a.gz"
+    v8_binding="${v8_cache}/src_binding_ptrcomp_sandbox_release_${rust_target}.rs"
+    /bin/mkdir -p "${v8_cache}"
+    actual_v8_archive_sha=""
+    if [[ -f "${v8_archive}" ]]; then
+        actual_v8_archive_sha="$(/usr/bin/shasum -a 256 "${v8_archive}" \
+            | /usr/bin/awk '{print $1}')"
+    fi
+    if [[ "${actual_v8_archive_sha}" != "${expected_v8_archive_sha}" ]]; then
+        /bin/rm -f "${v8_archive}" "${v8_archive}.partial"
+        /usr/bin/curl --fail --location --proto '=https' --tlsv1.2 \
+            "${v8_release_url}/${v8_archive:t}" --output "${v8_archive}.partial"
+        /bin/mv "${v8_archive}.partial" "${v8_archive}"
+    fi
+    actual_v8_binding_sha=""
+    if [[ -f "${v8_binding}" ]]; then
+        actual_v8_binding_sha="$(/usr/bin/shasum -a 256 "${v8_binding}" \
+            | /usr/bin/awk '{print $1}')"
+    fi
+    if [[ "${actual_v8_binding_sha}" != "${expected_v8_binding_sha}" ]]; then
+        /bin/rm -f "${v8_binding}" "${v8_binding}.partial"
+        /usr/bin/curl --fail --location --proto '=https' --tlsv1.2 \
+            "${v8_release_url}/${v8_binding:t}" --output "${v8_binding}.partial"
+        /bin/mv "${v8_binding}.partial" "${v8_binding}"
+    fi
+    actual_v8_archive_sha="$(/usr/bin/shasum -a 256 "${v8_archive}" | /usr/bin/awk '{print $1}')"
+    actual_v8_binding_sha="$(/usr/bin/shasum -a 256 "${v8_binding}" | /usr/bin/awk '{print $1}')"
+    [[ "${actual_v8_archive_sha}" == "${expected_v8_archive_sha}" ]] || {
+        echo "error: OpenAI V8 archive checksum mismatch (${actual_v8_archive_sha})" >&2
+        exit 1
+    }
+    [[ "${actual_v8_binding_sha}" == "${expected_v8_binding_sha}" ]] || {
+        echo "error: OpenAI V8 binding checksum mismatch (${actual_v8_binding_sha})" >&2
+        exit 1
+    }
+    (cd "${source}/codex-rs" && \
+        RUSTY_V8_ARCHIVE="${v8_archive}" \
+        RUSTY_V8_SRC_BINDING_PATH="${v8_binding}" \
+        cargo build --locked --release \
+        --bin codex --bin codex-code-mode-host --target "${rust_target}")
+    outputs+=("${CARGO_TARGET_DIR}/${rust_target}/release/codex")
+    code_mode_host_outputs+=(
+        "${CARGO_TARGET_DIR}/${rust_target}/release/codex-code-mode-host"
+    )
+done
+if (( ${#outputs} == 1 )); then
+    /usr/bin/ditto "${outputs[1]}" "${binary}"
+    /usr/bin/ditto "${code_mode_host_outputs[1]}" "${code_mode_host_binary}"
+else
+    /usr/bin/lipo -create "${outputs[@]}" -output "${binary}"
+    /usr/bin/lipo -create "${code_mode_host_outputs[@]}" -output "${code_mode_host_binary}"
+fi
+/bin/chmod 755 "${binary}" "${code_mode_host_binary}"
+{
+    echo "tag=${tag}"
+    echo "version=${version}"
+    echo "architectures=${normalized_archs}"
+    echo "source_sha256=${source_sha256}"
+    echo "binary_sha256=$(/usr/bin/shasum -a 256 "${binary}" | /usr/bin/awk '{print $1}')"
+    echo "code_mode_host_sha256=$(/usr/bin/shasum -a 256 "${code_mode_host_binary}" | /usr/bin/awk '{print $1}')"
+    echo "v8_version=${v8_version}"
+    echo "v8_aarch64_archive_sha256=${v8_aarch64_archive_sha256}"
+    echo "v8_aarch64_binding_sha256=${v8_aarch64_binding_sha256}"
+    echo "v8_x86_64_archive_sha256=${v8_x86_64_archive_sha256}"
+    echo "v8_x86_64_binding_sha256=${v8_x86_64_binding_sha256}"
+    echo "upstream_cargo_lock_sha256=${upstream_lock_sha256}"
+    echo "cargo_lock_normalization=workspace_versions_0.0.0_to_${version}"
+    echo "cargo_lock_sha256=${normalized_lock_sha256}"
+} > "${provenance}"

--- a/agent/PROTOCOL.md
+++ b/agent/PROTOCOL.md
@@ -5,6 +5,7 @@ The server exposes the agent core (`ollama_code/core.py`) over:
 
 - REST: `http://127.0.0.1:8791/api/...`
 - WebSocket: `ws://127.0.0.1:8791/ws/chat`
+- Internal ChatGPT worker broker: `ws://127.0.0.1:8791/ws/internal/codex`
 
 Start it with:
 
@@ -209,14 +210,41 @@ about vision — `null` means "not known", never a guess. 502 if Ollama is down.
   "account_label": "Claude — Work" }
 ```
 
-`POST` accepts `provider: "ollama" | "remote"`. Ollama accepts optional `host`
-and `context_window`. Remote requires `base_url` and accepts `api_key`, `model`,
-`auth_style`, `account_label`, `lists_models`, `context_window`, and `verify`.
+`POST` accepts `provider: "ollama" | "remote" | "chatgpt"`. Ollama accepts
+optional `host` and `context_window`. Remote requires `base_url` and accepts
+`api_key`, `model`, `auth_style`, `account_label`, `lists_models`,
+`context_window`, and `verify`.
 Omitting a credential or account field keeps its in-memory value; an explicit
 empty key clears it. Keys are never returned or persisted. Anthropic uses its
 native Messages API; other remote providers use OpenAI chat completions.
 Authenticated non-loopback HTTP and every redirect are rejected. Errors: 409
 busy, 422 invalid configuration, 502 verification failure.
+
+The `chatgpt` variant requires `account_id`, with optional `account_label` and
+`model`, and rejects `api_key`, `base_url`, or `remote_base_url`. It uses the
+primary service's bundled Codex App Server and never falls back to `remote`.
+
+### Managed ChatGPT account API
+
+All responses are secret-free. `GET /api/chatgpt/account` returns `status`,
+`runtime_available`, `runtime_version`, `email`, `plan_type`, and a user-facing
+`message`; `?refresh=true` asks the helper to refresh authentication first.
+
+- `POST /api/chatgpt/login/start` returns `status: "signing_in"`, `login_id`,
+  and OpenAI's `auth_url` for the browser.
+- `POST /api/chatgpt/login/cancel` requires `{ "login_id": "…" }`.
+- `POST /api/chatgpt/logout` clears the managed session and returns active
+  ChatGPT routing to Ollama.
+- `GET /api/chatgpt/models` returns the signed-in account's visible App Server
+  model list.
+- `GET /api/chatgpt/usage` returns plan type, rate-limit windows, reset times,
+  spend-control state, and token-activity summaries.
+
+The app-owned backend is the only process allowed to launch App Server. The
+internal `/ws/internal/codex` broker requires the per-launch `X-Locus-Token`,
+rejects browser origins and nested brokers, and multiplexes account, model,
+usage, thread start/resume, turn/interrupt, dynamic tool, and tool-result
+operations for isolated team workers. OAuth values never cross this broker.
 
 ### `GET /api/sessions`
 
@@ -611,6 +639,12 @@ only clear or branch their visible transcript after this event.
 `reason` is `clear_chat`, `retry`, or another server-defined session-start
 reason. A retry copies history only through the latest user message; the source
 session is never modified.
+
+### `chatgpt_account_updated` / `chatgpt_usage_updated`
+
+App Server notifications are reduced to invalidation events. The native client
+refetches the corresponding secret-free REST resource; token values and raw
+helper payloads are never placed on the chat WebSocket.
 
 ### `message_start` / `token` / `thinking` / `message_end`
 Assistant streaming. `token` carries `{ "type": "token", "text": "<piece>" }`;

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,15 +1,16 @@
 # ollama-code
 
-A local coding agent powered by [Ollama](https://ollama.com). It ships as two
-front ends over one agent core:
+A local coding-agent runtime with [Ollama](https://ollama.com) as its default
+model source and explicit support for hosted accounts. It ships as two front
+ends over one agent core:
 
 - **`ollama-code`** — an interactive terminal REPL.
 - **`ollama-code-server`** — the REST + WebSocket service that Locus for
   macOS (the app in the repository root above this folder) drives.
 
 Everything runs on your machine by default. No prompt, file, or model response
-leaves it unless you deliberately point the agent at a remote endpoint — see
-*Model providers*.
+leaves it unless you deliberately select a hosted API account or the managed
+ChatGPT-plan route — see *Model providers*.
 
 ## Install
 
@@ -59,7 +60,8 @@ permission mode and retain non-bypassable high-consequence guardrails.
 ## Parallel agent teams
 
 Locus can route a Work turn through an explicit team made from local Ollama,
-custom OpenAI-compatible/vLLM, Kimi, and Anthropic accounts. A dispatcher must
+managed ChatGPT-plan, custom OpenAI-compatible/vLLM, OpenAI API, Kimi, and
+Anthropic accounts. A dispatcher must
 submit a schema-constrained job graph first. Read-only planner, researcher,
 tester, and reviewer jobs may overlap. One or more write-capable coding jobs use
 the ordinary permission loop sequentially in a shared checkout; every writer
@@ -89,9 +91,10 @@ leaves source changes unstaged and uncommitted.
 
 ## Model providers
 
-By default the agent talks to a local Ollama. It can also talk to Anthropic's
-native API or any OpenAI-compatible endpoint — a Hugging Face Inference
-Endpoint, the HF Inference Providers router, or vLLM/TGI on a rented GPU:
+By default the agent talks to a local Ollama. It can also use a bundled OpenAI
+Codex App Server with managed ChatGPT sign-in, Anthropic's native API, or any
+OpenAI-compatible endpoint — a Hugging Face Inference Endpoint, the HF
+Inference Providers router, or vLLM/TGI on a rented GPU:
 
 ```bash
 .venv/bin/ollama-code-server \
@@ -109,6 +112,14 @@ credential file via `POST /api/provider`. **It is never written to
 An API key may be sent over HTTP only to loopback (`localhost`, `127.0.0.0/8`,
 or `::1`); every other authenticated endpoint must use HTTPS. Redirects are
 refused rather than followed with credentials.
+
+The ChatGPT-plan variant of `POST /api/provider` takes `provider: "chatgpt"`,
+`account_id`, `account_label`, and `model`; it rejects API-key and base-URL
+fields. The primary app-owned service lazily starts one pinned App Server over
+JSONL/stdio in an isolated `CODEX_HOME`. OAuth values remain inside that
+helper. Team workers reach it only through the launch-token-authenticated
+`/ws/internal/codex` broker, so they never receive credentials or start their
+own helper.
 
 Endpoints that reject tool calling get one automatic retry without tools, and
 the reply says so instead of failing.
@@ -171,7 +182,13 @@ batch name; deleting a chat never touches files in its workspace.
 | POST | `/api/tasks/{id}/apply` | Dry-run check, then apply task changes unstaged |
 | GET | `/api/tools` | Tool schemas |
 | GET/POST | `/api/permissions` | Read or change the permission mode |
-| GET/POST | `/api/provider` | Switch between local Ollama and a remote endpoint |
+| GET/POST | `/api/provider` | Switch among local Ollama, a managed ChatGPT account, and an API endpoint |
+| GET | `/api/chatgpt/account` | Managed sign-in state and secret-free account metadata |
+| POST | `/api/chatgpt/login/start` | Start OpenAI's browser login flow |
+| POST | `/api/chatgpt/login/cancel` | Cancel the active browser login |
+| POST | `/api/chatgpt/logout` | Clear the managed session and leave active ChatGPT routing |
+| GET | `/api/chatgpt/models` | Models available to the signed-in ChatGPT account |
+| GET | `/api/chatgpt/usage` | Plan rate limits and token-activity summary |
 | GET/POST | `/api/config` | Model, host, working directory, context window |
 
 ### Context window
@@ -219,7 +236,8 @@ Server → client: `session_info`, `session_started`, `orchestration_started`,
 `orchestration_state`, `dispatch_plan`, `agent_job_started`,
 `agent_job_stream`, `agent_job_completed`, scheduler-lease events, task events,
 `message_start`, `token`,
-`thinking`, `message_end`, `plan_ready`, `steer_ack`, `steer_applied`,
+`thinking`, `message_end`, `chatgpt_account_updated`,
+`chatgpt_usage_updated`, `plan_ready`, `steer_ack`, `steer_applied`,
 `computer_control_status`, `computer_action_request`, `tool_call_proposed`,
 `permission_request`, `tool_result`, `todo_update`, `turn_done`, `slash_result`,
 ordered orchestration/checkpoint/recovery/routing events, evaluation progress,
@@ -246,7 +264,7 @@ an audit hook that fails the suite if anything writes to the real
 `~/.ollama-code`. `tests/live/` holds manual real-model smoke tests, not
 collected by pytest; each starts its own server on its own port.
 
-367 tests cover the tools (including atomic `multi_edit` and the binary-file
+458 collected tests cover the tools (including atomic `multi_edit` and the binary-file
 guard), permission modes and the deny list, streaming and `<think>` filtering,
 session metadata and trash recovery, the context window (that the number sent as
 `num_ctx` is the same one compaction budgets against, that a window a hosted
@@ -260,4 +278,7 @@ provider HTTP endpoints, the WebSocket handshake, and the agent loop end to end
 against a scripted model. The extensions surface — plugins, skills, MCP servers
 and marketplaces — is covered at the unit level in `test_extensions.py`. The
 suite also covers capability flags, orchestration and recovery, durable run
-storage, evaluations, telemetry, local knowledge, and modern MCP behavior.
+storage, evaluations, telemetry, local knowledge, modern MCP behavior, and a
+deterministic fake App Server for managed authentication, model/usage lookup,
+dynamic tool correlation, permission denial, streaming, interruption, restart,
+thread resume, and reasoning-summary mapping.

--- a/agent/ollama_code/codex_app_server.py
+++ b/agent/ollama_code/codex_app_server.py
@@ -1,0 +1,899 @@
+"""Managed OpenAI Codex App Server transport for ChatGPT-plan accounts.
+
+The helper owns OAuth credentials and refreshes them itself. Locus communicates
+over the documented JSONL/stdin protocol, never reads the token file, and never
+turns a ChatGPT credential into an API bearer token.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import re
+import subprocess
+import threading
+import time
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
+
+from .paths import APP_DIR
+
+logger = logging.getLogger(__name__)
+
+PINNED_CODEX_APP_SERVER_VERSION = "0.147.0"
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+
+class CodexAppServerError(RuntimeError):
+    """The bundled helper is unavailable or rejected a protocol request."""
+
+
+class CodexProtocolMismatch(CodexAppServerError):
+    """The helper exposed behavior outside Locus's pinned compatibility contract."""
+
+
+def helper_path_from_environment() -> str:
+    """Return the explicitly bundled helper path, with a development opt-in.
+
+    Release builds always set ``LOCUS_CODEX_APP_SERVER_PATH``. The ChatGPT app
+    fallback exists only for local source-tree development and is never used
+    unless the developer explicitly opts in.
+    """
+    configured = os.environ.get("LOCUS_CODEX_APP_SERVER_PATH", "").strip()
+    if configured:
+        return configured
+    if os.environ.get("LOCUS_CODEX_ALLOW_DEVELOPMENT_HELPER") == "1":
+        candidate = "/Applications/ChatGPT.app/Contents/Resources/codex"
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return ""
+
+
+def codex_home_from_environment() -> Path:
+    configured = os.environ.get("LOCUS_CODEX_HOME", "").strip()
+    return Path(configured).expanduser() if configured else APP_DIR / "codex"
+
+
+def _thread_id(message: dict[str, Any]) -> str:
+    params = message.get("params")
+    if not isinstance(params, dict):
+        return ""
+    direct = params.get("threadId") or params.get("thread_id")
+    if isinstance(direct, str):
+        return direct
+    thread = params.get("thread")
+    if isinstance(thread, dict) and isinstance(thread.get("id"), str):
+        return str(thread["id"])
+    turn = params.get("turn")
+    if isinstance(turn, dict) and isinstance(turn.get("threadId"), str):
+        return str(turn["threadId"])
+    return ""
+
+
+def dynamic_tools(schemas: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Translate Locus/OpenAI function schemas to App Server dynamic tools."""
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in schemas:
+        function = raw.get("function") if isinstance(raw, dict) else None
+        if not isinstance(function, dict):
+            raise CodexProtocolMismatch("Locus produced a non-function tool schema")
+        name = str(function.get("name") or "")
+        if not _TOOL_NAME.fullmatch(name):
+            raise CodexProtocolMismatch(f"Locus tool name is not App Server compatible: {name!r}")
+        if name in seen:
+            raise CodexProtocolMismatch(f"Locus tool schema contains duplicate name: {name}")
+        seen.add(name)
+        schema = function.get("parameters")
+        if not isinstance(schema, dict):
+            schema = {"type": "object", "properties": {}, "additionalProperties": False}
+        result.append({
+            "type": "function",
+            "name": name,
+            "description": str(function.get("description") or "")[:8_192],
+            "inputSchema": schema,
+            "deferLoading": False,
+        })
+    return result
+
+
+class CodexAppServerManager:
+    """One multiplexed App Server process owned by the primary Locus backend."""
+
+    def __init__(
+        self,
+        *,
+        helper_path: str | None = None,
+        codex_home: Path | None = None,
+        client_version: str = "0",
+    ) -> None:
+        self.helper_path = helper_path if helper_path is not None else helper_path_from_environment()
+        self.codex_home = codex_home or codex_home_from_environment()
+        self.client_version = client_version
+        self._process: subprocess.Popen[str] | None = None
+        self._write_lock = threading.Lock()
+        self._state_lock = threading.RLock()
+        self._next_id = 1
+        self._pending: dict[int | str, queue.Queue[dict[str, Any]]] = {}
+        self._thread_queues: dict[str, list[queue.Queue[dict[str, Any]]]] = {}
+        self._global_listeners: list[Callable[[dict[str, Any]], None]] = []
+        self._stderr_tail = ""
+        self._reader: threading.Thread | None = None
+        self._stderr_reader: threading.Thread | None = None
+        self._initialized: dict[str, Any] = {}
+
+    @property
+    def available(self) -> bool:
+        return bool(
+            self.helper_path
+            and os.path.isfile(self.helper_path)
+            and os.access(self.helper_path, os.X_OK)
+        )
+
+    @property
+    def is_running(self) -> bool:
+        process = self._process
+        return process is not None and process.poll() is None
+
+    @property
+    def runtime_version(self) -> str:
+        user_agent = str(self._initialized.get("userAgent") or "")
+        return user_agent or PINNED_CODEX_APP_SERVER_VERSION
+
+    @property
+    def recent_error(self) -> str:
+        return self._stderr_tail[-2_000:]
+
+    def add_listener(self, listener: Callable[[dict[str, Any]], None]) -> None:
+        with self._state_lock:
+            self._global_listeners.append(listener)
+
+    def remove_listener(self, listener: Callable[[dict[str, Any]], None]) -> None:
+        with self._state_lock:
+            self._global_listeners = [item for item in self._global_listeners if item != listener]
+
+    def _prepare_home(self) -> None:
+        self.codex_home.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            self.codex_home.chmod(0o700)
+        except OSError:
+            pass
+        config = self.codex_home / "config.toml"
+        content = (
+            'cli_auth_credentials_store = "file"\n'
+            'check_for_update_on_startup = false\n'
+            'web_search = "disabled"\n'
+            'include_permissions_instructions = false\n'
+            'include_apps_instructions = false\n'
+            'include_collaboration_mode_instructions = false\n'
+            'include_environment_context = false\n\n'
+            '[analytics]\n'
+            'enabled = false\n\n'
+            '[features]\n'
+            'shell_tool = false\n'
+            'view_image = false\n'
+            'unified_exec = false\n'
+            'tool_suggest = false\n'
+            'plugins = false\n'
+            'goals = false\n'
+            'apps = false\n'
+            'multi_agent = false\n'
+            'multi_agent_v2 = false\n'
+            'standalone_web_search = false\n'
+            'web_search_request = false\n'
+            'web_search_cached = false\n\n'
+            '[agents]\n'
+            'enabled = false\n\n'
+            '[skills]\n'
+            'include_instructions = false\n\n'
+            '[tools.update_plan]\n'
+            'enabled = false\n\n'
+            '[tools.experimental_request_user_input]\n'
+            'enabled = false\n'
+        )
+        # This is an isolated Locus-owned CODEX_HOME. Rewrite only its policy
+        # file so an app update cannot retain a looser, older tool inventory;
+        # auth.json and the helper's other credential state are untouched.
+        temporary = self.codex_home / "config.toml.locus.tmp"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        descriptor = os.open(temporary, flags, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        temporary.chmod(0o600)
+        os.replace(temporary, config)
+
+    def _command(self) -> list[str]:
+        path = self.helper_path
+        if not path:
+            raise CodexAppServerError("The bundled ChatGPT helper is unavailable")
+        name = Path(path).name
+        args = [path]
+        if name == "codex" or (name.startswith("codex-") and "app-server" not in name):
+            args.append("app-server")
+        args.extend(["--listen", "stdio://"])
+        return args
+
+    def _verify_version(self) -> None:
+        if os.environ.get("LOCUS_CODEX_SKIP_VERSION_CHECK") == "1":
+            return
+        try:
+            result = subprocess.run(
+                [self.helper_path, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise CodexAppServerError(f"Could not verify the ChatGPT helper: {error}") from error
+        reported = (result.stdout + " " + result.stderr).strip()
+        if result.returncode != 0 or PINNED_CODEX_APP_SERVER_VERSION not in reported:
+            raise CodexProtocolMismatch(
+                "ChatGPT runtime version mismatch: "
+                f"expected {PINNED_CODEX_APP_SERVER_VERSION}, got {reported or 'unknown'}"
+            )
+
+    def ensure_started(self) -> None:
+        with self._state_lock:
+            if self.is_running:
+                return
+            if not self.available:
+                raise CodexAppServerError("The bundled ChatGPT helper is unavailable")
+            self._verify_version()
+            self._prepare_home()
+            environment = dict(os.environ)
+            environment["CODEX_HOME"] = str(self.codex_home)
+            environment.pop("OPENAI_API_KEY", None)
+            environment.pop("LOCUS_REMOTE_API_KEY", None)
+            try:
+                process = subprocess.Popen(
+                    self._command(),
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    encoding="utf-8",
+                    bufsize=1,
+                    env=environment,
+                )
+            except OSError as error:
+                raise CodexAppServerError(f"Could not launch the ChatGPT helper: {error}") from error
+            self._process = process
+            self._stderr_tail = ""
+            self._reader = threading.Thread(
+                target=self._read_loop, name="locus-codex-jsonl", daemon=True
+            )
+            self._stderr_reader = threading.Thread(
+                target=self._read_stderr, name="locus-codex-stderr", daemon=True
+            )
+            self._reader.start()
+            self._stderr_reader.start()
+        try:
+            initialized = self._rpc(
+                "initialize",
+                {
+                    "clientInfo": {
+                        "name": "locus",
+                        "title": "Locus",
+                        "version": self.client_version,
+                    },
+                    "capabilities": {"experimentalApi": True},
+                },
+                timeout=15,
+            )
+            self._initialized = initialized
+            self.notify("initialized", {})
+        except Exception:
+            self.close()
+            raise
+
+    def _read_stderr(self) -> None:
+        process = self._process
+        if process is None or process.stderr is None:
+            return
+        for line in process.stderr:
+            # App Server logs may contain account identifiers. Keep only a
+            # bounded diagnostic tail in memory and never persist it.
+            self._stderr_tail = (self._stderr_tail + line)[-8_000:]
+
+    def _read_loop(self) -> None:
+        process = self._process
+        if process is None or process.stdout is None:
+            return
+        try:
+            for raw_line in process.stdout:
+                try:
+                    message = json.loads(raw_line)
+                except (TypeError, json.JSONDecodeError):
+                    logger.warning("ignored malformed JSONL from ChatGPT helper")
+                    continue
+                if not isinstance(message, dict):
+                    continue
+                identifier = message.get("id")
+                method = message.get("method")
+                if identifier is not None and not isinstance(method, str):
+                    with self._state_lock:
+                        target = self._pending.get(identifier)
+                    if target is not None:
+                        target.put(message)
+                    continue
+                thread_id = _thread_id(message)
+                delivered = False
+                if thread_id:
+                    with self._state_lock:
+                        targets = list(self._thread_queues.get(thread_id, []))
+                    for target in targets:
+                        target.put(message)
+                        delivered = True
+                if identifier is not None and isinstance(method, str) and not delivered:
+                    self.respond_error(identifier, -32601, "Locus rejected an unexpected helper request")
+                with self._state_lock:
+                    listeners = list(self._global_listeners)
+                for listener in listeners:
+                    try:
+                        listener(message)
+                    except Exception:  # noqa: BLE001 - observers cannot break transport
+                        logger.exception("ChatGPT helper listener failed")
+        finally:
+            error = CodexAppServerError(
+                self.recent_error.strip() or "The ChatGPT helper stopped unexpectedly"
+            )
+            with self._state_lock:
+                pending = list(self._pending.values())
+                thread_queues = [item for values in self._thread_queues.values() for item in values]
+            failure = {"error": {"code": -32099, "message": str(error)}}
+            for target in pending + thread_queues:
+                target.put(failure)
+
+    def _send(self, message: dict[str, Any]) -> None:
+        process = self._process
+        if process is None or process.poll() is not None or process.stdin is None:
+            raise CodexAppServerError("The ChatGPT helper is not running")
+        encoded = json.dumps(message, separators=(",", ":"), ensure_ascii=False)
+        with self._write_lock:
+            try:
+                process.stdin.write(encoded + "\n")
+                process.stdin.flush()
+            except (BrokenPipeError, OSError) as error:
+                raise CodexAppServerError("The ChatGPT helper connection closed") from error
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        message: dict[str, Any] = {"method": method}
+        if params is not None:
+            message["params"] = params
+        self._send(message)
+
+    def _rpc(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        *,
+        timeout: float = 30,
+    ) -> dict[str, Any]:
+        with self._state_lock:
+            identifier = self._next_id
+            self._next_id += 1
+            target: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=1)
+            self._pending[identifier] = target
+        message: dict[str, Any] = {"method": method, "id": identifier}
+        if params is not None:
+            message["params"] = params
+        try:
+            self._send(message)
+            try:
+                response = target.get(timeout=timeout)
+            except queue.Empty as error:
+                raise CodexAppServerError(f"ChatGPT helper timed out during {method}") from error
+        finally:
+            with self._state_lock:
+                self._pending.pop(identifier, None)
+        failure = response.get("error")
+        if isinstance(failure, dict):
+            text = str(failure.get("message") or f"ChatGPT helper rejected {method}")
+            raise CodexAppServerError(text)
+        result = response.get("result")
+        return result if isinstance(result, dict) else {}
+
+    def request(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        *,
+        timeout: float = 30,
+    ) -> dict[str, Any]:
+        self.ensure_started()
+        return self._rpc(method, params, timeout=timeout)
+
+    def respond(self, identifier: int | str, result: dict[str, Any]) -> None:
+        self._send({"id": identifier, "result": result})
+
+    def respond_error(self, identifier: int | str, code: int, message: str) -> None:
+        self._send({"id": identifier, "error": {"code": code, "message": message}})
+
+    def account(self, *, refresh: bool = False) -> dict[str, Any]:
+        result = self.request("account/read", {"refreshToken": refresh})
+        result["runtimeVersion"] = self.runtime_version
+        return result
+
+    def start_login(self) -> dict[str, Any]:
+        return self.request(
+            "account/login/start",
+            {"type": "chatgpt", "useHostedLoginSuccessPage": True, "appBrand": "chatgpt"},
+            timeout=30,
+        )
+
+    def cancel_login(self, login_id: str) -> None:
+        self.request("account/login/cancel", {"loginId": login_id})
+
+    def logout(self) -> None:
+        self.request("account/logout")
+
+    def models(self) -> list[dict[str, Any]]:
+        data: list[dict[str, Any]] = []
+        cursor: str | None = None
+        while True:
+            params: dict[str, Any] = {"limit": 100, "includeHidden": False}
+            if cursor:
+                params["cursor"] = cursor
+            page = self.request("model/list", params)
+            rows = page.get("data")
+            if isinstance(rows, list):
+                data.extend(item for item in rows if isinstance(item, dict))
+            cursor = page.get("nextCursor") if isinstance(page.get("nextCursor"), str) else None
+            if not cursor:
+                return data
+
+    def usage(self) -> dict[str, Any]:
+        limits = self.request("account/rateLimits/read")
+        activity = self.request("account/usage/read")
+        return {"rateLimits": limits, "activity": activity}
+
+    def _subscribe(self, thread_id: str) -> queue.Queue[dict[str, Any]]:
+        target: queue.Queue[dict[str, Any]] = queue.Queue()
+        with self._state_lock:
+            self._thread_queues.setdefault(thread_id, []).append(target)
+        return target
+
+    def _unsubscribe(self, thread_id: str, target: queue.Queue[dict[str, Any]]) -> None:
+        with self._state_lock:
+            remaining = [item for item in self._thread_queues.get(thread_id, []) if item is not target]
+            if remaining:
+                self._thread_queues[thread_id] = remaining
+            else:
+                self._thread_queues.pop(thread_id, None)
+
+    @staticmethod
+    def parity_config() -> dict[str, Any]:
+        return {
+            "web_search": "disabled",
+            # Request the provider's user-visible reasoning summary. Raw
+            # reasoning deltas remain private and are never mapped to Locus.
+            "model_reasoning_summary": "auto",
+            "include_permissions_instructions": False,
+            "include_apps_instructions": False,
+            "include_collaboration_mode_instructions": False,
+            "include_environment_context": False,
+            "features": {
+                "shell_tool": False,
+                "view_image": False,
+                "unified_exec": False,
+                "tool_suggest": False,
+                "plugins": False,
+                "goals": False,
+                "apps": False,
+                "multi_agent": False,
+                "multi_agent_v2": False,
+                "standalone_web_search": False,
+                "web_search_request": False,
+                "web_search_cached": False,
+            },
+            "agents": {"enabled": False},
+            "skills": {"include_instructions": False},
+            "tools": {
+                "update_plan": {"enabled": False},
+                "experimental_request_user_input": {"enabled": False},
+            },
+        }
+
+    def start_thread(
+        self,
+        *,
+        model: str,
+        cwd: str,
+        base_instructions: str,
+        tools: Iterable[dict[str, Any]],
+        ephemeral: bool = False,
+    ) -> str:
+        result = self.request(
+            "thread/start",
+            {
+                "model": model or None,
+                "cwd": cwd,
+                "approvalPolicy": "never",
+                "sandbox": "read-only",
+                "baseInstructions": base_instructions,
+                "developerInstructions": "",
+                "personality": "none",
+                "ephemeral": ephemeral,
+                "environments": [],
+                "dynamicTools": dynamic_tools(tools),
+                "config": self.parity_config(),
+                "serviceName": "locus",
+            },
+            timeout=60,
+        )
+        thread = result.get("thread")
+        thread_id = thread.get("id") if isinstance(thread, dict) else None
+        if not isinstance(thread_id, str) or not thread_id:
+            raise CodexProtocolMismatch("ChatGPT helper returned no thread id")
+        return thread_id
+
+    def resume_thread(self, thread_id: str, *, model: str, cwd: str) -> str:
+        result = self.request(
+            "thread/resume",
+            {
+                "threadId": thread_id,
+                "model": model or None,
+                "cwd": cwd,
+                "approvalPolicy": "never",
+                "sandbox": "read-only",
+                "excludeTurns": True,
+                "config": self.parity_config(),
+            },
+            timeout=60,
+        )
+        thread = result.get("thread")
+        resumed = thread.get("id") if isinstance(thread, dict) else None
+        if not isinstance(resumed, str) or not resumed:
+            raise CodexProtocolMismatch("ChatGPT helper could not resume the thread")
+        return resumed
+
+    def run_turn(
+        self,
+        *,
+        thread_id: str,
+        text: str,
+        input_items: list[dict[str, Any]] | None = None,
+        model: str = "",
+        output_schema: dict[str, Any] | None = None,
+        tool_handler: Callable[[str, dict[str, Any], str], str] | None = None,
+        event_handler: Callable[[dict[str, Any]], None] | None = None,
+        should_interrupt: Callable[[], bool] | None = None,
+        timeout: float = 1_800,
+    ) -> dict[str, Any]:
+        target = self._subscribe(thread_id)
+        turn_id = ""
+        interrupted = False
+        started = time.monotonic()
+        try:
+            params: dict[str, Any] = {
+                "threadId": thread_id,
+                "input": input_items or [{"type": "text", "text": text}],
+            }
+            if model:
+                params["model"] = model
+            if output_schema is not None:
+                params["outputSchema"] = output_schema
+            response = self.request("turn/start", params, timeout=60)
+            turn = response.get("turn")
+            if isinstance(turn, dict):
+                turn_id = str(turn.get("id") or "")
+            while True:
+                if time.monotonic() - started > timeout:
+                    if turn_id:
+                        try:
+                            self.request(
+                                "turn/interrupt",
+                                {"threadId": thread_id, "turnId": turn_id},
+                                timeout=10,
+                            )
+                        except CodexAppServerError:
+                            pass
+                    raise CodexAppServerError("ChatGPT turn timed out")
+                if should_interrupt is not None and should_interrupt() and not interrupted:
+                    interrupted = True
+                    if turn_id:
+                        self.request(
+                            "turn/interrupt",
+                            {"threadId": thread_id, "turnId": turn_id},
+                            timeout=10,
+                        )
+                try:
+                    event = target.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+                failure = event.get("error")
+                if isinstance(failure, dict) and not event.get("method"):
+                    raise CodexAppServerError(str(failure.get("message") or "ChatGPT turn failed"))
+                method = str(event.get("method") or "")
+                identifier = event.get("id")
+                if identifier is not None and method != "item/tool/call":
+                    self.respond_error(
+                        identifier, -32601, "Locus accepts only registered dynamic tool calls"
+                    )
+                    raise CodexProtocolMismatch(f"Unexpected helper request: {method or 'unknown'}")
+                if event_handler is not None:
+                    event_handler(event)
+                if identifier is not None:
+                    call = event.get("params")
+                    if not isinstance(call, dict):
+                        self.respond_error(identifier, -32602, "Invalid dynamic tool request")
+                        continue
+                    name = str(call.get("tool") or "")
+                    arguments = call.get("arguments")
+                    call_id = str(call.get("callId") or "")
+                    if tool_handler is None:
+                        result = "Not run: this Locus route has no tool access."
+                        success = False
+                    else:
+                        try:
+                            result = tool_handler(
+                                name,
+                                arguments if isinstance(arguments, dict) else {},
+                                call_id,
+                            )
+                            success = not str(result).startswith("Error")
+                        except Exception as error:  # noqa: BLE001 - tool errors return to model
+                            logger.exception("Locus dynamic tool failed")
+                            result = f"Error: {error}"
+                            success = False
+                    self.respond(
+                        identifier,
+                        {
+                            "contentItems": [{"type": "inputText", "text": str(result)}],
+                            "success": success,
+                        },
+                    )
+                    continue
+                if method == "turn/completed":
+                    params_value = event.get("params")
+                    completed = params_value.get("turn") if isinstance(params_value, dict) else None
+                    return completed if isinstance(completed, dict) else {}
+        finally:
+            self._unsubscribe(thread_id, target)
+
+    def complete(
+        self,
+        *,
+        model: str,
+        cwd: str,
+        base_instructions: str,
+        prompt: str,
+        output_schema: dict[str, Any] | None = None,
+        timeout: float = 300,
+    ) -> dict[str, Any]:
+        thread_id = self.start_thread(
+            model=model,
+            cwd=cwd,
+            base_instructions=base_instructions,
+            tools=[],
+            ephemeral=True,
+        )
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        usage: dict[str, Any] = {}
+
+        def collect(event: dict[str, Any]) -> None:
+            nonlocal usage
+            method = event.get("method")
+            params = event.get("params")
+            if not isinstance(params, dict):
+                return
+            if method == "item/agentMessage/delta":
+                delta = params.get("delta")
+                if isinstance(delta, str):
+                    text_parts.append(delta)
+            elif method == "item/reasoning/summaryTextDelta":
+                delta = params.get("delta")
+                if isinstance(delta, str):
+                    reasoning_parts.append(delta)
+            elif method == "thread/tokenUsage/updated":
+                candidate = params.get("tokenUsage")
+                if isinstance(candidate, dict):
+                    usage = candidate
+
+        turn = self.run_turn(
+            thread_id=thread_id,
+            text=prompt,
+            model=model,
+            output_schema=output_schema,
+            event_handler=collect,
+            timeout=timeout,
+        )
+        return {
+            "text": "".join(text_parts),
+            "reasoning": "".join(reasoning_parts),
+            "turn": turn,
+            "usage": usage,
+            "threadId": thread_id,
+        }
+
+    def interrupt(self, thread_id: str, turn_id: str) -> None:
+        self.request("turn/interrupt", {"threadId": thread_id, "turnId": turn_id}, timeout=10)
+
+    def close(self) -> None:
+        with self._state_lock:
+            process = self._process
+            self._process = None
+            self._initialized = {}
+        if process is None:
+            return
+        try:
+            if process.stdin is not None:
+                process.stdin.close()
+        except OSError:
+            pass
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+
+
+class CodexBrokerClient:
+    """Worker-side proxy to the primary backend's sole App Server owner."""
+
+    def __init__(self, url: str, token: str) -> None:
+        self.url = url.strip()
+        self.token = token.strip()
+
+    @property
+    def available(self) -> bool:
+        return bool(self.url and self.token)
+
+    @property
+    def runtime_version(self) -> str:
+        return PINNED_CODEX_APP_SERVER_VERSION
+
+    def add_listener(self, listener: Callable[[dict[str, Any]], None]) -> None:
+        del listener
+
+    def _connect(self):
+        if not self.available:
+            raise CodexAppServerError("The internal ChatGPT broker is unavailable")
+        try:
+            from websockets.sync.client import connect
+            return connect(
+                self.url,
+                additional_headers={"X-Locus-Token": self.token},
+                open_timeout=10,
+                max_size=40 * 1024 * 1024,
+            )
+        except Exception as error:  # noqa: BLE001
+            raise CodexAppServerError(f"Could not connect to the ChatGPT broker: {error}") from error
+
+    def _call(self, operation: str, payload: dict[str, Any] | None = None) -> Any:
+        with self._connect() as socket:
+            socket.send(json.dumps({"op": operation, **(payload or {})}))
+            raw = socket.recv(timeout=1_800)
+        try:
+            response = json.loads(raw)
+        except (TypeError, json.JSONDecodeError) as error:
+            raise CodexProtocolMismatch("The ChatGPT broker returned malformed JSON") from error
+        if not isinstance(response, dict):
+            raise CodexProtocolMismatch("The ChatGPT broker returned an invalid response")
+        if response.get("type") == "error":
+            raise CodexAppServerError(str(response.get("message") or "ChatGPT broker failed"))
+        return response.get("result")
+
+    def account(self, *, refresh: bool = False) -> dict[str, Any]:
+        result = self._call("account", {"refresh": refresh})
+        return result if isinstance(result, dict) else {}
+
+    def models(self) -> list[dict[str, Any]]:
+        result = self._call("models")
+        return [item for item in result if isinstance(item, dict)] if isinstance(result, list) else []
+
+    def usage(self) -> dict[str, Any]:
+        result = self._call("usage")
+        return result if isinstance(result, dict) else {}
+
+    def start_thread(
+        self,
+        *,
+        model: str,
+        cwd: str,
+        base_instructions: str,
+        tools: Iterable[dict[str, Any]],
+        ephemeral: bool = False,
+    ) -> str:
+        result = self._call("thread_start", {
+            "model": model,
+            "cwd": cwd,
+            "base_instructions": base_instructions,
+            "tools": list(tools),
+            "ephemeral": ephemeral,
+        })
+        if not isinstance(result, str) or not result:
+            raise CodexProtocolMismatch("The ChatGPT broker returned no thread id")
+        return result
+
+    def resume_thread(self, thread_id: str, *, model: str, cwd: str) -> str:
+        result = self._call("thread_resume", {
+            "thread_id": thread_id,
+            "model": model,
+            "cwd": cwd,
+        })
+        if not isinstance(result, str) or not result:
+            raise CodexProtocolMismatch("The ChatGPT broker could not resume the thread")
+        return result
+
+    def run_turn(
+        self,
+        *,
+        thread_id: str,
+        text: str,
+        input_items: list[dict[str, Any]] | None = None,
+        model: str = "",
+        output_schema: dict[str, Any] | None = None,
+        tool_handler: Callable[[str, dict[str, Any], str], str] | None = None,
+        event_handler: Callable[[dict[str, Any]], None] | None = None,
+        should_interrupt: Callable[[], bool] | None = None,
+        timeout: float = 1_800,
+    ) -> dict[str, Any]:
+        with self._connect() as socket:
+            socket.send(json.dumps({
+                "op": "turn_run",
+                "thread_id": thread_id,
+                "text": text,
+                "input_items": input_items,
+                "model": model,
+                "output_schema": output_schema,
+                "timeout": timeout,
+            }))
+            while True:
+                if should_interrupt is not None and should_interrupt():
+                    socket.send(json.dumps({"type": "interrupt"}))
+                try:
+                    raw = socket.recv(timeout=min(timeout, 30))
+                except TimeoutError:
+                    continue
+                message = json.loads(raw)
+                kind = str(message.get("type") or "")
+                if kind == "event":
+                    event = message.get("event")
+                    if event_handler is not None and isinstance(event, dict):
+                        event_handler(event)
+                elif kind == "tool_call":
+                    name = str(message.get("tool") or "")
+                    arguments = message.get("arguments")
+                    call_id = str(message.get("call_id") or "")
+                    result = (
+                        tool_handler(name, arguments if isinstance(arguments, dict) else {}, call_id)
+                        if tool_handler is not None
+                        else "Not run: this route has no tool access."
+                    )
+                    socket.send(json.dumps({
+                        "type": "tool_result", "call_id": call_id, "result": str(result),
+                    }))
+                elif kind == "completed":
+                    turn = message.get("turn")
+                    return turn if isinstance(turn, dict) else {}
+                elif kind == "error":
+                    raise CodexAppServerError(str(message.get("message") or "ChatGPT broker failed"))
+
+    def complete(
+        self,
+        *,
+        model: str,
+        cwd: str,
+        base_instructions: str,
+        prompt: str,
+        output_schema: dict[str, Any] | None = None,
+        timeout: float = 300,
+    ) -> dict[str, Any]:
+        result = self._call("complete", {
+            "model": model,
+            "cwd": cwd,
+            "base_instructions": base_instructions,
+            "prompt": prompt,
+            "output_schema": output_schema,
+            "timeout": timeout,
+        })
+        return result if isinstance(result, dict) else {}
+
+    def close(self) -> None:
+        return

--- a/agent/ollama_code/config.py
+++ b/agent/ollama_code/config.py
@@ -41,6 +41,11 @@ DEFAULTS: dict[str, Any] = {
     # file via /api/provider, or from one of REMOTE_API_KEY_ENV at the command
     # line.
     "remote_api_key": "",
+    # Managed ChatGPT-plan routing. Only identifiers and display metadata are
+    # persisted; OAuth credentials remain in the isolated App Server home.
+    "chatgpt_account_id": "",
+    "chatgpt_account_label": "",
+    "chatgpt_model": "",
     # "ask" prompts for every non-safe tool, "accept_edits" also auto-allows
     # file writes/edits, "bypass" auto-allows everything (equivalent to
     # --dangerously-skip-permissions).
@@ -80,7 +85,7 @@ DEFAULTS: dict[str, Any] = {
 
 PERMISSION_MODES = ("ask", "accept_edits", "bypass")
 
-PROVIDERS = ("ollama", "remote")
+PROVIDERS = ("ollama", "remote", "chatgpt")
 
 #: Environment variables searched for the remote API key, in order.
 REMOTE_API_KEY_ENV = (
@@ -208,7 +213,10 @@ def load_config() -> dict[str, Any]:
         cfg["deny_commands"] = list(DEFAULTS["deny_commands"])
     if cfg.get("provider") not in PROVIDERS:
         cfg["provider"] = "ollama"
-    for key in ("remote_auth_style", "remote_account_label"):
+    for key in (
+        "remote_auth_style", "remote_account_label", "chatgpt_account_id",
+        "chatgpt_account_label", "chatgpt_model",
+    ):
         if not isinstance(cfg.get(key), str):
             cfg[key] = ""
     # Silently, rather than raising: a hand-edited config reaches here at

--- a/agent/ollama_code/core.py
+++ b/agent/ollama_code/core.py
@@ -298,6 +298,18 @@ class AgentCore:
         self.model: str = model or str(self.config.get("model") or "")
         if self.provider == "remote":
             self._build_remote_client()
+        elif self.provider == "chatgpt":
+            self.host = "chatgpt://managed"
+            self.model = model or str(self.config.get("chatgpt_model") or "")
+        # Injected by ChatService. Keeping the transport out of Swift and out
+        # of provider clients prevents managed OAuth from ever entering an API
+        # key route.
+        self.codex_manager: Any = None
+        self._chatgpt_thread_id = ""
+        self._chatgpt_thread_fingerprint = ""
+        self._chatgpt_thread_protocol = ""
+        self._chatgpt_thread_history_revision = 0
+        self._chatgpt_thread_needs_resume = False
         self.max_iterations = iteration_limit(
             max_iterations or self.config.get("max_iterations")
         )
@@ -463,7 +475,9 @@ class AgentCore:
         actually is. Strong self-identifying models broke through; compliant
         ones did not, which read as smart models "knowing" and others not.
         """
-        if self.provider == "remote":
+        if self.provider == "chatgpt":
+            provider_label = str(self.config.get("chatgpt_account_label") or "ChatGPT plan")
+        elif self.provider == "remote":
             provider_label = (
                 str(self.config.get("remote_account_label") or "").strip()
                 or str(self.config.get("remote_base_url") or "a remote endpoint")
@@ -493,6 +507,8 @@ class AgentCore:
 
     def ensure_model(self) -> str | None:
         """Pick a model if unset. Returns a warning or None. Raises OllamaError."""
+        if self.provider == "chatgpt":
+            return None
         names = [m.get("name") for m in self.client.list_models() if m.get("name")]
         if not names:
             if self.provider == "remote":
@@ -525,6 +541,13 @@ class AgentCore:
         endpoint that states its own window deserves a working meter just as
         much as a local model does.
         """
+        if self.provider == "chatgpt":
+            # App Server reports token activity, but does not expose a stable
+            # context-window contract through account/model metadata.
+            self.context_limit = 0
+            self._context_source = SOURCE_UNKNOWN
+            self._context_requested = 0
+            return
         if not self.model:
             return
         # Tolerant: `self.config` is not always the dict `load_config` built —
@@ -951,6 +974,48 @@ class AgentCore:
         self.reset_system_message()
         self._emit_info()
 
+    def use_chatgpt(
+        self,
+        *,
+        account_id: str,
+        model: str,
+        account_label: str,
+        manager: Any,
+    ) -> None:
+        """Switch to managed ChatGPT-plan access without accepting secrets."""
+        if manager is None:
+            raise ValueError("the ChatGPT runtime is unavailable")
+        account = manager.account(refresh=False)
+        identity = account.get("account")
+        if not isinstance(identity, dict) or identity.get("type") != "chatgpt":
+            raise ValueError("Sign in with ChatGPT before selecting this account")
+        selected = model.strip()
+        if not selected:
+            models = manager.models()
+            selected = next(
+                (str(item.get("model") or item.get("id") or "") for item in models
+                 if item.get("model") or item.get("id")),
+                "",
+            )
+        if not selected:
+            raise ValueError("The ChatGPT account did not report any available models")
+        self.codex_manager = manager
+        self.provider = "chatgpt"
+        self.host = "chatgpt://managed"
+        self.model = selected
+        self.config["provider"] = "chatgpt"
+        self.config["chatgpt_account_id"] = account_id.strip()
+        self.config["chatgpt_account_label"] = account_label.strip() or "ChatGPT plan"
+        self.config["chatgpt_model"] = selected
+        self.config["remote_api_key"] = ""
+        self.context_limit = 0
+        self._context_source = SOURCE_UNKNOWN
+        self._context_requested = 0
+        self._clear_chatgpt_thread()
+        save_config(self.config)
+        self.reset_system_message()
+        self._emit_info()
+
     def provider_state(self) -> dict[str, Any]:
         """Provider description for the UI. Never includes the key itself."""
         return {
@@ -974,6 +1039,8 @@ class AgentCore:
     @property
     def account_label(self) -> str:
         """The app's name for the account in use, or "" for local Ollama."""
+        if self.provider == "chatgpt":
+            return str(self.config.get("chatgpt_account_label") or "ChatGPT plan")
         if self.provider != "remote":
             return ""
         return str(self.config.get("remote_account_label") or "")
@@ -982,7 +1049,10 @@ class AgentCore:
         self.model = name
         # Each provider remembers its own model, so switching back and forth
         # does not clobber the other's choice.
-        if self.provider == "remote":
+        if self.provider == "chatgpt":
+            self.config["chatgpt_model"] = name
+            self._clear_chatgpt_thread()
+        elif self.provider == "remote":
             self.config["remote_model"] = name
             self.client.configured_model = name
         else:
@@ -1009,6 +1079,7 @@ class AgentCore:
         self.reload_context()
         self.session = self._new_session_store()
         self.messages = [self.system_message()]
+        self._clear_chatgpt_thread()
         self.tool_ctx.todos = []
         self.tool_ctx.plan_document = None
         self._emit({"type": "todo_update", "todos": []})
@@ -1055,6 +1126,7 @@ class AgentCore:
 
     def reset_conversation(self) -> None:
         self.messages = [self.system_message()]
+        self._clear_chatgpt_thread()
         self.tool_ctx.todos = []
         self.tool_ctx.plan_document = None
         self.tool_ctx.read_files.clear()
@@ -1063,6 +1135,14 @@ class AgentCore:
         self._ax_only_routes.clear()
         self._emit({"type": "todo_update", "todos": []})
         self._emit_info()
+
+    def _clear_chatgpt_thread(self) -> None:
+        """Forget helper history while preserving the canonical Locus chat."""
+        self._chatgpt_thread_id = ""
+        self._chatgpt_thread_fingerprint = ""
+        self._chatgpt_thread_protocol = ""
+        self._chatgpt_thread_history_revision = 0
+        self._chatgpt_thread_needs_resume = False
 
     def start_new_session(
         self,
@@ -1213,6 +1293,17 @@ class AgentCore:
         persist_user_message: bool = True,
     ) -> None:
         """Run one local-agent turn."""
+        if self.provider == "chatgpt":
+            self._run_chatgpt_turn(
+                user_text,
+                decider,
+                allow_tools=allow_tools,
+                attachments=attachments,
+                persisted_user_text=persisted_user_text,
+                model_call_limit=model_call_limit,
+                persist_user_message=persist_user_message,
+            )
+            return
         self._run_classic_turn(
             user_text,
             decider,
@@ -1222,6 +1313,236 @@ class AgentCore:
             model_call_limit=model_call_limit,
             persist_user_message=persist_user_message,
         )
+
+    def _run_chatgpt_turn(
+        self,
+        user_text: str,
+        decider: PermissionDecider | None,
+        *,
+        allow_tools: bool,
+        attachments: list[dict[str, str]] | None,
+        persisted_user_text: str | None,
+        model_call_limit: int | None,
+        persist_user_message: bool,
+    ) -> None:
+        """Run a turn through App Server while retaining Locus tool ownership."""
+        from .codex_app_server import CodexAppServerError
+
+        started_at = time.monotonic()
+        prompt_before = self.total_prompt_tokens
+        completion_before = self.total_completion_tokens
+        reason = "complete"
+        self._turn_allows_tools = allow_tools
+        self._last_turn_allowed_tools = allow_tools
+        self._interrupt.clear()
+        self.begin_steerable_turn()
+        self.tool_ctx.read_files.clear()
+        self._last_user_message = user_text
+        if allow_tools:
+            self.reload_context()
+            self.tool_registry.begin_turn(user_text, self.cwd)
+        self.reset_system_message()
+        persisted = (
+            {"role": "user", "content": persisted_user_text}
+            if persisted_user_text is not None else None
+        )
+        self._add_message(
+            {"role": "user", "content": user_text},
+            persisted,
+            persist=persist_user_message,
+        )
+        schemas = self.tool_registry.schemas() if allow_tools else []
+        instructions = str(self.system_message().get("content") or "")
+        if allow_tools:
+            extension_prompt = self._extension_prompt()
+            if extension_prompt:
+                instructions += "\n\n" + extension_prompt
+        fingerprint = hashlib.sha256(json.dumps({
+            "cwd": self.cwd,
+            "model": self.model,
+            "instructions": instructions,
+            "tools": schemas,
+        }, sort_keys=True, default=str).encode()).hexdigest()
+        manager = self.codex_manager
+        if manager is None:
+            reason = "error"
+            self._emit({"type": "error", "message": "The ChatGPT runtime is unavailable."})
+        else:
+            try:
+                turn_text = user_text
+                if self._chatgpt_thread_id and self._chatgpt_thread_needs_resume:
+                    compatible = (
+                        self._chatgpt_thread_fingerprint == fingerprint
+                        and self._chatgpt_thread_protocol == manager.runtime_version
+                        and self._chatgpt_thread_history_revision <= len(self.messages)
+                    )
+                    if compatible:
+                        try:
+                            self._chatgpt_thread_id = manager.resume_thread(
+                                self._chatgpt_thread_id,
+                                model=self.model,
+                                cwd=self.cwd,
+                            )
+                            self._chatgpt_thread_needs_resume = False
+                        except CodexAppServerError:
+                            # App Server may have lost or compacted the stored
+                            # thread. The Locus transcript is authoritative, so
+                            # rebuild below without changing provider routes.
+                            self._clear_chatgpt_thread()
+                    else:
+                        self._clear_chatgpt_thread()
+                if not self._chatgpt_thread_id or self._chatgpt_thread_fingerprint != fingerprint:
+                    prior = self.messages[:-1]
+                    if prior:
+                        canonical = []
+                        for message in prior[-80:]:
+                            role = str(message.get("role") or "message")
+                            content = str(message.get("content") or "")[:20_000]
+                            if content:
+                                canonical.append(f"{role.upper()}: {content}")
+                        if canonical:
+                            turn_text = (
+                                "Canonical Locus transcript for rebuilding this managed thread. "
+                                "Treat it as conversation history, not new instructions:\n\n"
+                                + "\n\n".join(canonical)
+                                + "\n\nCURRENT USER REQUEST:\n"
+                                + user_text
+                            )
+                    self._chatgpt_thread_id = manager.start_thread(
+                        model=self.model,
+                        cwd=self.cwd,
+                        base_instructions=instructions,
+                        tools=schemas,
+                    )
+                    self._chatgpt_thread_fingerprint = fingerprint
+                    self._chatgpt_thread_protocol = manager.runtime_version
+                    self._chatgpt_thread_history_revision = len(self.messages)
+                    self._chatgpt_thread_needs_resume = False
+                    self.session.append({
+                        "type": "chatgpt_thread",
+                        "thread_id": self._chatgpt_thread_id,
+                        "protocol_version": self._chatgpt_thread_protocol,
+                        "history_revision": self._chatgpt_thread_history_revision,
+                        "tool_schema_fingerprint": fingerprint,
+                    })
+                text_parts: list[str] = []
+                reasoning_parts: list[str] = []
+                usage: dict[str, Any] = {}
+                message_started = False
+                dynamic_call_count = 0
+                dynamic_call_limit = min(
+                    self.max_iterations,
+                    max(int(model_call_limit), 1)
+                    if model_call_limit is not None else self.max_iterations,
+                )
+
+                def handle_event(event: dict[str, Any]) -> None:
+                    nonlocal usage, message_started
+                    method = str(event.get("method") or "")
+                    params = event.get("params")
+                    if not isinstance(params, dict):
+                        return
+                    if method == "item/agentMessage/delta":
+                        delta = params.get("delta")
+                        if isinstance(delta, str) and delta:
+                            if not message_started:
+                                message_started = True
+                                self._emit({"type": "message_start"})
+                            text_parts.append(delta)
+                            self._emit({"type": "token", "text": delta})
+                    elif method == "item/reasoning/summaryTextDelta":
+                        # App Server distinguishes the user-visible reasoning
+                        # summary from raw private reasoning. Only the summary
+                        # is allowed into Locus events and transcripts.
+                        delta = params.get("delta")
+                        if isinstance(delta, str) and delta:
+                            reasoning_parts.append(delta)
+                            self._emit({"type": "thinking", "text": delta})
+                    elif method == "thread/tokenUsage/updated":
+                        candidate = params.get("tokenUsage")
+                        if isinstance(candidate, dict):
+                            usage = candidate
+                    elif method in {"item/commandExecution/requestApproval", "item/fileChange/requestApproval"}:
+                        raise RuntimeError("ChatGPT helper requested a disabled native approval")
+
+                def handle_tool(name: str, arguments: dict[str, Any], call_id: str) -> str:
+                    nonlocal dynamic_call_count
+                    if not allow_tools:
+                        return "Not run: Just Chat has no tool or workspace access."
+                    if dynamic_call_count >= dynamic_call_limit:
+                        self._interrupt.set()
+                        return "Error: Locus stopped this turn at its configured tool-step budget."
+                    dynamic_call_count += 1
+                    return self._run_tool_call(
+                        ToolCall(name=name, arguments=arguments, call_id=call_id), decider
+                    )
+
+                manager.run_turn(
+                    thread_id=self._chatgpt_thread_id,
+                    text=turn_text,
+                    input_items=(
+                        [{"type": "text", "text": turn_text}]
+                        + [
+                            {
+                                "type": "image",
+                                "url": (
+                                    f"data:{str(item.get('mime_type') or 'image/png')};base64,"
+                                    f"{str(item.get('data') or '')}"
+                                ),
+                            }
+                            for item in (attachments or [])
+                            if item.get("data")
+                            and str(item.get("mime_type") or "").startswith("image/")
+                        ]
+                    ),
+                    model=self.model,
+                    tool_handler=handle_tool if allow_tools else None,
+                    event_handler=handle_event,
+                    should_interrupt=self._interrupt.is_set,
+                )
+                answer = "".join(text_parts)
+                if message_started:
+                    self._emit({"type": "message_end", "content": answer})
+                assistant_message: dict[str, Any] = {"role": "assistant", "content": answer}
+                reasoning = "".join(reasoning_parts).strip()
+                if reasoning:
+                    assistant_message["_display_reasoning"] = reasoning
+                self._add_message(assistant_message)
+                last = usage.get("last") if isinstance(usage.get("last"), dict) else {}
+                prompt = int(last.get("inputTokens") or 0)
+                completion = int(last.get("outputTokens") or 0)
+                self.total_prompt_tokens += max(prompt, 0)
+                self.total_completion_tokens += max(completion, 0)
+                if self._interrupt.is_set():
+                    reason = "interrupted"
+            except (CodexAppServerError, RuntimeError, ValueError) as error:
+                reason = "interrupted" if self._interrupt.is_set() else "error"
+                self._emit({"type": "error", "message": str(error)})
+                # A crashed or incompatible helper thread is never silently
+                # reused. The canonical Locus transcript remains untouched.
+                self._clear_chatgpt_thread()
+        self.end_steerable_turn()
+        self.tool_registry.end_turn()
+        self._turn_allows_tools = True
+        terminal = {
+            "type": "turn_done",
+            "reason": reason,
+            "duration_ms": max(int((time.monotonic() - started_at) * 1000), 0),
+            "model_calls": 1,
+            "iteration_limit": self.max_iterations,
+            "model_call_limit": model_call_limit,
+            "prompt_tokens": max(self.total_prompt_tokens - prompt_before, 0),
+            "completion_tokens": max(self.total_completion_tokens - completion_before, 0),
+            "provider": self.provider,
+            "model": self.model,
+            "account_label": self.account_label,
+            "workspace_root": self.workspace_root,
+            "session_id": self.session.session_id,
+        }
+        self.last_turn_result = terminal
+        if not self._suppress_turn_done:
+            self._emit(terminal)
+        self._emit_info()
 
     def _run_classic_turn(
         self,
@@ -1499,6 +1820,26 @@ class AgentCore:
             self._emit({"type": "error", "message": "Nothing to regenerate yet."})
             self._emit({"type": "turn_done", "reason": "error", "duration_ms": 0})
             return False
+        if self.provider == "chatgpt":
+            original = dict(self.messages[index])
+            self.messages = self.messages[:index]
+            self.session = self._new_session_store()
+            for message in self.messages[1:]:
+                self.session.append({"type": "message", "message": message})
+            self._clear_chatgpt_thread()
+            self._run_chatgpt_turn(
+                str(original.get("content") or ""),
+                decider,
+                allow_tools=self._last_turn_allowed_tools,
+                attachments=(
+                    original.get("attachments")
+                    if isinstance(original.get("attachments"), list) else None
+                ),
+                persisted_user_text=None,
+                model_call_limit=None,
+                persist_user_message=True,
+            )
+            return True
         started_at = time.monotonic()
         with self._steer_lock:
             if not self._accepting_steers:
@@ -2404,6 +2745,15 @@ class AgentCore:
             except OSError:
                 pass
         self.messages = [self.system_message()] + messages
+        self._clear_chatgpt_thread()
+        if self.provider == "chatgpt":
+            marker = SessionStore.chatgpt_thread_state(path)
+            if marker is not None:
+                self._chatgpt_thread_id = str(marker["thread_id"])
+                self._chatgpt_thread_fingerprint = str(marker["tool_schema_fingerprint"])
+                self._chatgpt_thread_protocol = str(marker["protocol_version"])
+                self._chatgpt_thread_history_revision = int(marker["history_revision"])
+                self._chatgpt_thread_needs_resume = True
         self._pending_computer_screenshot = None
         self._ax_only_routes.clear()
         # Continue appending to the session the user resumed.

--- a/agent/ollama_code/orchestration.py
+++ b/agent/ollama_code/orchestration.py
@@ -25,7 +25,8 @@ from pathlib import Path
 from typing import Any
 
 from .capabilities import enabled as capability_enabled
-from .ollama import OllamaClient, OllamaError, looks_like_image_rejection
+from .codex_app_server import CodexBrokerClient
+from .ollama import ChatResponse, OllamaClient, OllamaError, looks_like_image_rejection
 from .remote import AUTH_ANTHROPIC, RemoteClient
 from .runstore import RunStore
 
@@ -1834,10 +1835,92 @@ def writer_prompt_for_job(prepared: TeamPreparation, job: AgentJob) -> str:
     )
 
 
+class ChatGPTTeamClient:
+    """Tool-free orchestration adapter backed by the primary Codex broker."""
+
+    host = "chatgpt://managed"
+
+    def __init__(self, broker: Any, timeout_seconds: int) -> None:
+        self.broker = broker
+        self.timeout_seconds = timeout_seconds
+
+    def chat_stream(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        on_token: Callable[[str], None] | None = None,
+        should_stop: Stop | None = None,
+        options: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> ChatResponse:
+        if should_stop is not None and should_stop():
+            raise InterruptedError("orchestration cancelled")
+        system = "\n\n".join(
+            str(message.get("content") or "")
+            for message in messages if message.get("role") == "system"
+        )
+        prompt = "\n\n".join(
+            f"{str(message.get('role') or 'user').upper()}: "
+            f"{str(message.get('content') or '')}"
+            for message in messages if message.get("role") != "system"
+        )
+        output_schema = None
+        if tools:
+            function = tools[0].get("function") if isinstance(tools[0], dict) else None
+            if isinstance(function, dict) and isinstance(function.get("parameters"), dict):
+                output_schema = function["parameters"]
+        result = self.broker.complete(
+            model=model,
+            cwd=os.getcwd(),
+            base_instructions=system,
+            prompt=prompt,
+            output_schema=output_schema,
+            timeout=self.timeout_seconds,
+        )
+        text = str(result.get("text") or "")
+        if on_token is not None and text:
+            on_token(text)
+        usage = result.get("usage") if isinstance(result.get("usage"), dict) else {}
+        last = usage.get("last") if isinstance(usage.get("last"), dict) else {}
+        response = ChatResponse(
+            content_parts=[text],
+            done=True,
+            done_reason="stop",
+            prompt_eval_count=int(last.get("inputTokens") or 0),
+            eval_count=int(last.get("outputTokens") or 0),
+        )
+        if should_stop is not None and should_stop():
+            raise InterruptedError("orchestration cancelled")
+        return response
+
+
+_TEAM_CODEX_BROKER_URL = os.environ.get("LOCUS_CODEX_BROKER_URL", "").strip()
+_TEAM_CODEX_BROKER_TOKEN = os.environ.get("LOCUS_CODEX_BROKER_TOKEN", "").strip()
+_TEAM_CODEX_BROKER = (
+    CodexBrokerClient(_TEAM_CODEX_BROKER_URL, _TEAM_CODEX_BROKER_TOKEN)
+    if _TEAM_CODEX_BROKER_URL and _TEAM_CODEX_BROKER_TOKEN else None
+)
+
+
+def configure_chatgpt_manager(manager: Any) -> None:
+    """Install the primary manager when orchestration runs in that process."""
+    global _TEAM_CODEX_BROKER
+    if _TEAM_CODEX_BROKER is None:
+        _TEAM_CODEX_BROKER = manager
+
+
 def _client(profile: AgentProfile):
     route = profile.route
     if route.get("provider") == "ollama":
         return OllamaClient(str(route.get("host") or "http://localhost:11434"), profile.timeout_seconds)
+    if route.get("provider") == "chatgpt":
+        # The module captures this before ChatService removes the environment
+        # values, so tools and child processes never inherit the broker token.
+        broker = _TEAM_CODEX_BROKER
+        if broker is None:
+            raise OrchestrationError("the primary ChatGPT broker is unavailable")
+        return ChatGPTTeamClient(broker, profile.timeout_seconds)
     return RemoteClient(
         base_url=str(route.get("base_url") or ""),
         api_key=str(route.get("api_key") or ""),
@@ -1897,6 +1980,13 @@ def _validate_route(route: dict[str, Any], name: str) -> None:
         if not host:
             raise OrchestrationError(f"local route for {name} has no Ollama host")
         return
+    if provider == "chatgpt":
+        if not str(route.get("account_id") or ""):
+            raise OrchestrationError(f"ChatGPT route for {name} has no account id")
+        forbidden = {"api_key", "base_url", "authorization", "token"}.intersection(route)
+        if forbidden:
+            raise OrchestrationError(f"ChatGPT route for {name} contains credentials")
+        return
     if provider != "remote" or not str(route.get("base_url") or ""):
         raise OrchestrationError(f"provider route for {name} is unavailable")
     if not str(route.get("api_key") or ""):
@@ -1906,6 +1996,8 @@ def _validate_route(route: dict[str, Any], name: str) -> None:
 def _route_label(route: dict[str, Any]) -> str:
     if route.get("provider") == "ollama":
         return "Local Ollama"
+    if route.get("provider") == "chatgpt":
+        return str(route.get("account_label") or "ChatGPT plan")
     return str(route.get("account_label") or route.get("base_url") or "Hosted provider")
 
 

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -37,6 +37,12 @@ from fastapi.responses import JSONResponse
 from . import __version__, gitinfo, proxy
 from .capabilities import enabled as capability_enabled
 from .capabilities import snapshot as capability_snapshot
+from .codex_app_server import (
+    CodexAppServerError,
+    CodexAppServerManager,
+    CodexBrokerClient,
+    CodexProtocolMismatch,
+)
 from .config import (
     MAX_ITERATIONS_CEILING,
     MINIMUM_CONTEXT_WINDOW,
@@ -65,6 +71,7 @@ from .orchestration import (
     TeamOrchestrator,
     TeamPreparation,
     client_for_profile,
+    configure_chatgpt_manager,
     orchestration_fingerprint,
     parse_manifest,
     writer_prompt_for_job,
@@ -141,6 +148,15 @@ class ChatService:
 
     def __init__(self, core: AgentCore) -> None:
         self.core = core
+        broker_url = os.environ.pop("LOCUS_CODEX_BROKER_URL", "").strip()
+        broker_token = os.environ.pop("LOCUS_CODEX_BROKER_TOKEN", "").strip()
+        self.codex = (
+            CodexBrokerClient(broker_url, broker_token)
+            if broker_url else CodexAppServerManager(client_version=__version__)
+        )
+        configure_chatgpt_manager(self.codex)
+        self.core.codex_manager = self.codex
+        self.codex.add_listener(self._on_codex_event)
         self.worker_id = uuid.uuid4().hex
         self.loop: asyncio.AbstractEventLoop | None = None
         self.queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
@@ -191,6 +207,14 @@ class ChatService:
             record=lambda record: self.core.session.append(record),
             config=core.config,
         )
+
+    def _on_codex_event(self, event: dict[str, Any]) -> None:
+        """Expose only account/limit invalidations, never helper payloads."""
+        method = str(event.get("method") or "")
+        if method in {"account/login/completed", "account/updated"}:
+            self.emit({"type": "chatgpt_account_updated"})
+        elif method == "account/rateLimits/updated":
+            self.emit({"type": "chatgpt_usage_updated"})
 
     def resolve_context_limit_soon(self) -> None:
         """Ask the core to settle its window off-thread, if probing is allowed."""
@@ -690,6 +714,7 @@ async def lifespan(app: FastAPI):
             # Dev servers deliberately have no deadline; shutdown is the one
             # guaranteed reaper.
             svc.dev_servers.stop_all()
+            svc.codex.close()
             svc.core.close()
 
 
@@ -746,13 +771,18 @@ def _require_capability(name: str) -> None:
 @app.get("/api/health")
 def health() -> dict[str, Any]:
     svc = service()
-    try:
-        svc.core.client.check()
-        reachable = True
-        error = None
-    except OllamaError as e:
-        reachable = False
-        error = str(e)
+    if svc.core.provider == "chatgpt":
+        state = _chatgpt_account_payload(svc)
+        reachable = state["status"] == "signed_in"
+        error = None if reachable else state.get("message") or "ChatGPT sign-in is required"
+    else:
+        try:
+            svc.core.client.check()
+            reachable = True
+            error = None
+        except OllamaError as e:
+            reachable = False
+            error = str(e)
     return {
         "ok": True,
         "version": __version__,
@@ -1127,6 +1157,11 @@ def _run_evaluation_suite(
                     role="evaluation",
                 )
                 evaluation_service = ChatService(evaluation_core)
+                # Evaluations in a dedicated worker share that worker's
+                # authenticated proxy; they never launch another App Server.
+                evaluation_service.codex.close()
+                evaluation_service.codex = parent.codex
+                evaluation_service.core.codex_manager = parent.codex
                 evaluation_service.run_store = parent.run_store
                 evaluation_service.core.mcp.task_store = parent.run_store
                 evaluation_service.current_task = task
@@ -1386,6 +1421,133 @@ def _evaluation_changed_paths(task: TaskCheckout, current_tree: str) -> list[str
     ]
 
 
+def _chatgpt_account_payload(svc: ChatService, *, refresh: bool = False) -> dict[str, Any]:
+    """Stable, secret-free account shape for native clients."""
+    if not svc.codex.available:
+        return {
+            "status": "runtime_unavailable",
+            "runtime_available": False,
+            "message": "The bundled ChatGPT runtime is unavailable.",
+            "email": None,
+            "plan_type": None,
+        }
+    try:
+        raw = svc.codex.account(refresh=refresh)
+    except CodexAppServerError as error:
+        return {
+            "status": "runtime_unavailable",
+            "runtime_available": False,
+            "message": str(error),
+            "email": None,
+            "plan_type": None,
+        }
+    account = raw.get("account")
+    signed_in = isinstance(account, dict) and account.get("type") == "chatgpt"
+    return {
+        "status": "signed_in" if signed_in else "signed_out",
+        "runtime_available": True,
+        "runtime_version": str(raw.get("runtimeVersion") or ""),
+        "email": account.get("email") if signed_in else None,
+        "plan_type": account.get("planType") if signed_in else None,
+        "message": "" if signed_in else "Sign in to use included ChatGPT plan usage.",
+    }
+
+
+@app.get("/api/chatgpt/account")
+def chatgpt_account(refresh: bool = Query(default=False)) -> dict[str, Any]:
+    return _chatgpt_account_payload(service(), refresh=refresh)
+
+
+@app.post("/api/chatgpt/login/start")
+def chatgpt_login_start() -> dict[str, Any]:
+    svc = service()
+    try:
+        result = svc.codex.start_login()
+    except CodexAppServerError as error:
+        raise HTTPException(503, str(error)) from error
+    return {
+        "status": "signing_in",
+        "login_id": str(result.get("loginId") or ""),
+        "auth_url": str(result.get("authUrl") or ""),
+    }
+
+
+@app.post("/api/chatgpt/login/cancel")
+def chatgpt_login_cancel(body: dict[str, Any] = Body(default_factory=dict)) -> dict[str, Any]:
+    login_id = str(body.get("login_id") or "").strip()
+    if not login_id:
+        raise HTTPException(422, "login_id is required")
+    try:
+        service().codex.cancel_login(login_id)
+    except CodexAppServerError as error:
+        raise HTTPException(409, str(error)) from error
+    return _chatgpt_account_payload(service())
+
+
+@app.post("/api/chatgpt/logout")
+def chatgpt_logout() -> dict[str, Any]:
+    svc = service()
+    try:
+        with svc.state_mutation():
+            svc.codex.logout()
+            if svc.core.provider == "chatgpt":
+                svc.core.use_ollama()
+    except AgentBusyError as error:
+        raise _busy_http() from error
+    except CodexAppServerError as error:
+        raise HTTPException(409, str(error)) from error
+    return _chatgpt_account_payload(svc)
+
+
+@app.get("/api/chatgpt/models")
+def chatgpt_models() -> dict[str, Any]:
+    svc = service()
+    account = _chatgpt_account_payload(svc)
+    if account["status"] != "signed_in":
+        return {"models": [], "status": account["status"], "message": account["message"]}
+    try:
+        rows = svc.codex.models()
+    except CodexAppServerError as error:
+        raise HTTPException(503, str(error)) from error
+    return {
+        "status": "signed_in",
+        "models": [
+            {
+                "id": str(row.get("model") or row.get("id") or ""),
+                "display_name": str(row.get("displayName") or row.get("model") or row.get("id") or ""),
+                "description": str(row.get("description") or ""),
+                "is_default": bool(row.get("isDefault")),
+            }
+            for row in rows if row.get("model") or row.get("id")
+        ],
+    }
+
+
+@app.get("/api/chatgpt/usage")
+def chatgpt_usage() -> dict[str, Any]:
+    svc = service()
+    account = _chatgpt_account_payload(svc)
+    if account["status"] != "signed_in":
+        return {
+            "status": account["status"],
+            "plan_type": account.get("plan_type"),
+            "rate_limits": {},
+            "activity": {},
+            "message": account["message"],
+        }
+    try:
+        raw = svc.codex.usage()
+    except CodexAppServerError as error:
+        raise HTTPException(503, str(error)) from error
+    return {
+        "status": "signed_in",
+        "plan_type": account.get("plan_type"),
+        "rate_limits": raw.get("rateLimits") or {},
+        "activity": raw.get("activity") or {},
+        "message": "",
+    }
+
+
 @app.post("/api/provider")
 def set_provider(body: dict[str, Any] = Body(default_factory=dict)) -> dict[str, Any]:
     """Switch between the local runtime and a hosted endpoint.
@@ -1404,8 +1566,8 @@ def set_provider(body: dict[str, Any] = Body(default_factory=dict)) -> dict[str,
 def _apply_provider(svc: ChatService, body: dict[str, Any]) -> dict[str, Any]:
     """Apply a provider request after the service has reserved mutable state."""
     provider = str(body.get("provider") or "").strip().lower()
-    if provider not in ("ollama", "remote"):
-        raise HTTPException(422, "provider must be 'ollama' or 'remote'")
+    if provider not in ("ollama", "remote", "chatgpt"):
+        raise HTTPException(422, "provider must be 'ollama', 'remote', or 'chatgpt'")
 
     if provider == "ollama":
         try:
@@ -1416,6 +1578,27 @@ def _apply_provider(svc: ChatService, body: dict[str, Any]) -> dict[str, Any]:
         except ValueError as e:
             raise HTTPException(422, str(e)) from e
         svc.resolve_context_limit_soon()
+        return svc.core.provider_state()
+
+    if provider == "chatgpt":
+        forbidden = [key for key in ("api_key", "base_url", "remote_base_url") if key in body]
+        if forbidden:
+            raise HTTPException(
+                422,
+                "the ChatGPT provider rejects API-key and base-URL fields",
+            )
+        account_id = str(body.get("account_id") or "").strip()
+        if not account_id:
+            raise HTTPException(422, "account_id is required for the ChatGPT provider")
+        try:
+            svc.core.use_chatgpt(
+                account_id=account_id,
+                model=str(body.get("model") or ""),
+                account_label=str(body.get("account_label") or "ChatGPT plan"),
+                manager=svc.codex,
+            )
+        except (ValueError, CodexAppServerError) as error:
+            raise HTTPException(409, str(error)) from error
         return svc.core.provider_state()
 
     base_url = str(body.get("base_url") or body.get("remote_base_url") or "").strip()
@@ -1455,6 +1638,28 @@ def _apply_provider(svc: ChatService, body: dict[str, Any]) -> dict[str, Any]:
 @app.get("/api/models")
 def models() -> dict[str, Any]:
     svc = service()
+    if svc.core.provider == "chatgpt":
+        try:
+            return {
+                "models": [
+                    {
+                        "name": str(item.get("model") or item.get("id") or ""),
+                        "size": 0,
+                        "parameter_size": "ChatGPT plan",
+                        "context_length": 0,
+                        "trained_context_length": 0,
+                        "vision": (
+                            "image" in item.get("inputModalities", [])
+                            if isinstance(item.get("inputModalities"), list) else None
+                        ),
+                    }
+                    for item in svc.codex.models()
+                    if item.get("model") or item.get("id")
+                ],
+                "current": svc.core.model,
+            }
+        except CodexAppServerError as error:
+            raise HTTPException(503, str(error)) from error
     try:
         raw = svc.core.client.list_models()
     except OllamaError as e:
@@ -3597,16 +3802,29 @@ def _install_writer_route(core: AgentCore, writer: AgentProfile) -> dict[str, An
         "context_source": core._context_source,
         "context_requested": core._context_requested,
         "context_for": core._context_limit_for,
+        "chatgpt_thread_id": getattr(core, "_chatgpt_thread_id", ""),
+        "chatgpt_thread_fingerprint": getattr(core, "_chatgpt_thread_fingerprint", ""),
         "mcp_policy": core.tool_registry.mcp_agent_policy_snapshot(),
     }
-    client = client_for_profile(writer)
-    core.client = client
     core.model = writer.model
-    core.host = client.host
-    core.provider = "ollama" if writer.route.get("provider") == "ollama" else "remote"
-    core.config["remote_account_label"] = str(
-        writer.route.get("account_label") or writer.name
-    ) if core.provider == "remote" else ""
+    if writer.route.get("provider") == "chatgpt":
+        core.provider = "chatgpt"
+        core.host = "chatgpt://managed"
+        core.config["chatgpt_account_id"] = str(writer.route.get("account_id") or "")
+        core.config["chatgpt_account_label"] = str(
+            writer.route.get("account_label") or writer.name
+        )
+        core.config["chatgpt_model"] = writer.model
+        core._chatgpt_thread_id = ""
+        core._chatgpt_thread_fingerprint = ""
+    else:
+        client = client_for_profile(writer)
+        core.client = client
+        core.host = client.host
+        core.provider = "ollama" if writer.route.get("provider") == "ollama" else "remote"
+        core.config["remote_account_label"] = str(
+            writer.route.get("account_label") or writer.name
+        ) if core.provider == "remote" else ""
     core.context_limit = 0
     core._context_source = "unknown"
     core._context_requested = 0
@@ -3634,6 +3852,8 @@ def _restore_writer_route(core: AgentCore, snapshot: dict[str, Any]) -> None:
     core._context_source = snapshot["context_source"]
     core._context_requested = snapshot["context_requested"]
     core._context_limit_for = snapshot["context_for"]
+    core._chatgpt_thread_id = snapshot.get("chatgpt_thread_id", "")
+    core._chatgpt_thread_fingerprint = snapshot.get("chatgpt_thread_fingerprint", "")
     policy, access_ceiling, role = snapshot["mcp_policy"]
     core.tool_registry.set_mcp_agent_policy(
         policy, access_ceiling=access_ceiling, role=role,
@@ -3940,6 +4160,138 @@ async def _handle_client_message(svc: ChatService, msg: dict[str, Any]) -> None:
         svc.queue_event({"type": "pong"})
     else:
         _command_error(svc, str(mtype or "unknown"), f"unknown message type: {mtype}")
+
+
+@app.websocket("/ws/internal/codex")
+async def ws_codex_broker(ws: WebSocket) -> None:
+    """Authenticated duplex broker for isolated team worker processes."""
+    origin = ws.headers.get("origin")
+    if origin:
+        await ws.close(code=1008, reason="browser connections are not allowed")
+        return
+    token = str(getattr(app.state, "auth_token", "") or "")
+    if not token or ws.headers.get("x-locus-token") != token:
+        await ws.close(code=1008, reason="internal broker authentication failed")
+        return
+    await ws.accept()
+    svc = service()
+    # A worker must never cause another helper to launch behind the broker.
+    if isinstance(svc.codex, CodexBrokerClient):
+        await ws.send_json({"type": "error", "message": "nested ChatGPT brokers are forbidden"})
+        await ws.close(code=1008)
+        return
+    try:
+        request = await ws.receive_json()
+        operation = str(request.get("op") or "")
+        if operation == "account":
+            result = await asyncio.to_thread(
+                svc.codex.account, refresh=bool(request.get("refresh"))
+            )
+            await ws.send_json({"type": "result", "result": result})
+        elif operation == "models":
+            await ws.send_json({
+                "type": "result", "result": await asyncio.to_thread(svc.codex.models),
+            })
+        elif operation == "usage":
+            await ws.send_json({
+                "type": "result", "result": await asyncio.to_thread(svc.codex.usage),
+            })
+        elif operation == "thread_start":
+            result = await asyncio.to_thread(
+                svc.codex.start_thread,
+                model=str(request.get("model") or ""),
+                cwd=str(request.get("cwd") or svc.core.cwd),
+                base_instructions=str(request.get("base_instructions") or ""),
+                tools=request.get("tools") if isinstance(request.get("tools"), list) else [],
+                ephemeral=bool(request.get("ephemeral")),
+            )
+            await ws.send_json({"type": "result", "result": result})
+        elif operation == "thread_resume":
+            result = await asyncio.to_thread(
+                svc.codex.resume_thread,
+                str(request.get("thread_id") or ""),
+                model=str(request.get("model") or ""),
+                cwd=str(request.get("cwd") or svc.core.cwd),
+            )
+            await ws.send_json({"type": "result", "result": result})
+        elif operation == "complete":
+            result = await asyncio.to_thread(
+                svc.codex.complete,
+                model=str(request.get("model") or ""),
+                cwd=str(request.get("cwd") or svc.core.cwd),
+                base_instructions=str(request.get("base_instructions") or ""),
+                prompt=str(request.get("prompt") or ""),
+                output_schema=(
+                    request.get("output_schema")
+                    if isinstance(request.get("output_schema"), dict) else None
+                ),
+                timeout=float(request.get("timeout") or 300),
+            )
+            await ws.send_json({"type": "result", "result": result})
+        elif operation == "turn_run":
+            loop = asyncio.get_running_loop()
+            inbound: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+            interrupted = threading.Event()
+
+            async def receive_worker_results() -> None:
+                while True:
+                    message = await ws.receive_json()
+                    if message.get("type") == "interrupt":
+                        interrupted.set()
+                    else:
+                        await inbound.put(message)
+
+            receiver = asyncio.create_task(receive_worker_results())
+
+            def send_from_helper(message: dict[str, Any]) -> None:
+                future = asyncio.run_coroutine_threadsafe(ws.send_json(message), loop)
+                future.result(timeout=30)
+
+            def forward_event(event: dict[str, Any]) -> None:
+                send_from_helper({"type": "event", "event": event})
+
+            def run_tool(name: str, arguments: dict[str, Any], call_id: str) -> str:
+                send_from_helper({
+                    "type": "tool_call", "tool": name,
+                    "arguments": arguments, "call_id": call_id,
+                })
+                future = asyncio.run_coroutine_threadsafe(inbound.get(), loop)
+                reply = future.result(timeout=1_800)
+                if reply.get("type") != "tool_result" or reply.get("call_id") != call_id:
+                    raise CodexProtocolMismatch("worker returned an invalid dynamic tool result")
+                return str(reply.get("result") or "")
+
+            try:
+                turn = await asyncio.to_thread(
+                    svc.codex.run_turn,
+                    thread_id=str(request.get("thread_id") or ""),
+                    text=str(request.get("text") or ""),
+                    input_items=(
+                        request.get("input_items")
+                        if isinstance(request.get("input_items"), list) else None
+                    ),
+                    model=str(request.get("model") or ""),
+                    output_schema=(
+                        request.get("output_schema")
+                        if isinstance(request.get("output_schema"), dict) else None
+                    ),
+                    tool_handler=run_tool,
+                    event_handler=forward_event,
+                    should_interrupt=interrupted.is_set,
+                    timeout=float(request.get("timeout") or 1_800),
+                )
+                await ws.send_json({"type": "completed", "turn": turn})
+            finally:
+                receiver.cancel()
+        else:
+            await ws.send_json({"type": "error", "message": "unknown broker operation"})
+    except (CodexAppServerError, CodexProtocolMismatch, ValueError, RuntimeError) as error:
+        try:
+            await ws.send_json({"type": "error", "message": str(error)})
+        except RuntimeError:
+            pass
+    except WebSocketDisconnect:
+        return
 
 
 @app.websocket("/ws/chat")

--- a/agent/ollama_code/sessions.py
+++ b/agent/ollama_code/sessions.py
@@ -267,6 +267,50 @@ class SessionStore:
         return messages
 
     @staticmethod
+    def chatgpt_thread_state(path: Path) -> dict[str, Any] | None:
+        """Return the latest secret-free managed-thread resume marker.
+
+        The marker stays outside message history so exports and canonical
+        transcript rebuilds never treat a helper id as user content. Reads use
+        the normal transcript ceilings to keep damaged files bounded.
+        """
+        latest: dict[str, Any] | None = None
+        try:
+            if path.stat().st_size > MAX_SESSION_BYTES:
+                return None
+            with path.open("rb") as handle:
+                for raw in handle:
+                    if len(raw) > MAX_SESSION_LINE_BYTES:
+                        return None
+                    if not raw.strip():
+                        continue
+                    try:
+                        record = json.loads(raw.decode("utf-8", errors="replace"))
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(record, dict) or record.get("type") != "chatgpt_thread":
+                        continue
+                    thread_id = record.get("thread_id")
+                    protocol = record.get("protocol_version")
+                    fingerprint = record.get("tool_schema_fingerprint")
+                    revision = record.get("history_revision")
+                    if (
+                        isinstance(thread_id, str) and thread_id
+                        and isinstance(protocol, str) and protocol
+                        and isinstance(fingerprint, str) and fingerprint
+                        and isinstance(revision, int) and revision >= 0
+                    ):
+                        latest = {
+                            "thread_id": thread_id,
+                            "protocol_version": protocol,
+                            "tool_schema_fingerprint": fingerprint,
+                            "history_revision": revision,
+                        }
+        except OSError:
+            return None
+        return latest
+
+    @staticmethod
     def agent_activity(path: Path) -> dict[str, Any]:
         """Rebuild the latest bounded team-activity snapshot in one pass.
 

--- a/agent/tests/test_chatgpt_app_server.py
+++ b/agent/tests/test_chatgpt_app_server.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import pytest
+
+from ollama_code.codex_app_server import (
+    CodexAppServerError,
+    CodexAppServerManager,
+    CodexProtocolMismatch,
+    dynamic_tools,
+)
+from ollama_code.core import AgentCore
+
+
+def schema(name: str) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"Run {name}",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def test_dynamic_tools_preserve_only_the_locus_inventory():
+    translated = dynamic_tools([schema("read_file"), schema("browser_read_page")])
+    assert [item["name"] for item in translated] == ["read_file", "browser_read_page"]
+    assert all(item["type"] == "function" for item in translated)
+    assert all("command_execution" not in item["name"] for item in translated)
+    assert translated[0]["inputSchema"]["required"] == ["path"]
+
+
+def test_dynamic_tools_reject_duplicates_and_invalid_names():
+    with pytest.raises(CodexProtocolMismatch, match="duplicate"):
+        dynamic_tools([schema("read_file"), schema("read_file")])
+    with pytest.raises(CodexProtocolMismatch, match="not App Server compatible"):
+        dynamic_tools([schema("bad tool name")])
+
+
+def test_bundled_codex_command_uses_supported_app_server_flags():
+    manager = CodexAppServerManager(helper_path="/fake/codex")
+    assert manager._command() == ["/fake/codex", "app-server", "--listen", "stdio://"]
+
+
+def test_thread_contract_disables_native_environment_and_tools(monkeypatch):
+    manager = CodexAppServerManager(helper_path="/fake/codex")
+    captured = {}
+
+    def request(method, params=None, **_kwargs):
+        captured["method"] = method
+        captured["params"] = params
+        return {"thread": {"id": "thread-1"}}
+
+    monkeypatch.setattr(manager, "request", request)
+    assert manager.start_thread(
+        model="gpt-test",
+        cwd="/workspace",
+        base_instructions="Locus system prompt",
+        tools=[schema("read_file")],
+    ) == "thread-1"
+
+    assert captured["method"] == "thread/start"
+    params = captured["params"]
+    assert params["environments"] == []
+    assert params["approvalPolicy"] == "never"
+    assert params["sandbox"] == "read-only"
+    assert params["baseInstructions"] == "Locus system prompt"
+    assert [item["name"] for item in params["dynamicTools"]] == ["read_file"]
+    assert params["config"]["web_search"] == "disabled"
+    assert params["config"]["model_reasoning_summary"] == "auto"
+    assert params["config"]["agents"]["enabled"] is False
+    assert all(value is False for value in params["config"]["features"].values())
+
+
+def test_chatgpt_route_contains_no_secret_fields():
+    from ollama_code.orchestration import AgentProfile
+
+    base = {
+        "id": "writer",
+        "name": "Writer",
+        "model": "gpt-test",
+        "role": "implementer",
+        "instructions": "Write carefully",
+        "capabilities": [],
+        "access_ceiling": "workspace_write",
+        "timeout_seconds": 60,
+        "token_limit": 8_000,
+        "metering": "self_hosted",
+        "route": {
+            "provider": "chatgpt",
+            "account_id": "managed-account",
+            "account_label": "ChatGPT plan",
+        },
+    }
+    assert AgentProfile.parse(base).route["provider"] == "chatgpt"
+    base["route"]["api_key"] = "must-not-pass"
+    with pytest.raises(ValueError, match="contains credentials"):
+        AgentProfile.parse(base)
+
+
+class FakeManagedRuntime:
+    runtime_version = "0.147.0"
+
+    def __init__(self, *, reject_resume: bool = False):
+        self.reject_resume = reject_resume
+        self.started: list[str] = []
+        self.resumed: list[str] = []
+        self.turn_texts: list[str] = []
+
+    def account(self, *, refresh=False):
+        del refresh
+        return {"account": {"type": "chatgpt", "email": "person@example.com"}}
+
+    def models(self):
+        return [{"model": "gpt-test"}]
+
+    def start_thread(self, **_kwargs):
+        thread_id = f"thread-{len(self.started) + 1}"
+        self.started.append(thread_id)
+        return thread_id
+
+    def resume_thread(self, thread_id, **_kwargs):
+        self.resumed.append(thread_id)
+        if self.reject_resume:
+            raise CodexAppServerError("history unavailable")
+        return thread_id
+
+    def run_turn(self, *, text, event_handler, **_kwargs):
+        self.turn_texts.append(text)
+        event_handler({
+            "method": "item/reasoning/summaryTextDelta",
+            "params": {"delta": "Checked the workspace."},
+        })
+        event_handler({
+            "method": "item/reasoning/textDelta",
+            "params": {"delta": "private chain of thought"},
+        })
+        event_handler({
+            "method": "item/agentMessage/delta",
+            "params": {"delta": "managed answer"},
+        })
+        event_handler({
+            "method": "thread/tokenUsage/updated",
+            "params": {
+                "tokenUsage": {"last": {"inputTokens": 4, "outputTokens": 2}},
+            },
+        })
+        return {"status": "completed"}
+
+
+def _managed_core(tmp_path, runtime):
+    core = AgentCore(cwd=str(tmp_path), config={})
+    core.use_chatgpt(
+        account_id="managed-account",
+        model="gpt-test",
+        account_label="ChatGPT plan",
+        manager=runtime,
+    )
+    return core
+
+
+def test_managed_thread_resumes_from_secret_free_session_marker(tmp_path):
+    runtime = FakeManagedRuntime()
+    core = _managed_core(tmp_path, runtime)
+    core.run_turn("first request", allow_tools=False)
+    session_id = core.session.session_id
+
+    core.start_new_session()
+    core.resume_session(session_id)
+    core.run_turn("second request", allow_tools=False)
+
+    assert runtime.started == ["thread-1"]
+    assert runtime.resumed == ["thread-1"]
+    marker = core.session.chatgpt_thread_state(core.session.path)
+    assert marker is not None
+    assert marker["thread_id"] == "thread-1"
+    assert "token" not in marker and "api_key" not in marker
+
+
+def test_managed_reasoning_streams_only_provider_summary(tmp_path):
+    runtime = FakeManagedRuntime()
+    core = _managed_core(tmp_path, runtime)
+    events = []
+    core.on_event(events.append)
+
+    core.run_turn("inspect", allow_tools=False)
+
+    thinking = "".join(event.get("text", "") for event in events if event["type"] == "thinking")
+    assert thinking == "Checked the workspace."
+    assert "private chain of thought" not in thinking
+    assistant = next(message for message in reversed(core.messages) if message["role"] == "assistant")
+    assert assistant["_display_reasoning"] == "Checked the workspace."
+
+
+def test_missing_managed_history_rebuilds_from_canonical_transcript(tmp_path):
+    runtime = FakeManagedRuntime(reject_resume=True)
+    core = _managed_core(tmp_path, runtime)
+    core.run_turn("first request", allow_tools=False)
+    session_id = core.session.session_id
+
+    core.start_new_session()
+    core.resume_session(session_id)
+    core.run_turn("second request", allow_tools=False)
+
+    assert runtime.resumed == ["thread-1"]
+    assert runtime.started == ["thread-1", "thread-2"]
+    assert "Canonical Locus transcript" in runtime.turn_texts[-1]
+    assert "first request" in runtime.turn_texts[-1]


### PR DESCRIPTION
## What changed
- add one managed ChatGPT-plan account backed by the pinned OpenAI Codex App Server, including browser sign-in, model discovery, usage/limit reporting, streaming reasoning summaries, normal chat, teams, and evaluations
- preserve Locus tools, permissions, budgets, events, and transcript ownership through dynamic tools and the authenticated internal broker
- make account rows full-width and left-to-right, hand Settings off cleanly to the Hugging Face library, and include the browser toolbar reorder
- bundle and audit the Rust helper and code-mode host with signing entitlements, provenance, checksums, notices, and release checks
- update README, changelog, security, contribution, agent, and protocol documentation

## Why
Users can use eligible ChatGPT subscription usage without supplying an API key or keeping the ChatGPT/Codex desktop apps open. OpenAI API accounts remain separate and never act as a fallback.

## Verification
- Python: 458 passed
- Swift unit tests: 376 passed
- macOS UI tests: 40 passed in the full run; the two selector regressions found during that run were fixed and passed in isolated reruns
- Release and ReleaseMAS builds passed
- Ruff, shell syntax, entitlements/plists, dependency audit, project-generation check, helper checksum/provenance, and credential scan passed

## Public-readiness notes
The source tree has the expected license, notice, security policy, contribution guide, templates, CI, and no detected credentials or accidental artifacts. Before changing repository visibility, follow up by enabling Issues/security features and main-branch rules, reviewing public operational identifiers, and generating a complete transitive Rust/V8 license inventory before the next binary release.