### PR TITLE
Refine workspace UI and tool activity

### DIFF
--- a/Locus/AgentTeamsSettingsView.swift
+++ b/Locus/AgentTeamsSettingsView.swift
@@ -934,7 +934,7 @@ private struct AgentProfileEditor: View {
                 .font(.system(size: 8, weight: .bold))
                 .tracking(0.8)
                 .foregroundStyle(LocusTheme.muted)
-            Text("Read-only agents get only the tool groups you check. These choices can remove access; they never override Bypass, workspace boundaries, or the read-only ceiling.")
+            Text("Read-only agents get only the tool groups you check. These choices can remove access; they never override Full Access, workspace boundaries, or the read-only ceiling.")
                 .font(.system(size: 8))
                 .foregroundStyle(LocusTheme.muted)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -10005,6 +10005,38 @@ final class AppModel: ObservableObject {
                 ))
             }
         }
+        extensions = ExtensionsResponse(
+            capabilities: ExtensionCapabilities(),
+            marketplaces: [],
+            plugins: [],
+            skills: [],
+            mcpServers: [],
+            mcpPresets: [
+                ExtensionMCPPreset(
+                    id: "github",
+                    name: "github",
+                    displayName: "GitHub",
+                    description: "Search repositories and work with issues and pull requests.",
+                    url: "https://api.githubcopilot.com/mcp/",
+                    sourceURL: nil,
+                    auth: "oauth",
+                    fallback: nil,
+                    fallbackHeader: nil,
+                    optionalHeader: nil,
+                    scopes: [],
+                    warning: "Review requested permissions before connecting.",
+                    requiresProjectRef: false,
+                    installed: false,
+                    serverID: nil,
+                    defaultToolsApprovalMode: "annotations",
+                    resourcesDiscoverable: true,
+                    promptsEnabled: false,
+                    catalogVersion: 1
+                ),
+            ],
+            errors: [],
+            pendingUpdates: 0
+        )
         promptHistory = ["Audit the current changes", "Review the workspace"]
 
         // The three newest inspector tabs read from state the agent normally

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -1083,6 +1083,13 @@ final class AppModel: ObservableObject {
         set { settings.thinkingVisibilityRaw = newValue.rawValue }
     }
 
+    /// App-wide transcript density for tool activity. Like reasoning
+    /// visibility, changing it is immediate and persists through `settings`.
+    var toolActivityVisibility: ToolActivityVisibility {
+        get { settings.resolvedToolActivityVisibility }
+        set { settings.toolActivityVisibilityRaw = newValue.rawValue }
+    }
+
     var justChatEnabled: Bool { selectedMode == .ask }
 
     func setJustChatEnabled(_ enabled: Bool) {
@@ -1132,11 +1139,15 @@ final class AppModel: ObservableObject {
         if let steeringState { return steeringState }
         if let orchestrationState, isBusy { return orchestrationState.title }
         if let request = activePermissionRequest {
+            if toolActivityVisibility == .hidden { return "Action needs approval" }
             return "Waiting for permission · \(request.tool)"
         }
         if let tool = blocks.reversed().compactMap(\.tool).first(where: {
             $0.status == .running || $0.status == .awaitingPermission
         }) {
+            if toolActivityVisibility == .hidden {
+                return tool.status == .running ? "Working…" : "Action needs approval"
+            }
             return tool.status == .running
                 ? "Using \(tool.tool)"
                 : "Waiting for permission · \(tool.tool)"
@@ -5230,6 +5241,14 @@ final class AppModel: ObservableObject {
             guard let self else { return }
             await refreshActivityRuns()
             markAllActivitySeen()
+        }
+    }
+
+    func toggleActivityCenter() {
+        if activityCenterPresented {
+            activityCenterPresented = false
+        } else {
+            openActivityCenter()
         }
     }
 
@@ -9872,6 +9891,11 @@ final class AppModel: ObservableObject {
         settings.automaticInspectorPresentationRaw = AutomaticInspectorPresentation.never.rawValue
         settings.soloPlanPresentationRaw = AutomaticInspectorPresentation.never.rawValue
         settings.teamRunsPresentationRaw = AutomaticInspectorPresentation.never.rawValue
+        if let rawMode = ProcessInfo.processInfo.environment[
+            "LOCUS_UI_TESTING_TOOL_ACTIVITY_MODE"
+        ], ToolActivityVisibility(rawValue: rawMode) != nil {
+            settings.toolActivityVisibilityRaw = rawMode
+        }
         // The suite's inspector tests assume the panel starts open; the
         // collapsed default is covered by a settings unit test instead.
         openInspectorTabs = [.plan]

--- a/Locus/ComposerView.swift
+++ b/Locus/ComposerView.swift
@@ -4,6 +4,7 @@ struct ComposerView: View {
     @EnvironmentObject private var model: AppModel
     @State private var contextPresented = false
     @State private var attachmentsPresented = false
+    @State private var permissionModesPresented = false
     @State private var popupSelection = 0
     @State private var popupDismissedDraft: String?
     @FocusState private var focused: Bool
@@ -798,55 +799,95 @@ struct ComposerView: View {
     /// Always-visible reminder of what the agent may do without asking, and
     /// the fastest way to change it.
     private var permissionChip: some View {
-        Menu {
-            Picker("Permission mode", selection: Binding(
-                get: { model.permissionMode },
-                set: { model.setPermissionMode($0) }
-            )) {
-                ForEach(PermissionMode.allCases) { mode in
-                    Label(mode.title, systemImage: mode.symbol).tag(mode)
-                }
-            }
-            .pickerStyle(.inline)
-            .labelsHidden()
-            Divider()
-            Text(model.permissionMode.detail)
-            Button("Reset session allowances") { model.resetPermissions() }
-                .disabled(model.allowedTools.isEmpty && model.permissionMode == .ask)
+        Button {
+            permissionModesPresented.toggle()
         } label: {
-            HStack(spacing: 5) {
-                Image(systemName: model.permissionMode.isRisky
-                    ? "exclamationmark.shield.fill"
-                    : "shield.lefthalf.filled")
-                Text(model.permissionMode.shortTitle)
-            }
-            .font(.system(size: 8, weight: .semibold))
-            .foregroundStyle(model.permissionMode.isRisky ? LocusTheme.coral : LocusTheme.muted)
-            .padding(.horizontal, 8)
-            .frame(height: 27)
-            .background(
-                model.permissionMode.isRisky
-                    ? LocusTheme.coral.opacity(0.1)
-                    : LocusTheme.paperDeep.opacity(0.75)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    .stroke(
-                        model.permissionMode.isRisky
-                            ? LocusTheme.coral.opacity(0.35)
-                            : LocusTheme.line,
-                        lineWidth: 1
-                    )
-            }
-            .contentShape(Rectangle())
+            permissionChipLabel
+                .foregroundStyle(model.permissionMode.isRisky
+                    ? LocusTheme.danger : LocusTheme.muted)
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
+        .buttonStyle(.plain)
         .fixedSize()
+        .background(LocusTheme.paperDeep.opacity(0.75))
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(LocusTheme.line, lineWidth: 1)
+        }
+        .popover(isPresented: $permissionModesPresented, arrowEdge: .bottom) {
+            permissionModePopover
+        }
         .help("Permissions: \(model.permissionMode.detail)")
         .accessibilityLabel("Permission mode, \(model.permissionMode.title)")
+        .accessibilityValue(model.permissionMode.isRisky ? "Danger" : "Standard")
         .accessibilityIdentifier("composer.permissionMode")
+    }
+
+    private var permissionChipLabel: some View {
+        HStack(spacing: 5) {
+            Image(systemName: model.permissionMode.isRisky
+                ? "exclamationmark.shield.fill"
+                : "shield.lefthalf.filled")
+            Text(model.permissionMode.shortTitle)
+        }
+        .font(.system(size: 8, weight: .semibold))
+        .padding(.horizontal, 8)
+        .frame(height: 27)
+        .contentShape(Rectangle())
+    }
+
+    private var permissionModePopover: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Permission mode")
+                .font(.system(size: 10, weight: .bold))
+
+            ForEach(PermissionMode.allCases) { mode in
+                Button {
+                    model.setPermissionMode(mode)
+                    permissionModesPresented = false
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: mode.symbol)
+                            .frame(width: 15)
+                        Text(mode.title)
+                        Spacer(minLength: 12)
+                        if model.permissionMode == mode {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 8, weight: .bold))
+                        }
+                    }
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(mode.isRisky ? LocusTheme.danger : LocusTheme.inkSoft)
+                    .padding(.horizontal, 8)
+                    .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+                    .background(model.permissionMode == mode
+                        ? LocusTheme.paperDeep : Color.clear)
+                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("composer.permissionMode.\(mode.rawValue)")
+            }
+
+            Divider().overlay(LocusTheme.line)
+
+            Text(model.permissionMode.detail)
+                .font(.system(size: 8))
+                .foregroundStyle(LocusTheme.muted)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button("Reset session allowances") {
+                model.resetPermissions()
+                permissionModesPresented = false
+            }
+            .buttonStyle(.plain)
+            .font(.system(size: 8, weight: .semibold))
+            .foregroundStyle(LocusTheme.inkSoft)
+            .disabled(model.allowedTools.isEmpty && model.permissionMode == .ask)
+        }
+        .padding(10)
+        .frame(width: 240)
+        .background(LocusTheme.white)
     }
 
     private var promptTrimmed: String {

--- a/Locus/ComputerControlService.swift
+++ b/Locus/ComputerControlService.swift
@@ -502,7 +502,7 @@ final class ComputerControlService: ObservableObject {
         guard confirm.contains(where: context.contains) else { return true }
         let alert = NSAlert()
         alert.messageText = "Allow this computer action?"
-        alert.informativeText = "Locus wants to use \(tool) on “\(descriptor.title.nilIfEmpty ?? descriptor.role)”. This action stays confirmation-gated even in Bypass mode."
+        alert.informativeText = "Locus wants to use \(tool) on “\(descriptor.title.nilIfEmpty ?? descriptor.role)”. This action stays confirmation-gated even in Full Access mode."
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Allow Once")
         alert.addButton(withTitle: "Cancel")

--- a/Locus/InspectorPlanTab.swift
+++ b/Locus/InspectorPlanTab.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct InspectorPlanTab: View {
@@ -17,94 +18,140 @@ struct InspectorPlanTab: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    ContextWindowInfoCard()
-                        .environmentObject(model)
-
-                    Divider().overlay(LocusTheme.line)
-
-                    HStack {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("CURRENT RUN")
-                                .font(.system(size: 8, weight: .bold))
-                                .tracking(0.8)
-                                .foregroundStyle(LocusTheme.muted)
-                            Text(model.todos.isEmpty ? "No active plan" : "Agent implementation plan")
-                                .font(.system(size: 11, weight: .bold))
-                        }
-                        Spacer()
-                    }
-                    .accessibilityElement(children: .contain)
-                    .accessibilityIdentifier("plan.activePlan")
-
-                    if model.todos.isEmpty {
-                        VStack(spacing: 11) {
-                            Image(systemName: "list.bullet.clipboard")
-                                .font(.system(size: 23))
-                                .foregroundStyle(LocusTheme.muted)
-                            Text("Plans appear here as the agent breaks work into steps.")
-                                .font(.system(size: 9))
-                                .foregroundStyle(LocusTheme.muted)
-                                .multilineTextAlignment(.center)
-                            Button("Create a plan") {
-                                suggestionsPresented = true
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .tint(LocusTheme.ink)
-                            .controlSize(.small)
-                            .disabled(model.isBusy || model.hasPendingPermission)
-                            .accessibilityIdentifier("plan.create")
-                            .popover(isPresented: $suggestionsPresented, arrowEdge: .bottom) {
-                                PlanSuggestionsPopover { prompt in
-                                    suggestionsPresented = false
-                                    model.requestPlan(prompt: prompt)
-                                }
-                            }
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 28)
-                        .locusCard(radius: 9)
-                    } else {
-                        VStack(spacing: 6) {
-                            GeometryReader { proxy in
-                                ZStack(alignment: .leading) {
-                                    Capsule().fill(LocusTheme.line)
-                                    Capsule()
-                                        .fill(LocusTheme.signalDeep)
-                                        .frame(width: proxy.size.width * progress)
-                                }
-                            }
-                            .frame(height: 4)
-                            HStack {
-                                Text("\(completedCount) of \(model.todos.count) complete")
-                                Spacer()
-                                Text(progress.formatted(.percent.precision(.fractionLength(0))))
-                            }
-                            .font(.system(size: 8))
-                            .foregroundStyle(LocusTheme.muted)
-                        }
-
-                        VStack(spacing: 0) {
-                            ForEach(Array(model.todos.enumerated()), id: \.element.id) { index, todo in
-                                PlanRow(todo: todo, isLast: index == model.todos.count - 1)
-                            }
-                        }
-                    }
+                    activePlanHeader
+                    planContent
                 }
+                // Constrain the padded stack to the vertical scroll view's
+                // viewport so Plan cards never extend under the inspector rail.
                 .padding(17)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxHeight: .infinity)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             Divider().overlay(LocusTheme.line)
 
-            PermissionGuardCard()
+            ContextWindowInfoCard()
                 .environmentObject(model)
                 .fixedSize(horizontal: false, vertical: true)
-                .layoutPriority(1)
-                .padding(.horizontal, 17)
-                .padding(.top, 12)
-                .padding(.bottom, 17)
+                .padding(17)
                 .background(LocusTheme.paperDeep)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var activePlanHeader: some View {
+        HStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("CURRENT RUN")
+                    .font(.system(size: 8, weight: .bold))
+                    .tracking(0.8)
+                    .foregroundStyle(LocusTheme.muted)
+                Text(model.todos.isEmpty ? "No active plan" : "Agent implementation plan")
+                    .font(.system(size: 11, weight: .bold))
+            }
+            Spacer(minLength: 6)
+            PlanOpenFinderButton()
+                .environmentObject(model)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("plan.activePlan")
+    }
+
+    @ViewBuilder
+    private var planContent: some View {
+        if model.todos.isEmpty {
+            VStack(spacing: 11) {
+                Image(systemName: "list.bullet.clipboard")
+                    .font(.system(size: 23))
+                    .foregroundStyle(LocusTheme.muted)
+                Text("Plans appear here as the agent breaks work into steps.")
+                    .font(.system(size: 9))
+                    .foregroundStyle(LocusTheme.muted)
+                    .multilineTextAlignment(.center)
+                Button("Create a plan") {
+                    suggestionsPresented = true
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(LocusTheme.ink)
+                .controlSize(.small)
+                .disabled(model.isBusy || model.hasPendingPermission)
+                .accessibilityIdentifier("plan.create")
+                .popover(isPresented: $suggestionsPresented, arrowEdge: .bottom) {
+                    PlanSuggestionsPopover { prompt in
+                        suggestionsPresented = false
+                        model.requestPlan(prompt: prompt)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 28)
+            .locusCard(radius: 9)
+        } else {
+            VStack(spacing: 6) {
+                GeometryReader { proxy in
+                    ZStack(alignment: .leading) {
+                        Capsule().fill(LocusTheme.line)
+                        Capsule()
+                            .fill(LocusTheme.signalDeep)
+                            .frame(width: proxy.size.width * progress)
+                    }
+                }
+                .frame(height: 4)
+                HStack {
+                    Text("\(completedCount) of \(model.todos.count) complete")
+                    Spacer()
+                    Text(progress.formatted(.percent.precision(.fractionLength(0))))
+                }
+                .font(.system(size: 8))
+                .foregroundStyle(LocusTheme.muted)
+            }
+
+            VStack(spacing: 0) {
+                ForEach(Array(model.todos.enumerated()), id: \.element.id) { index, todo in
+                    PlanRow(todo: todo, isLast: index == model.todos.count - 1)
+                }
+            }
+        }
+    }
+}
+
+/// Opens a managed task's checkout, or the current workspace, in Finder.
+private struct PlanOpenFinderButton: View {
+    @EnvironmentObject private var model: AppModel
+
+    private var targetURL: URL {
+        if let checkout = model.activeTaskRecord?.executionPath,
+           FileManager.default.fileExists(atPath: checkout) {
+            return URL(fileURLWithPath: checkout, isDirectory: true)
+        }
+        return URL(fileURLWithPath: model.workspacePath, isDirectory: true)
+    }
+
+    var body: some View {
+        Button {
+            NSWorkspace.shared.open(targetURL)
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "folder")
+                    .font(.system(size: 9, weight: .semibold))
+                Text("Finder")
+                    .font(.system(size: 8, weight: .semibold))
+            }
+            .foregroundStyle(LocusTheme.inkSoft)
+            .padding(.horizontal, 8)
+            .frame(height: 24)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(LocusTheme.white)
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(LocusTheme.lineStrong, lineWidth: 1)
+        }
+        .help("Open workspace in Finder")
+        .accessibilityLabel("Open workspace in Finder")
+        .accessibilityIdentifier("plan.openIn")
     }
 }
 
@@ -272,88 +319,6 @@ struct PlanSuggestionsPopover: View {
     }
 }
 
-struct PermissionGuardCard: View {
-    @EnvironmentObject private var model: AppModel
-
-    private var mode: PermissionMode { model.permissionMode }
-
-    private var ink: Color {
-        mode.isRisky ? LocusTheme.coral : LocusTheme.permissionInk
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            HStack(spacing: 5) {
-                Image(systemName: mode.isRisky ? "exclamationmark.shield.fill" : "shield.lefthalf.filled")
-                Text("Permissions")
-                Spacer()
-                Text(mode.shortTitle.uppercased())
-                    .font(.system(size: 7, weight: .bold))
-                    .tracking(0.6)
-            }
-            .font(.system(size: 9, weight: .bold))
-            .foregroundStyle(ink)
-
-            Picker("Permission mode", selection: Binding(
-                get: { mode },
-                set: { model.setPermissionMode($0) }
-            )) {
-                ForEach(PermissionMode.allCases) { option in
-                    Text(option.title).tag(option)
-                }
-            }
-            .pickerStyle(.segmented)
-            .controlSize(.small)
-            .labelsHidden()
-            .accessibilityIdentifier("plan.permissionMode")
-
-            Text(mode.detail)
-                .font(.system(size: 8))
-                .foregroundStyle(LocusTheme.permissionMuted)
-                .lineSpacing(2)
-                .fixedSize(horizontal: false, vertical: true)
-
-            if !model.allowedTools.isEmpty {
-                Text("Always allowed this session: \(model.allowedTools.joined(separator: ", "))")
-                    .font(.system(size: 8))
-                    .foregroundStyle(LocusTheme.permissionMuted)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            HStack(spacing: 12) {
-                if !model.allowedTools.isEmpty || mode != .ask {
-                    Button("Reset") { model.resetPermissions() }
-                        .buttonStyle(.plain)
-                        .font(.system(size: 8, weight: .bold))
-                        .underline()
-                        .accessibilityIdentifier("plan.permissionReset")
-                }
-                Button("Review settings") {
-                    model.settingsPresented = true
-                }
-                .buttonStyle(.plain)
-                .font(.system(size: 8, weight: .bold))
-                .underline()
-                .accessibilityIdentifier("plan.permissionSettings")
-            }
-        }
-        .padding(11)
-        .background(LocusTheme.paperDeep)
-        .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 9, style: .continuous)
-                .stroke(
-                    mode.isRisky
-                        ? LocusTheme.coral.opacity(0.4)
-                        : LocusTheme.line,
-                    lineWidth: 1
-                )
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("plan.permissions")
-    }
-}
-
 struct ContextWindowInfoCard: View {
     @EnvironmentObject private var model: AppModel
 
@@ -439,6 +404,7 @@ struct ContextWindowInfoCard: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(11)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(LocusTheme.white.opacity(0.72))
         .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
         .overlay {
@@ -455,11 +421,14 @@ struct ContextWindowInfoCard: View {
             Text(label)
                 .font(.system(size: 8))
                 .foregroundStyle(LocusTheme.muted)
+                .lineLimit(1)
             Spacer(minLength: 4)
             Text(value)
                 .font(.system(size: 8, weight: .semibold, design: .monospaced))
                 .foregroundStyle(LocusTheme.inkSoft)
                 .multilineTextAlignment(.trailing)
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
         }
     }
 }

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -12,6 +12,10 @@ struct InspectorView: View {
             if !model.openInspectorTabs.isEmpty {
                 InspectorOpenTabBar()
                     .environmentObject(model)
+                    // Browser and Terminal install native AppKit surfaces.
+                    // Keep the title-bar controls above those siblings for
+                    // hit-testing as well as drawing.
+                    .zIndex(1)
             }
 
             Group {
@@ -36,6 +40,7 @@ struct InspectorView: View {
             }
             .environmentObject(model)
             .frame(maxHeight: .infinity)
+            .clipped()
         }
         .background(LocusTheme.paperDeep)
         .clipShape(RoundedRectangle(
@@ -68,10 +73,7 @@ private struct InspectorOpenTabBar: View {
 
     var body: some View {
         Group {
-            if model.openInspectorTabs.count <= 3 {
-                // Three tabs fit at the inspector's minimum width. Keeping
-                // them out of a ScrollView avoids a macOS 15 AppKit bug where
-                // its pan recognizer can consume clicks on sibling buttons.
+            if model.openInspectorTabs.count <= 4 {
                 tabItems
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
@@ -88,7 +90,8 @@ private struct InspectorOpenTabBar: View {
                 }
             }
         }
-        .frame(height: 28)
+        .frame(height: 31)
+        .clipped()
         .background(LocusTheme.paperDeep)
         .overlay(alignment: .bottom) {
             Rectangle().fill(LocusTheme.line).frame(height: 1)
@@ -98,75 +101,190 @@ private struct InspectorOpenTabBar: View {
     }
 
     private var tabItems: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 3) {
             ForEach(model.openInspectorTabs) { tab in
-                tabItem(tab)
+                InspectorOpenTabItem(tab: tab, width: tabWidth(tab))
+                    .environmentObject(model)
                     .id(tab.id)
             }
         }
-        .padding(.horizontal, 4)
+        .padding(.horizontal, 7)
     }
 
-    private func tabItem(_ tab: InspectorTab) -> some View {
-        let selected = model.inspectorTab == tab
-        return HStack(spacing: 2) {
-            Button {
-                focus(tab)
-            } label: {
-                HStack(spacing: 6) {
-                    Text(tab.title)
-                        .font(.system(size: 10, weight: .semibold))
-                        .lineLimit(1)
-                    InspectorTextTabBadge(tab: tab)
-                        .environmentObject(model)
-                }
-                .padding(.leading, 10)
-                .padding(.trailing, 3)
-                .frame(height: 27)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.borderless)
-            .accessibilityLabel("\(tab.title) inspector tab")
-            .accessibilityValue(selected ? "Selected" : "Not selected")
-            .accessibilityIdentifier("inspector.tab.\(tab.rawValue)")
-            // macOS 15 can let the horizontal ScrollView's drag recognizer
-            // consume a plain button click. Give an intentional tap priority;
-            // the guarded action below keeps keyboard and AX activation on
-            // the same path without running selection side effects twice.
-            .highPriorityGesture(TapGesture().onEnded { focus(tab) })
+    private func tabWidth(_ tab: InspectorTab) -> CGFloat {
+        let labelWidth = ceil((tab.title as NSString).size(withAttributes: [
+            .font: NSFont.systemFont(ofSize: 10, weight: .semibold),
+        ]).width)
+        let badgeWidth = InspectorOpenTabItem.reservedBadgeWidth(for: tab)
+        // Text, optional status, and close control each get a stable slot. This
+        // avoids the loose label/X spacing that made the old row feel uneven.
+        return min(104, max(55, labelWidth + badgeWidth + 35))
+    }
 
-            Button {
-                model.closeInspectorTab(tab)
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 8, weight: .semibold))
-                    .foregroundStyle(selected ? LocusTheme.inkSoft : LocusTheme.muted)
-                    .frame(width: 22, height: 22)
-                    .contentShape(Rectangle())
+}
+
+/// Kept as its own identity-bearing view so rebuilding the selected panel can
+/// never leave another tab's click closure attached to this tab's label.
+private struct InspectorOpenTabItem: View {
+    @EnvironmentObject private var model: AppModel
+    let tab: InspectorTab
+    let width: CGFloat
+    @State private var isHovering = false
+
+    private var selected: Bool { model.inspectorTab == tab }
+    private var labelWidth: CGFloat {
+        ceil((tab.title as NSString).size(withAttributes: [
+            .font: NSFont.systemFont(ofSize: 10, weight: .semibold),
+        ]).width)
+    }
+
+    static func reservedBadgeWidth(for tab: InspectorTab) -> CGFloat {
+        tab == .changes ? 18 : (tab == .plan ? 7 : 0)
+    }
+
+    var body: some View {
+        HStack(spacing: 3) {
+            InspectorTabActivationButton(
+                title: tab.title,
+                selected: selected,
+                accessibilityIdentifier: "inspector.tab.\(tab.rawValue)",
+                action: focus
+            )
+            .frame(maxWidth: .infinity, minHeight: 26, maxHeight: 26)
+
+            if Self.reservedBadgeWidth(for: tab) > 0 {
+                InspectorTextTabBadge(tab: tab)
+                    .environmentObject(model)
+                    .frame(width: Self.reservedBadgeWidth(for: tab))
+                    .allowsHitTesting(false)
             }
-            .buttonStyle(.plain)
-            .help("Close \(tab.title)")
-            .accessibilityLabel("Close \(tab.title) tab")
-            .accessibilityIdentifier("inspector.tab.close.\(tab.rawValue)")
+
+            InspectorTabCloseButton(tab: tab, emphasized: selected || isHovering)
+                .environmentObject(model)
         }
-        .foregroundStyle(selected ? LocusTheme.ink : LocusTheme.muted)
-        // Leave the final point to the bar-wide divider so every tab has the
-        // same footprint and selecting Plan cannot cover the separator.
-        .frame(height: 27)
-        .fixedSize(horizontal: true, vertical: false)
-        .overlay(alignment: .bottom) {
+        .padding(.leading, 8)
+        .padding(.trailing, 4)
+        .frame(width: width, height: 28)
+        .background(
+            isHovering ? LocusTheme.white.opacity(selected ? 0.28 : 0.38) : Color.clear
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .overlay(alignment: .bottomLeading) {
             if selected {
-                Rectangle()
+                Capsule()
                     .fill(LocusTheme.ink)
                     .frame(height: 2)
-                    .padding(.horizontal, 8)
+                    .frame(width: min(labelWidth + 2, width - 30))
+                    .padding(.leading, 8)
             }
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .onHover { isHovering = $0 }
+    }
+
+    private func focus() {
+        guard !selected || model.inspectorCollapsed else { return }
+        model.selectInspectorTab(tab)
+    }
+}
+
+/// The close affordance stays quiet until its tab is active or hovered, but
+/// its hit target never changes size. Tabs therefore remain calm and do not
+/// shift as the pointer moves across the bar.
+private struct InspectorTabCloseButton: View {
+    @EnvironmentObject private var model: AppModel
+    let tab: InspectorTab
+    let emphasized: Bool
+    @State private var isHovering = false
+
+    var body: some View {
+        Button {
+            model.closeInspectorTab(tab)
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 6.5, weight: .bold))
+                .foregroundStyle(LocusTheme.inkSoft)
+                .frame(width: 16, height: 18)
+                .background(isHovering ? LocusTheme.ink.opacity(0.08) : Color.clear)
+                .clipShape(Circle())
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .opacity(emphasized || isHovering ? 0.9 : 0.42)
+        .onHover { isHovering = $0 }
+        .help("Close \(tab.title)")
+        .accessibilityLabel("Close \(tab.title) tab")
+        .accessibilityIdentifier("inspector.tab.close.\(tab.rawValue)")
+    }
+}
+
+/// A title-bar control must accept the first mouse event even when a native
+/// editor, web view, or PTY currently owns first responder. SwiftUI's macOS
+/// Button does not guarantee that when it is moved into the hidden title-bar
+/// safe area, which makes the first tab switch appear to do nothing.
+private struct InspectorTabActivationButton: NSViewRepresentable {
+    let title: String
+    let selected: Bool
+    let accessibilityIdentifier: String
+    let action: () -> Void
+
+    final class FirstMouseButton: NSButton {
+        var mouseDownAction: (() -> Void)?
+
+        override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+        override func mouseDown(with event: NSEvent) {
+            // Browser and Terminal can change first responder during the same
+            // event transaction. Dispatch from the control that was hit
+            // instead of relying on mouse-up tracking to finish later.
+            mouseDownAction?()
         }
     }
 
-    private func focus(_ tab: InspectorTab) {
-        guard model.inspectorTab != tab || model.inspectorCollapsed else { return }
-        model.selectInspectorTab(tab)
+    final class Coordinator: NSObject {
+        var action: () -> Void
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        @objc func activate() { action() }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(action: action) }
+
+    func makeNSView(context: Context) -> FirstMouseButton {
+        let button = FirstMouseButton(
+            title: title,
+            target: context.coordinator,
+            action: #selector(Coordinator.activate)
+        )
+        button.isBordered = false
+        button.focusRingType = .none
+        button.refusesFirstResponder = true
+        button.alignment = .left
+        button.lineBreakMode = .byTruncatingTail
+        button.setButtonType(.momentaryChange)
+        button.mouseDownAction = context.coordinator.activate
+        return button
+    }
+
+    func updateNSView(_ button: FirstMouseButton, context: Context) {
+        context.coordinator.action = action
+        // The selected-state rebuild can give an existing NSButton a fresh
+        // representable coordinator. NSControl does not retain its target, so
+        // refresh both pieces instead of leaving the button pointed at the
+        // coordinator from the previous panel transaction.
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.activate)
+        button.mouseDownAction = context.coordinator.activate
+        button.title = title
+        button.font = .systemFont(ofSize: 10, weight: selected ? .semibold : .medium)
+        button.contentTintColor = selected ? .labelColor : .secondaryLabelColor.withAlphaComponent(0.86)
+        button.identifier = NSUserInterfaceItemIdentifier(accessibilityIdentifier)
+        button.setAccessibilityIdentifier(accessibilityIdentifier)
+        button.setAccessibilityLabel("\(title) inspector tab")
+        button.setAccessibilityValue(selected ? "Selected" : "Not selected")
     }
 }
 

--- a/Locus/LocusApp.swift
+++ b/Locus/LocusApp.swift
@@ -310,12 +310,19 @@ struct RootView: View {
                             ? .infinity
                             : (locusIsUITesting ? 280 : model.inspectorWidth)
                     )
+                    // The dynamic tabs belong in the otherwise empty title-bar
+                    // band. Extending this column upward also carries its
+                    // leading separator cleanly to the window's top edge.
+                    .ignoresSafeArea(.container, edges: .top)
                     .transition(.move(edge: .trailing).combined(with: .opacity))
             }
 
             if !model.justChatEnabled {
                 InspectorRail()
                     .environmentObject(model)
+                    // Keep the inspector's outer separator continuous through
+                    // the hidden title bar, whether the panel is open or not.
+                    .ignoresSafeArea(.container, edges: .top)
             }
         }
         // Keyed on the sidebar and the zoom flag only: including the inspector

--- a/Locus/Models.swift
+++ b/Locus/Models.swift
@@ -396,6 +396,36 @@ enum ThinkingVisibility: String, Codable, CaseIterable, Identifiable {
     }
 }
 
+/// How much tool activity the transcript shows. This changes presentation
+/// only: every tool block remains in the conversation for permissions,
+/// persistence, resume, and export.
+enum ToolActivityVisibility: String, Codable, CaseIterable, Identifiable {
+    /// One expandable card for every tool call, matching the original UI.
+    case verbose
+    /// All calls made for one user request fold into a single expandable card.
+    case collapsed
+    /// A generic status line is the only transcript trace of tool activity.
+    case hidden
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .verbose: "Verbose"
+        case .collapsed: "Collapsed"
+        case .hidden: "Hidden"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .verbose: "Show every tool call as its own card"
+        case .collapsed: "Group each request's tool calls into one card"
+        case .hidden: "Show only a generic activity status line"
+        }
+    }
+}
+
 /// How much the agent may do without asking.
 enum PermissionMode: String, Codable, CaseIterable, Identifiable {
     /// Every write, command, and fetch asks first.
@@ -411,7 +441,7 @@ enum PermissionMode: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .ask: "Ask every time"
         case .acceptEdits: "Accept file edits"
-        case .bypass: "Bypass all"
+        case .bypass: "Full access"
         }
     }
 
@@ -427,7 +457,7 @@ enum PermissionMode: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .ask: "hand.raised"
         case .acceptEdits: "square.and.pencil"
-        case .bypass: "bolt"
+        case .bypass: "exclamationmark.shield.fill"
         }
     }
 
@@ -436,7 +466,7 @@ enum PermissionMode: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .ask: "Ask"
         case .acceptEdits: "Auto-edit"
-        case .bypass: "Bypass"
+        case .bypass: "Full access"
         }
     }
 
@@ -933,6 +963,31 @@ struct ToolPayload: Codable, Hashable {
     var result: String?
 }
 
+/// The status a compact tool-activity row presents for a group. Active work
+/// wins over earlier failures, while terminal groups preserve the most useful
+/// attention state instead of reading as successfully complete.
+enum ToolActivityAggregateStatus: Equatable {
+    case awaitingPermission
+    case running
+    case error
+    case denied
+    case done
+
+    init(tools: [ToolPayload]) {
+        if tools.contains(where: { $0.status == .awaitingPermission }) {
+            self = .awaitingPermission
+        } else if tools.contains(where: { $0.status == .running }) {
+            self = .running
+        } else if tools.contains(where: { $0.status == .error }) {
+            self = .error
+        } else if tools.contains(where: { $0.status == .denied }) {
+            self = .denied
+        } else {
+            self = .done
+        }
+    }
+}
+
 struct ChatBlock: Identifiable, Codable, Hashable {
     enum Kind: String, Codable {
         case user
@@ -981,6 +1036,82 @@ struct ChatBlock: Identifiable, Codable, Hashable {
         self.completion = completion
         self.teamRunID = teamRunID
         self.historyIndex = historyIndex
+    }
+}
+
+/// A stable presentation-only projection of transcript blocks. Compact modes
+/// replace the first tool in each request with one group and leave the stored
+/// blocks untouched.
+enum TranscriptPresentationItem: Identifiable, Equatable {
+    enum ID: Hashable {
+        case block(UUID)
+        case toolGroup(UUID)
+    }
+
+    case block(ChatBlock)
+    case toolGroup(id: UUID, tools: [ToolPayload])
+
+    var id: ID {
+        switch self {
+        case .block(let block): .block(block.id)
+        case .toolGroup(let id, _): .toolGroup(id)
+        }
+    }
+}
+
+enum TranscriptPresentation {
+    static func items(
+        from blocks: [ChatBlock],
+        visibility: ToolActivityVisibility
+    ) -> [TranscriptPresentationItem] {
+        guard visibility != .verbose else { return blocks.map(TranscriptPresentationItem.block) }
+
+        var items: [TranscriptPresentationItem] = []
+        var requestBlocks: [ChatBlock] = []
+        var requestID: UUID?
+
+        func flushRequest() {
+            guard !requestBlocks.isEmpty else { return }
+            let tools = requestBlocks.compactMap(\.tool)
+            let groupID = requestID ?? requestBlocks.first(where: { $0.tool != nil })?.id
+            var insertedGroup = false
+
+            for block in requestBlocks {
+                if block.kind == .tool {
+                    if !insertedGroup, let groupID, !tools.isEmpty {
+                        items.append(.toolGroup(id: groupID, tools: tools))
+                        insertedGroup = true
+                    }
+                    continue
+                }
+                if isCompletedEmptyAssistant(block) { continue }
+                items.append(.block(block))
+            }
+            requestBlocks.removeAll(keepingCapacity: true)
+        }
+
+        for block in blocks {
+            if block.kind == .user {
+                flushRequest()
+                items.append(.block(block))
+                requestID = block.id
+            } else if block.completion != nil {
+                flushRequest()
+                items.append(.block(block))
+                requestID = nil
+            } else {
+                requestBlocks.append(block)
+            }
+        }
+        flushRequest()
+        return items
+    }
+
+    private static func isCompletedEmptyAssistant(_ block: ChatBlock) -> Bool {
+        guard block.kind == .assistant, !block.isStreaming else { return false }
+        return block.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (block.reasoningText ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
 
@@ -1295,6 +1426,9 @@ struct AppSettings: Codable, Hashable {
     var teamRunsPresentationRaw = AutomaticInspectorPresentation.ask.rawValue
     /// Raw string for the same forward-compatibility reason as the tab.
     var thinkingVisibilityRaw = ThinkingVisibility.collapsed.rawValue
+    /// Compact by default so tool-heavy requests do not overwhelm the answer.
+    /// Stored raw so a future mode cannot invalidate the rest of the settings.
+    var toolActivityVisibilityRaw = ToolActivityVisibility.collapsed.rawValue
     /// One-time compatibility marker: releases before adaptive Work persisted
     /// Build because an agentic mode was mandatory, not necessarily chosen.
     var adaptiveWorkMigrationCompleted = false
@@ -1447,6 +1581,10 @@ struct AppSettings: Codable, Hashable {
         ThinkingVisibility(rawValue: thinkingVisibilityRaw) ?? .collapsed
     }
 
+    var resolvedToolActivityVisibility: ToolActivityVisibility {
+        ToolActivityVisibility(rawValue: toolActivityVisibilityRaw) ?? .collapsed
+    }
+
     var preferredPermissionMode: PermissionMode? {
         PermissionMode(rawValue: permissionModeRaw)
     }
@@ -1528,6 +1666,10 @@ struct AppSettings: Codable, Hashable {
         ) ?? automaticInspectorPresentationRaw
         thinkingVisibilityRaw = try container.decodeIfPresent(String.self, forKey: .thinkingVisibilityRaw)
             ?? defaults.thinkingVisibilityRaw
+        toolActivityVisibilityRaw = try container.decodeIfPresent(
+            String.self,
+            forKey: .toolActivityVisibilityRaw
+        ) ?? defaults.toolActivityVisibilityRaw
         adaptiveWorkMigrationCompleted = try container.decodeIfPresent(
             Bool.self,
             forKey: .adaptiveWorkMigrationCompleted

--- a/Locus/SessionSidebarView.swift
+++ b/Locus/SessionSidebarView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// The sidebar's shared rail. Every leading glyph — plus, magnifying glass,
-/// folder, and the nav rows above them — is drawn in a fixed-width column at
+/// bell, and the nav rows above them — is drawn in a fixed-width column at
 /// the same inset, so they line up down the edge whatever each symbol's own
 /// intrinsic width happens to be.
 private enum SidebarMetrics {
@@ -79,7 +79,12 @@ struct SessionSidebarView: View {
         .frame(maxHeight: .infinity)
         .background(LocusTheme.paperDeep)
         .overlay(alignment: .trailing) {
-            Rectangle().fill(LocusTheme.line).frame(width: 1)
+            Rectangle()
+                .fill(LocusTheme.line)
+                .frame(width: 1)
+                // The sidebar content stays below the traffic lights, but its
+                // column boundary should meet the top of the window chrome.
+                .ignoresSafeArea(.container, edges: .top)
         }
         .alert("Rename Session", isPresented: Binding(
             get: { sessionToRename != nil },
@@ -141,45 +146,6 @@ struct SessionSidebarView: View {
                     model.setJustChatEnabled(enabled)
                 }
             }
-
-            Button {
-                model.openActivityCenter()
-            } label: {
-                HStack(spacing: SidebarMetrics.iconGap) {
-                    Image(systemName: "waveform.path.ecg.rectangle")
-                        .font(.system(size: 12, weight: .medium))
-                        .frame(width: SidebarMetrics.iconColumn)
-                    Text("Activity")
-                        .font(.system(size: 10, weight: .semibold))
-                    Spacer(minLength: 4)
-                    if model.activityNeedsAttentionCount > 0 {
-                        Text("\(model.activityNeedsAttentionCount)")
-                            .font(.system(size: 8, weight: .bold, design: .monospaced))
-                            .foregroundStyle(LocusTheme.brandInk)
-                            .padding(.horizontal, 6)
-                            .frame(height: 18)
-                            .background(LocusTheme.signal)
-                            .clipShape(Capsule())
-                            .accessibilityIdentifier("sidebar.activity.badge")
-                    }
-                }
-                .foregroundStyle(model.activityCenterPresented
-                    ? LocusTheme.ink : LocusTheme.inkSoft)
-                .padding(.horizontal, SidebarMetrics.rowInset)
-                .frame(height: 30)
-                .background(model.activityCenterPresented
-                    ? LocusTheme.white.opacity(0.72) : Color.clear)
-                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .help("Monitor and control work across chats")
-            .accessibilityIdentifier("sidebar.activity")
-            .accessibilityValue(
-                model.activityNeedsAttentionCount > 0
-                    ? "\(model.activityNeedsAttentionCount) needs attention"
-                    : "No new activity"
-            )
 
             navigationRow(
                 symbol: "puzzlepiece.extension",
@@ -275,30 +241,46 @@ struct SessionSidebarView: View {
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("sidebar.newSession")
 
-                Menu {
-                    Button("New Workspace Folder…") { model.createWorkspace() }
-                        .accessibilityIdentifier("workspace.new")
-                    Button("Add Existing Folder…") { model.chooseWorkspace() }
-                        .accessibilityIdentifier("workspace.addExisting")
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        model.toggleActivityCenter()
+                    }
                 } label: {
-                    Image(systemName: "folder.badge.plus")
+                    Image(systemName: model.activityCenterPresented ? "bell.fill" : "bell")
                         .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(LocusTheme.ink)
+                        .foregroundStyle(model.activityCenterPresented
+                            ? LocusTheme.ink : LocusTheme.inkSoft)
                         .frame(width: 36, height: 36)
-                        .background(LocusTheme.white.opacity(0.82))
+                        .background(model.activityCenterPresented
+                            ? LocusTheme.signal.opacity(0.9)
+                            : LocusTheme.white.opacity(0.82))
                         .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
                         .overlay {
                             RoundedRectangle(cornerRadius: 9, style: .continuous)
                                 .stroke(LocusTheme.line, lineWidth: 1)
                         }
+                        .overlay(alignment: .topTrailing) {
+                            if model.activityNeedsAttentionCount > 0 {
+                                Text("\(model.activityNeedsAttentionCount)")
+                                    .font(.system(size: 7, weight: .bold, design: .monospaced))
+                                    .foregroundStyle(Color.white)
+                                    .frame(minWidth: 14, minHeight: 14)
+                                    .background(LocusTheme.danger)
+                                    .clipShape(Capsule())
+                                    .offset(x: 4, y: -4)
+                                    .accessibilityIdentifier("sidebar.activity.badge")
+                            }
+                        }
                 }
-                .menuStyle(.borderlessButton)
-                .menuIndicator(.hidden)
-                .frame(width: 36)
-                .help("Add workspace")
-                .accessibilityLabel("Add workspace")
-                .accessibilityIdentifier("sidebar.addWorkspace")
-                .disabled(model.chatNavigationDisabled)
+                .buttonStyle(.plain)
+                .help("Activities")
+                .accessibilityLabel("Activities")
+                .accessibilityIdentifier("sidebar.activity")
+                .accessibilityValue(
+                    model.activityNeedsAttentionCount > 0
+                        ? "\(model.activityNeedsAttentionCount) needs attention"
+                        : "No new activity"
+                )
             }
 
             HStack(spacing: SidebarMetrics.iconGap) {
@@ -594,6 +576,7 @@ struct SessionSidebarView: View {
                     .font(.system(size: 11, weight: .medium))
                     .frame(width: SidebarMetrics.iconColumn)
                     .foregroundStyle(LocusTheme.muted)
+                    .accessibilityIdentifier("sidebar.workspaceIcon")
                 VStack(alignment: .leading, spacing: 1) {
                     Text(URL(fileURLWithPath: model.workspacePath).lastPathComponent)
                         .font(.system(size: 10, weight: .semibold))
@@ -1030,6 +1013,8 @@ private struct WorkspaceGroupRow: View {
                     Image(systemName: group.isOther ? "tray.full" : "folder.fill")
                         .font(.system(size: 10, weight: .medium))
                         .foregroundStyle(active ? LocusTheme.signalDeep : LocusTheme.muted)
+                        .frame(width: 20, height: 20)
+                        .accessibilityIdentifier("workspace.group.icon.\(group.id)")
                     VStack(alignment: .leading, spacing: 1) {
                         Text(group.title)
                             .font(.system(size: 10, weight: .semibold))

--- a/Locus/Sheets.swift
+++ b/Locus/Sheets.swift
@@ -455,9 +455,13 @@ private struct ExtensionsSettingsView: View {
                         }
                         ForEach(model.extensions.mcpPresets) { preset in
                             HStack(alignment: .top, spacing: 10) {
-                                Image(systemName: "network.badge.shield.half.filled")
-                                    .foregroundStyle(LocusTheme.muted)
-                                    .frame(width: 20)
+                                MCPLogo(
+                                    name: preset.displayName,
+                                    url: preset.url,
+                                    presetID: preset.id,
+                                    size: 28
+                                )
+                                .accessibilityIdentifier("extensions.mcp.preset.\(preset.id).logo")
                                 VStack(alignment: .leading, spacing: 3) {
                                     Text(preset.displayName)
                                         .font(.system(size: 10, weight: .semibold))
@@ -492,10 +496,23 @@ private struct ExtensionsSettingsView: View {
                     }
                     ForEach(model.extensions.mcpServers) { server in
                         VStack(alignment: .leading, spacing: 8) {
-                            HStack {
-                                Circle()
-                                    .fill(mcpStatusColor(server.state))
-                                    .frame(width: 7, height: 7)
+                            HStack(spacing: 10) {
+                                MCPLogo(
+                                    name: server.name,
+                                    url: server.url,
+                                    presetID: server.presetID,
+                                    size: 30
+                                )
+                                .overlay(alignment: .bottomTrailing) {
+                                    Circle()
+                                        .fill(mcpStatusColor(server.state))
+                                        .frame(width: 8, height: 8)
+                                        .overlay {
+                                            Circle().stroke(LocusTheme.white, lineWidth: 1.5)
+                                        }
+                                        .offset(x: 2, y: 2)
+                                }
+                                .accessibilityIdentifier("extensions.mcp.server.\(server.id).logo")
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text(server.name).font(.system(size: 11, weight: .semibold))
                                     Text("\(server.transport.uppercased()) · \(server.state ?? "disconnected") · \(server.toolCount ?? 0) tools")
@@ -781,8 +798,16 @@ private struct MCPPresetReviewView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 13) {
-            Text("Review \(preset.displayName) connection")
-                .font(.system(size: 16, weight: .bold))
+            HStack(spacing: 10) {
+                MCPLogo(
+                    name: preset.displayName,
+                    url: preset.url,
+                    presetID: preset.id,
+                    size: 34
+                )
+                Text("Review \(preset.displayName) connection")
+                    .font(.system(size: 16, weight: .bold))
+            }
             Text(preset.description)
                 .font(.system(size: 10))
                 .foregroundStyle(LocusTheme.muted)
@@ -840,9 +865,17 @@ private struct MCPEnableReviewView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 13) {
-            Label("Connection verified", systemImage: "checkmark.shield.fill")
-                .font(.system(size: 16, weight: .bold))
-                .foregroundStyle(LocusTheme.success)
+            HStack(spacing: 10) {
+                MCPLogo(
+                    name: server.name,
+                    url: server.url,
+                    presetID: server.presetID,
+                    size: 34
+                )
+                Label("Connection verified", systemImage: "checkmark.shield.fill")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundStyle(LocusTheme.success)
+            }
             Text("\(server.name) completed its tool probe. Enable it now, or keep the reviewed server disabled in Settings.")
                 .font(.system(size: 10))
             Text("The default policy uses MCP safety annotations. Resources are discoverable; server prompts remain disabled until you explicitly allow them.")
@@ -1815,14 +1848,14 @@ struct SettingsView: View {
                     .disabled(model.allowedTools.isEmpty && model.permissionMode == .ask)
                     .accessibilityIdentifier("settings.resetPermissions")
 
-                Text("Ask and Accept File Edits confirm access outside the workspace. Bypass skips those confirmations, while the deny list and credential/transaction takeover rules still apply.")
+                Text("Ask and Accept File Edits confirm access outside the workspace. Full Access skips those confirmations, while the deny list and credential/transaction takeover rules still apply.")
                     .font(.system(size: 9))
                     .foregroundStyle(LocusTheme.muted)
                     .fixedSize(horizontal: false, vertical: true)
 
                 Label("macOS folder access is separate", systemImage: "folder.badge.questionmark")
                     .font(.system(size: 9, weight: .semibold))
-                Text("Bypass controls agent tool approvals. macOS may still ask Locus itself for Documents, Desktop, Accessibility, or Screen Recording access. A stable signed app normally remembers that system choice; rebuilding or launching a differently signed copy can make macOS ask again.")
+                Text("Full Access controls agent tool approvals. macOS may still ask Locus itself for Documents, Desktop, Accessibility, or Screen Recording access. A stable signed app normally remembers that system choice; rebuilding or launching a differently signed copy can make macOS ask again.")
                     .font(.system(size: 9))
                     .foregroundStyle(LocusTheme.muted)
                     .fixedSize(horizontal: false, vertical: true)
@@ -1834,7 +1867,7 @@ struct SettingsView: View {
                     set: { model.setBrowserEnabled($0) }
                 ))
                 .accessibilityIdentifier("settings.browser.enabled")
-                Text("The agent can open pages, read them, and act on them in the Browser tab. Reading never asks. Page JavaScript asks in Ask and Accept File Edits, and runs without another prompt in Bypass. Turning this off removes browser tools from the model.")
+                Text("The agent can open pages, read them, and act on them in the Browser tab. Reading never asks. Page JavaScript asks in Ask and Accept File Edits, and runs without another prompt in Full Access. Turning this off removes browser tools from the model.")
                     .font(.system(size: 9))
                     .foregroundStyle(LocusTheme.muted)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Locus/Theme.swift
+++ b/Locus/Theme.swift
@@ -40,6 +40,7 @@ enum LocusTheme {
         let signal: NSColor
         let signalDeep: NSColor
         let coral: NSColor
+        let danger: NSColor
         let blue: NSColor
         let success: NSColor
         let warning: NSColor
@@ -63,6 +64,7 @@ enum LocusTheme {
         signal: rgb(red: 0.788, green: 0.961, blue: 0.29),
         signalDeep: rgb(red: 0.655, green: 0.827, blue: 0.153),
         coral: rgb(red: 0.89, green: 0.435, blue: 0.314),
+        danger: rgb(0xD92D20),
         blue: rgb(red: 0.322, green: 0.455, blue: 0.843),
         success: rgb(red: 0.259, green: 0.506, blue: 0.325),
         warning: rgb(red: 0.73, green: 0.49, blue: 0.13),
@@ -84,6 +86,7 @@ enum LocusTheme {
         signal: rgb(0xC9F54A),
         signalDeep: rgb(0xB6E33B),
         coral: rgb(0xF18364),
+        danger: rgb(0xFF5A52),
         blue: rgb(0x7998FF),
         success: rgb(0x6DBB7B),
         warning: rgb(0xE1A54B),
@@ -104,6 +107,7 @@ enum LocusTheme {
     static let signal = adaptive(\.signal)
     static let signalDeep = adaptive(\.signalDeep)
     static let coral = adaptive(\.coral)
+    static let danger = adaptive(\.danger)
     static let blue = adaptive(\.blue)
     static let success = adaptive(\.success)
     static let warning = adaptive(\.warning)
@@ -177,5 +181,120 @@ struct BrandMark: View {
         .shadow(color: .black.opacity(0.16), radius: 0, x: 2, y: 2)
         .rotationEffect(.degrees(-2.5))
         .accessibilityHidden(true)
+    }
+}
+
+/// Local MCP brand marks. Known providers receive a recognizable color and
+/// glyph; custom servers receive a deterministic monogram instead of the same
+/// generic network icon everywhere. Keeping these local avoids fetching
+/// favicons merely because Settings was opened.
+struct MCPLogo: View {
+    let name: String
+    var url: String? = nil
+    var presetID: String? = nil
+    var size: CGFloat = 26
+
+    private enum Mark {
+        case text(String)
+        case symbol(String)
+    }
+
+    private struct Style {
+        let background: Color
+        let foreground: Color
+        let mark: Mark
+    }
+
+    private static let fallbackColors = [
+        Color(red: 0.29, green: 0.42, blue: 0.78),
+        Color(red: 0.46, green: 0.33, blue: 0.72),
+        Color(red: 0.09, green: 0.55, blue: 0.48),
+        Color(red: 0.73, green: 0.35, blue: 0.24),
+        Color(red: 0.12, green: 0.48, blue: 0.65),
+    ]
+
+    private var identity: String {
+        [presetID, name, url]
+            .compactMap { $0 }
+            .joined(separator: " ")
+            .lowercased()
+    }
+
+    private var initials: String {
+        let words = name.split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        let letters = words.prefix(2).compactMap(\.first)
+        let value = letters.isEmpty ? Array(name.prefix(2)) : letters
+        return String(value).uppercased()
+    }
+
+    private var style: Style {
+        if identity.contains("context7") {
+            return Style(
+                background: Color(red: 0.34, green: 0.27, blue: 0.95),
+                foreground: .white,
+                mark: .text("7")
+            )
+        }
+        if identity.contains("github") || identity.contains("githubcopilot") {
+            return Style(
+                background: Color(red: 0.12, green: 0.13, blue: 0.15),
+                foreground: .white,
+                mark: .text("GH")
+            )
+        }
+        if identity.contains("sentry") {
+            return Style(
+                background: Color(red: 0.43, green: 0.35, blue: 0.69),
+                foreground: .white,
+                mark: .symbol("scope")
+            )
+        }
+        if identity.contains("supabase") {
+            return Style(
+                background: Color(red: 0.24, green: 0.81, blue: 0.56),
+                foreground: Color(red: 0.04, green: 0.19, blue: 0.15),
+                mark: .symbol("bolt.fill")
+            )
+        }
+        if identity.contains("openai") {
+            return Style(
+                background: Color(red: 0.08, green: 0.09, blue: 0.09),
+                foreground: .white,
+                mark: .symbol("sparkles")
+            )
+        }
+
+        let index = identity.utf8.reduce(0) {
+            ($0 &* 31 &+ Int($1)) % Self.fallbackColors.count
+        }
+        return Style(
+            background: Self.fallbackColors[index],
+            foreground: .white,
+            mark: .text(initials)
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: size * 0.27, style: .continuous)
+                .fill(style.background)
+            switch style.mark {
+            case .text(let text):
+                Text(text)
+                    .font(.system(size: size * (text.count > 1 ? 0.32 : 0.48), weight: .bold, design: .rounded))
+                    .foregroundStyle(style.foreground)
+            case .symbol(let symbol):
+                Image(systemName: symbol)
+                    .font(.system(size: size * 0.46, weight: .semibold))
+                    .foregroundStyle(style.foreground)
+            }
+        }
+        .frame(width: size, height: size)
+        .overlay {
+            RoundedRectangle(cornerRadius: size * 0.27, style: .continuous)
+                .stroke(Color.white.opacity(0.28), lineWidth: 0.75)
+        }
+        .shadow(color: .black.opacity(0.12), radius: 1, y: 1)
+        .accessibilityLabel("\(name) logo")
     }
 }

--- a/Locus/Theme.swift
+++ b/Locus/Theme.swift
@@ -295,6 +295,7 @@ struct MCPLogo: View {
                 .stroke(Color.white.opacity(0.28), lineWidth: 0.75)
         }
         .shadow(color: .black.opacity(0.12), radius: 1, y: 1)
+        .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(name) logo")
     }
 }

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -1600,7 +1600,8 @@ private struct ConversationView: View {
             ToolActivityView(
                 groupID: id,
                 tools: tools,
-                visibility: model.toolActivityVisibility
+                visibility: model.toolActivityVisibility,
+                onExpansionChange: scrollCoordinator.detach
             )
             .padding(.leading, 43)
             .id("tool-activity-\(id.uuidString)")
@@ -2629,6 +2630,7 @@ private struct ToolActivityView: View {
     let groupID: UUID
     let tools: [ToolPayload]
     let visibility: ToolActivityVisibility
+    let onExpansionChange: () -> Void
     @State private var expanded = false
 
     private var status: ToolActivityAggregateStatus {
@@ -2650,6 +2652,7 @@ private struct ToolActivityView: View {
     private var collapsedCard: some View {
         VStack(spacing: 0) {
             Button {
+                onExpansionChange()
                 expanded.toggle()
             } label: {
                 HStack(spacing: 8) {

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -17,34 +17,7 @@ struct WorkspaceView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-
-            if model.activityCenterPresented {
-                ActivityCenterView()
-                    .environmentObject(model)
-                    .frame(maxHeight: .infinity)
-            } else {
-                switch model.agentRuntimePhase {
-                case .recovering(let message):
-                    runtimeBanner(message, recovering: true)
-                case .unavailable(let message):
-                    runtimeBanner(message, recovering: false)
-                case .starting, .online:
-                    EmptyView()
-                }
-
-                if model.transcriptSearchPresented {
-                    TranscriptSearchBar()
-                        .environmentObject(model)
-                }
-
-                ConversationView(streamingReply: model.streamingReply)
-                    .frame(maxHeight: .infinity)
-
-                WorkStatusStrip(streamingReply: model.streamingReply)
-                    .environmentObject(model)
-
-                ComposerView()
-            }
+            contentArea
         }
         .background(LocusTheme.panel)
         .alert("Create Branch in Worktree", isPresented: $createBranchPresented) {
@@ -58,6 +31,61 @@ struct WorkspaceView: View {
             .disabled(branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         } message: {
             Text("The worktree is detached until you deliberately create a branch.")
+        }
+    }
+
+    private var contentArea: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .topTrailing) {
+                chatContent
+                    .frame(width: proxy.size.width, height: proxy.size.height)
+
+                if model.activityCenterPresented {
+                    ActivityCenterView()
+                        .environmentObject(model)
+                        .frame(
+                            width: max(280, min(440, proxy.size.width - 24)),
+                            height: max(0, proxy.size.height - 24)
+                        )
+                        .background(LocusTheme.panel)
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .stroke(LocusTheme.lineStrong, lineWidth: 1)
+                        }
+                        .shadow(color: .black.opacity(0.18), radius: 18, x: 0, y: 8)
+                        .padding(12)
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                        .zIndex(2)
+                }
+            }
+            .clipped()
+        }
+    }
+
+    private var chatContent: some View {
+        VStack(spacing: 0) {
+            switch model.agentRuntimePhase {
+            case .recovering(let message):
+                runtimeBanner(message, recovering: true)
+            case .unavailable(let message):
+                runtimeBanner(message, recovering: false)
+            case .starting, .online:
+                EmptyView()
+            }
+
+            if model.transcriptSearchPresented {
+                TranscriptSearchBar()
+                    .environmentObject(model)
+            }
+
+            ConversationView(streamingReply: model.streamingReply)
+                .frame(maxHeight: .infinity)
+
+            WorkStatusStrip(streamingReply: model.streamingReply)
+                .environmentObject(model)
+
+            ComposerView()
         }
     }
 
@@ -77,9 +105,11 @@ struct WorkspaceView: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 5) {
-                    Text(model.activityCenterPresented
-                        ? "ALL WORKSPACES"
-                        : URL(fileURLWithPath: model.workspacePath).lastPathComponent)
+                    Image(systemName: "folder.fill")
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundStyle(LocusTheme.muted)
+                        .accessibilityIdentifier("workspace.header.workspaceIcon")
+                    Text(URL(fileURLWithPath: model.workspacePath).lastPathComponent)
                     if let branch = model.gitBranch {
                         HStack(spacing: 3) {
                             Image(systemName: "arrow.triangle.branch")
@@ -96,7 +126,7 @@ struct WorkspaceView: View {
                 .font(.system(size: 8, design: .monospaced))
                 .foregroundStyle(LocusTheme.muted.opacity(0.8))
 
-                Text(model.activityCenterPresented ? "Activity" : sessionTitle)
+                Text(sessionTitle)
                     .font(.system(size: 14, weight: .bold))
                     .lineLimit(1)
             }
@@ -246,6 +276,19 @@ struct WorkspaceView: View {
                 .disabled(!model.sessions.contains(where: { $0.id == model.currentSessionID }))
                 .accessibilityIdentifier("workspace.actions.export")
                 Divider()
+                Picker("Tool activity", selection: Binding(
+                    get: { model.toolActivityVisibility },
+                    set: { model.toolActivityVisibility = $0 }
+                )) {
+                    ForEach(ToolActivityVisibility.allCases) { visibility in
+                        Text(visibility.title)
+                            .tag(visibility)
+                            .accessibilityIdentifier(
+                                "workspace.actions.toolActivity.\(visibility.rawValue)"
+                            )
+                    }
+                }
+                .pickerStyle(.inline)
                 Picker("Thinking", selection: Binding(
                     get: { model.thinkingVisibility },
                     set: { model.thinkingVisibility = $0 }
@@ -656,6 +699,21 @@ private enum ActivityGroup: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
+/// Activity rows use restrained text actions, but each still needs a reliable
+/// macOS click target. Padding lives inside the button style so the visible and
+/// accessibility frames agree instead of exposing a ten-point-tall link.
+private struct ActivityActionButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 5)
+            .frame(minHeight: 22)
+            .background(configuration.isPressed ? LocusTheme.paperDeep : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+            .contentShape(Rectangle())
+            .opacity(configuration.isPressed ? 0.75 : 1)
+    }
+}
+
 struct ActivityCenterView: View {
     @EnvironmentObject private var model: AppModel
 
@@ -686,6 +744,18 @@ struct ActivityCenterView: View {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
                 .accessibilityIdentifier("activity.refresh")
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        model.toggleActivityCenter()
+                    }
+                } label: {
+                    Image(systemName: "xmark")
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.plain)
+                .help("Close Activities")
+                .accessibilityLabel("Close Activities")
+                .accessibilityIdentifier("activity.close")
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 14)
@@ -852,7 +922,7 @@ struct ActivityCenterView: View {
                 Spacer()
             }
             .font(.system(size: 8, weight: .semibold))
-            .buttonStyle(.borderless)
+            .buttonStyle(ActivityActionButtonStyle())
         }
         .padding(12)
         .background(LocusTheme.white.opacity(0.72))
@@ -1461,50 +1531,8 @@ private struct ConversationView: View {
                         EmptyConversationView()
                             .environmentObject(model)
                     } else {
-                        ForEach(model.blocks) { block in
-                            VStack(alignment: .leading, spacing: 12) {
-                                if block.kind == .assistant,
-                                   block.id == model.activeStreamingAssistantID
-                                {
-                                    ActiveAssistantBlockView(
-                                        reply: streamingReply,
-                                        thinkingVisibility: model.thinkingVisibility
-                                    )
-                                    .id(block.id)
-                                } else {
-                                    MessageBlockView(
-                                        block: block,
-                                        thinkingVisibility: model.thinkingVisibility,
-                                        actionsDisabled: model.isBusy || model.hasPendingPermission,
-                                        canRewind: model.canRewind(to: block),
-                                        canRegenerate: model.canRegenerate(block),
-                                        onCopy: { model.copyMessage(block.text) },
-                                        onUseAsDraft: { model.useAsDraft(block.text) },
-                                        onRewind: { model.rewind(to: block) },
-                                        onRegenerate: { model.retryLastResponse() }
-                                    )
-                                    .equatable()
-                                }
-                                if block.kind == .user, let runID = block.teamRunID {
-                                    TeamRunBoardView(runID: runID, request: block.text)
-                                        .environmentObject(model)
-                                        .id("team-board-\(runID)")
-                                }
-                            }
-                            .overlay {
-                                if let style = model.transcriptMatchStyle(for: block.id) {
-                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                        .stroke(
-                                            style == .current
-                                                ? LocusTheme.signalDeep
-                                                : LocusTheme.lineStrong.opacity(0.7),
-                                            lineWidth: style == .current ? 2 : 1
-                                        )
-                                        .padding(-7)
-                                        .allowsHitTesting(false)
-                                }
-                            }
-                            .id(block.id)
+                        ForEach(presentationItems) { item in
+                            presentationRow(item)
                         }
                     }
                     Color.clear
@@ -1554,6 +1582,75 @@ private struct ConversationView: View {
                 scrollToCurrentMatch(proxy)
             }
         }
+    }
+
+    private var presentationItems: [TranscriptPresentationItem] {
+        TranscriptPresentation.items(
+            from: model.blocks,
+            visibility: model.toolActivityVisibility
+        )
+    }
+
+    @ViewBuilder
+    private func presentationRow(_ item: TranscriptPresentationItem) -> some View {
+        switch item {
+        case .block(let block):
+            blockRow(block)
+        case .toolGroup(let id, let tools):
+            ToolActivityView(
+                groupID: id,
+                tools: tools,
+                visibility: model.toolActivityVisibility
+            )
+            .padding(.leading, 43)
+            .id("tool-activity-\(id.uuidString)")
+        }
+    }
+
+    private func blockRow(_ block: ChatBlock) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if block.kind == .assistant,
+               block.id == model.activeStreamingAssistantID
+            {
+                ActiveAssistantBlockView(
+                    reply: streamingReply,
+                    thinkingVisibility: model.thinkingVisibility
+                )
+                .id(block.id)
+            } else {
+                MessageBlockView(
+                    block: block,
+                    thinkingVisibility: model.thinkingVisibility,
+                    actionsDisabled: model.isBusy || model.hasPendingPermission,
+                    canRewind: model.canRewind(to: block),
+                    canRegenerate: model.canRegenerate(block),
+                    onCopy: { model.copyMessage(block.text) },
+                    onUseAsDraft: { model.useAsDraft(block.text) },
+                    onRewind: { model.rewind(to: block) },
+                    onRegenerate: { model.retryLastResponse() }
+                )
+                .equatable()
+            }
+            if block.kind == .user, let runID = block.teamRunID {
+                TeamRunBoardView(runID: runID, request: block.text)
+                    .environmentObject(model)
+                    .id("team-board-\(runID)")
+            }
+        }
+        .overlay {
+            if let style = model.transcriptMatchStyle(for: block.id) {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(
+                        style == .current
+                            ? LocusTheme.signalDeep
+                            : LocusTheme.lineStrong.opacity(0.7),
+                        lineWidth: style == .current ? 2 : 1
+                    )
+                    .padding(-7)
+                    .allowsHitTesting(false)
+            }
+        }
+        .id(block.id)
     }
 
     private func scrollToCurrentMatch(_ proxy: ScrollViewProxy) {
@@ -2224,8 +2321,8 @@ private struct MessageBlockView: View, Equatable {
 
     private var userAvatar: AnyView {
         AnyView(
-            Text("N")
-                .font(.system(size: 10, weight: .bold))
+            Image(systemName: "person.fill")
+                .font(.system(size: 10, weight: .semibold))
                 .foregroundStyle(LocusTheme.muted)
                 .frame(width: 30, height: 30)
                 .background(LocusTheme.paperDeep)
@@ -2234,6 +2331,7 @@ private struct MessageBlockView: View, Equatable {
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
                         .stroke(LocusTheme.line, lineWidth: 1)
                 }
+                .accessibilityHidden(true)
         )
     }
 
@@ -2524,6 +2622,137 @@ private struct ThinkingDots: View {
         }
         .animation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true), value: active)
         .onAppear { active = true }
+    }
+}
+
+private struct ToolActivityView: View {
+    let groupID: UUID
+    let tools: [ToolPayload]
+    let visibility: ToolActivityVisibility
+    @State private var expanded = false
+
+    private var status: ToolActivityAggregateStatus {
+        ToolActivityAggregateStatus(tools: tools)
+    }
+
+    @ViewBuilder
+    var body: some View {
+        switch visibility {
+        case .verbose:
+            EmptyView()
+        case .collapsed:
+            collapsedCard
+        case .hidden:
+            hiddenLine
+        }
+    }
+
+    private var collapsedCard: some View {
+        VStack(spacing: 0) {
+            Button {
+                expanded.toggle()
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(LocusTheme.muted)
+                    Image(systemName: statusSymbol)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(statusColor)
+                    Text("\(tools.count) tool call\(tools.count == 1 ? "" : "s")")
+                        .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    Spacer()
+                    Text(collapsedStatusLabel.uppercased())
+                        .font(.system(size: 7, weight: .bold))
+                        .tracking(0.6)
+                        .foregroundStyle(LocusTheme.muted)
+                }
+                .padding(.horizontal, 12)
+                .frame(height: 39)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(
+                "\(tools.count) tool call\(tools.count == 1 ? "" : "s"), "
+                    + "\(collapsedStatusLabel), \(expanded ? "collapse" : "expand")"
+            )
+            .accessibilityIdentifier("toolActivity.group.\(groupID.uuidString)")
+
+            if expanded {
+                VStack(spacing: 8) {
+                    ForEach(tools, id: \.toolID) { tool in
+                        ToolCardView(tool: tool)
+                    }
+                }
+                .padding(10)
+                .overlay(alignment: .top) {
+                    Rectangle().fill(LocusTheme.line).frame(height: 1)
+                }
+            }
+        }
+        .locusCard(radius: 9)
+    }
+
+    private var hiddenLine: some View {
+        HStack(spacing: 8) {
+            Rectangle()
+                .fill(LocusTheme.line)
+                .frame(height: 1)
+            Image(systemName: statusSymbol)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(statusColor)
+            Text(hiddenStatusLabel)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(LocusTheme.inkSoft)
+                .fixedSize()
+            Rectangle()
+                .fill(LocusTheme.line)
+                .frame(height: 1)
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(hiddenStatusLabel)
+        .accessibilityIdentifier("toolActivity.hidden.\(groupID.uuidString)")
+    }
+
+    private var collapsedStatusLabel: String {
+        switch status {
+        case .awaitingPermission: "Needs approval"
+        case .running: "Running"
+        case .error: "Failed"
+        case .denied: "Skipped"
+        case .done: "Done"
+        }
+    }
+
+    private var hiddenStatusLabel: String {
+        switch status {
+        case .awaitingPermission: "Action needs approval"
+        case .running: "Working…"
+        case .error: "Action failed"
+        case .denied: "Action skipped"
+        case .done: "Actions complete"
+        }
+    }
+
+    private var statusSymbol: String {
+        switch status {
+        case .awaitingPermission: "exclamationmark.circle.fill"
+        case .running: "circle.dotted"
+        case .error: "xmark.circle.fill"
+        case .denied: "minus.circle.fill"
+        case .done: "checkmark.circle.fill"
+        }
+    }
+
+    private var statusColor: Color {
+        switch status {
+        case .awaitingPermission: LocusTheme.warning
+        case .running: LocusTheme.blue
+        case .error: LocusTheme.coral
+        case .denied: LocusTheme.muted
+        case .done: LocusTheme.success
+        }
     }
 }
 

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -2591,6 +2591,193 @@ final class AppModelTests: XCTestCase {
         XCTAssertEqual(restored.resolvedThinkingVisibility, .collapsed)
     }
 
+    // MARK: - Tool activity visibility
+
+    func testToolActivityVisibilityDefaultsRoundTripsAndToleratesFutureValues() throws {
+        XCTAssertEqual(AppSettings().resolvedToolActivityVisibility, .collapsed)
+
+        let legacy = try JSONDecoder().decode(AppSettings.self, from: Data("{}".utf8))
+        XCTAssertEqual(legacy.resolvedToolActivityVisibility, .collapsed)
+
+        var chosen = AppSettings()
+        chosen.toolActivityVisibilityRaw = ToolActivityVisibility.hidden.rawValue
+        let restored = try JSONDecoder().decode(
+            AppSettings.self,
+            from: JSONEncoder().encode(chosen)
+        )
+        XCTAssertEqual(restored.resolvedToolActivityVisibility, .hidden)
+
+        let future = #"{"toolActivityVisibilityRaw":"summary-only"}"#
+        let futureRestored = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(future.utf8)
+        )
+        XCTAssertEqual(futureRestored.resolvedToolActivityVisibility, .collapsed)
+    }
+
+    @MainActor
+    func testToolActivityVisibilityAccessorUpdatesSettings() {
+        let model = AppModel(startImmediately: false)
+        model.toolActivityVisibility = .verbose
+        XCTAssertEqual(model.toolActivityVisibility, .verbose)
+        XCTAssertEqual(model.settings.toolActivityVisibilityRaw, "verbose")
+
+        model.blocks = [ChatBlock(
+            kind: .tool,
+            tool: ToolPayload(
+                toolID: "status-strip", tool: "bash", summary: "Run tests", detail: "swift test",
+                status: .running
+            )
+        )]
+        XCTAssertEqual(model.currentWorkPhase, "Using bash")
+        model.toolActivityVisibility = .hidden
+        XCTAssertEqual(model.currentWorkPhase, "Working…", "hidden mode must not leak tool metadata")
+    }
+
+    func testCompactTranscriptGroupsAllToolsForEachUserRequest() throws {
+        let firstUserID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000701"))
+        let secondUserID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000702"))
+        let emptyAssistantID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000703"))
+        let secondEmptyAssistantID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000704"))
+        let noteID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000705"))
+        let reasoningID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000706"))
+        let finalID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000707"))
+        let completionID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000708"))
+
+        let first = ToolPayload(
+            toolID: "first", tool: "list_dir", summary: "List files", detail: "",
+            status: .done
+        )
+        let second = ToolPayload(
+            toolID: "second", tool: "bash", summary: "Run tests", detail: "swift test",
+            status: .awaitingPermission
+        )
+        let third = ToolPayload(
+            toolID: "third", tool: "browser", summary: "Open preview", detail: "",
+            status: .error, result: "Could not connect"
+        )
+        let fourth = ToolPayload(
+            toolID: "fourth", tool: "read_file", summary: "Read README", detail: "",
+            status: .done
+        )
+        let blocks = [
+            ChatBlock(id: firstUserID, kind: .user, text: "Do the work"),
+            ChatBlock(id: emptyAssistantID, kind: .assistant),
+            ChatBlock(kind: .tool, tool: first),
+            ChatBlock(id: noteID, kind: .note, text: "Context was compacted"),
+            ChatBlock(id: reasoningID, kind: .assistant, reasoningText: "Checking next step"),
+            ChatBlock(kind: .tool, tool: second),
+            ChatBlock(id: secondEmptyAssistantID, kind: .assistant),
+            ChatBlock(kind: .tool, tool: third),
+            ChatBlock(id: finalID, kind: .assistant, text: "Finished with one warning."),
+            ChatBlock(
+                id: completionID,
+                kind: .note,
+                completion: TurnCompletion(
+                    outcome: .complete,
+                    mode: .work,
+                    durationMilliseconds: 1_000
+                )
+            ),
+            ChatBlock(id: secondUserID, kind: .user, text: "Check one more file"),
+            ChatBlock(kind: .assistant),
+            ChatBlock(kind: .tool, tool: fourth),
+        ]
+
+        let collapsed = TranscriptPresentation.items(from: blocks, visibility: .collapsed)
+        let hidden = TranscriptPresentation.items(from: blocks, visibility: .hidden)
+        XCTAssertEqual(hidden, collapsed, "compact modes share the same lossless grouping")
+        XCTAssertEqual(collapsed.count, 8)
+
+        guard case .toolGroup(let firstGroupID, let firstTools) = collapsed[1] else {
+            return XCTFail("the first tool position should become one request group")
+        }
+        XCTAssertEqual(firstGroupID, firstUserID)
+        XCTAssertEqual(firstTools.map(\.toolID), ["first", "second", "third"])
+        XCTAssertEqual(ToolActivityAggregateStatus(tools: firstTools), .awaitingPermission)
+
+        XCTAssertEqual(collapsed[2], .block(blocks[3]), "notes stay in transcript order")
+        XCTAssertEqual(collapsed[3], .block(blocks[4]), "reasoning stays in transcript order")
+        XCTAssertEqual(collapsed[4], .block(blocks[8]), "the final answer stays visible")
+        XCTAssertEqual(collapsed[5], .block(blocks[9]), "completion remains the request boundary")
+
+        guard case .toolGroup(let secondGroupID, let secondTools) = collapsed[7] else {
+            return XCTFail("the next user request should own a separate group")
+        }
+        XCTAssertEqual(secondGroupID, secondUserID)
+        XCTAssertEqual(secondTools.map(\.toolID), ["fourth"])
+
+        let compactBlockIDs = collapsed.compactMap { item -> UUID? in
+            guard case .block(let block) = item else { return nil }
+            return block.id
+        }
+        XCTAssertFalse(compactBlockIDs.contains(emptyAssistantID))
+        XCTAssertFalse(compactBlockIDs.contains(secondEmptyAssistantID))
+
+        let verbose = TranscriptPresentation.items(from: blocks, visibility: .verbose)
+        XCTAssertEqual(verbose, blocks.map(TranscriptPresentationItem.block))
+    }
+
+    func testToolActivityGroupIdentityAndStatusRemainStableAsCallsUpdate() throws {
+        let userID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000711"))
+        var blocks = [
+            ChatBlock(id: userID, kind: .user, text: "Run checks"),
+            ChatBlock(kind: .assistant),
+            ChatBlock(kind: .tool, tool: ToolPayload(
+                toolID: "one", tool: "bash", summary: "First check", detail: "",
+                status: .running
+            )),
+        ]
+
+        let firstProjection = TranscriptPresentation.items(from: blocks, visibility: .collapsed)
+        guard case .toolGroup(let initialID, let initialTools) = firstProjection[1] else {
+            return XCTFail("expected the initial tool group")
+        }
+        XCTAssertEqual(initialID, userID)
+        XCTAssertEqual(ToolActivityAggregateStatus(tools: initialTools), .running)
+
+        blocks[2].tool?.status = .error
+        blocks.append(ChatBlock(kind: .assistant))
+        blocks.append(ChatBlock(kind: .tool, tool: ToolPayload(
+            toolID: "two", tool: "read_file", summary: "Fallback check", detail: "",
+            status: .done
+        )))
+
+        let updatedProjection = TranscriptPresentation.items(from: blocks, visibility: .collapsed)
+        guard case .toolGroup(let updatedID, let updatedTools) = updatedProjection[1] else {
+            return XCTFail("expected the updated tool group")
+        }
+        XCTAssertEqual(updatedID, initialID)
+        XCTAssertEqual(updatedTools.map(\.toolID), ["one", "two"])
+        XCTAssertEqual(ToolActivityAggregateStatus(tools: updatedTools), .error)
+
+        func statusTools(_ statuses: [ToolStatus]) -> [ToolPayload] {
+            statuses.enumerated().map { index, status in
+                ToolPayload(
+                    toolID: "status-\(index)", tool: "tool", summary: "", detail: "",
+                    status: status
+                )
+            }
+        }
+        XCTAssertEqual(ToolActivityAggregateStatus(tools: statusTools([.done])), .done)
+        XCTAssertEqual(ToolActivityAggregateStatus(tools: statusTools([.done, .denied])), .denied)
+        XCTAssertEqual(
+            ToolActivityAggregateStatus(tools: statusTools([.done, .denied, .error])),
+            .error
+        )
+        XCTAssertEqual(
+            ToolActivityAggregateStatus(tools: statusTools([.done, .denied, .error, .running])),
+            .running
+        )
+        XCTAssertEqual(
+            ToolActivityAggregateStatus(
+                tools: statusTools([.done, .denied, .error, .running, .awaitingPermission])
+            ),
+            .awaitingPermission,
+            "attention and active states follow the documented precedence"
+        )
+    }
+
     // MARK: - Context window
 
     @MainActor

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -22,6 +22,19 @@ final class LocusUITests: XCTestCase {
         app.descendants(matching: .any)[identifier].firstMatch
     }
 
+    /// Existence becomes true at the start of a SwiftUI transition, before a
+    /// newly presented control has necessarily reached a clickable position.
+    private func waitUntilHittable(_ element: XCUIElement, timeout: TimeInterval = 3) -> Bool {
+        let ready = XCTNSPredicateExpectation(
+            predicate: NSPredicate { candidate, _ in
+                guard let candidate = candidate as? XCUIElement else { return false }
+                return candidate.exists && candidate.isHittable
+            },
+            object: element
+        )
+        return XCTWaiter.wait(for: [ready], timeout: timeout) == .completed
+    }
+
     /// SwiftUI alerts surface as sheets labeled "alert" on current macOS;
     /// their message text is exposed as a value, not a label.
     private func staticTextWithValue(containing fragment: String) -> XCUIElement {
@@ -141,7 +154,8 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(app.menuItems["Delete Chat"].exists)
         app.typeKey(.escape, modifierFlags: [])
 
-        XCTAssertTrue(anyElement("sidebar.addWorkspace").exists)
+        XCTAssertFalse(anyElement("sidebar.addWorkspace").exists)
+        XCTAssertTrue(anyElement("sidebar.activity").exists)
 
         anyElement("sidebar.more").click()
         let archivedToggle = app.menuItems["sidebar.showArchived"]
@@ -164,6 +178,8 @@ final class LocusUITests: XCTestCase {
     }
 
     func testWorkspaceProfileContextPackAndPromptHistoryControls() {
+        XCTAssertTrue(anyElement("workspace.header.workspaceIcon").waitForExistence(timeout: 3))
+
         let workspaceMenu = anyElement("sidebar.workspaceMenu")
         XCTAssertTrue(workspaceMenu.waitForExistence(timeout: 3))
         workspaceMenu.click()
@@ -194,6 +210,12 @@ final class LocusUITests: XCTestCase {
             let control = anyElement("extensions.tab.\(tab)")
             XCTAssertTrue(control.waitForExistence(timeout: 3))
             control.click()
+            if tab == "mcp-servers" {
+                XCTAssertTrue(
+                    anyElement("extensions.mcp.preset.github.logo").waitForExistence(timeout: 3),
+                    "MCP providers should display their own identity marks"
+                )
+            }
         }
         XCTAssertTrue(app.staticTexts["Reusable workflows"].exists)
     }
@@ -774,23 +796,67 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(anyElement("plan.create").waitForExistence(timeout: 3))
     }
 
-    func testPlanTabOrdersContextThenActivePlanThenPermissions() {
+    func testPlanTabPlacesPlanBeforeContextAndOmitsPermissions() {
+        let tabBar = anyElement("inspector.tabBar")
         let context = anyElement("plan.contextWindow")
         let activePlan = anyElement("plan.activePlan")
+        let openIn = anyElement("plan.openIn")
         let permissionControl = anyElement("plan.permissionMode")
         let window = app.windows.firstMatch
 
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 3))
         XCTAssertTrue(context.waitForExistence(timeout: 3))
         XCTAssertTrue(activePlan.exists)
-        XCTAssertTrue(permissionControl.exists)
-        XCTAssertLessThan(context.frame.minY, activePlan.frame.minY)
-        XCTAssertLessThan(activePlan.frame.minY, permissionControl.frame.minY)
-        XCTAssertLessThan(
-            window.frame.maxY - permissionControl.frame.maxY,
-            110,
-            "Permissions should stay anchored at the bottom of the inspector"
+        XCTAssertTrue(openIn.exists)
+        XCTAssertEqual(openIn.label, "Open workspace in Finder")
+        XCTAssertFalse(permissionControl.exists)
+        XCTAssertLessThanOrEqual(
+            abs(tabBar.frame.minY - window.frame.minY),
+            2,
+            "Inspector tabs should occupy the hidden title-bar band"
+        )
+        XCTAssertLessThan(activePlan.frame.minY, context.frame.minY)
+        XCTAssertLessThanOrEqual(
+            window.frame.maxY - context.frame.maxY,
+            30,
+            "Context window should stay pinned to the bottom of the Plan tab"
+        )
+        XCTAssertLessThanOrEqual(
+            context.frame.maxX,
+            tabBar.frame.maxX + 1,
+            "Plan cards must remain inside the inspector instead of clipping under the rail"
         )
         XCTAssertFalse(anyElement("checkpointTab.content").exists)
+    }
+
+    func testOverflowingInspectorTabsStillSwitchBrowserAndTerminal() {
+        // Six destinations exercise the horizontally scrolling tab path.
+        // Browser and Terminal both install native AppKit views; those views
+        // must never cover the shared inspector tabs for hit-testing.
+        app.typeKey("2", modifierFlags: .command)
+        app.typeKey("3", modifierFlags: .command)
+        app.typeKey("4", modifierFlags: .command)
+        app.typeKey("5", modifierFlags: .command)
+        app.typeKey("7", modifierFlags: .command)
+        app.typeKey("4", modifierFlags: .command)
+
+        var browserTab: XCUIElement { app.buttons["inspector.tab.preview"].firstMatch }
+        var terminalTab: XCUIElement { app.buttons["inspector.tab.terminal"].firstMatch }
+        XCTAssertTrue(browserTab.waitForExistence(timeout: 3))
+        XCTAssertTrue(terminalTab.exists)
+        XCTAssertTrue(browserTab.isHittable)
+        XCTAssertTrue(terminalTab.isHittable)
+        XCTAssertTrue(anyElement("terminal.output").waitForExistence(timeout: 3))
+
+        browserTab.click()
+        XCTAssertTrue(anyElement("browser.url").waitForExistence(timeout: 3))
+        XCTAssertFalse(anyElement("terminal.output").exists)
+
+        terminalTab.click()
+        XCTAssertTrue(anyElement("terminal.output").waitForExistence(timeout: 3))
+
+        browserTab.click()
+        XCTAssertTrue(anyElement("browser.url").waitForExistence(timeout: 3))
     }
 
     func testChangesTabShowsSeededWorkingTreeAndOpensADiff() {
@@ -871,9 +937,10 @@ final class LocusUITests: XCTestCase {
     /// Relaunches with the opt-in pending-permission fixture. It is not part
     /// of the base seed because a pending request disables send and
     /// clear-chat, which would break the rest of the suite.
-    private func relaunchWithPendingPermission() {
+    private func relaunchWithPendingPermission(toolActivityMode: String? = nil) {
         app.terminate()
         app.launchEnvironment["LOCUS_UI_TESTING_PERMISSION"] = "1"
+        app.launchEnvironment["LOCUS_UI_TESTING_TOOL_ACTIVITY_MODE"] = toolActivityMode
         app.launch()
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
     }
@@ -885,9 +952,10 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
     }
 
-    private func relaunchWithScrollFixture() {
+    private func relaunchWithScrollFixture(toolActivityMode: String? = nil) {
         app.terminate()
         app.launchEnvironment["LOCUS_UI_TESTING_SCROLL"] = "1"
+        app.launchEnvironment["LOCUS_UI_TESTING_TOOL_ACTIVITY_MODE"] = toolActivityMode
         app.launch()
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
     }
@@ -957,20 +1025,26 @@ final class LocusUITests: XCTestCase {
         relaunchWithRunFixture("activity")
 
         let destination = anyElement("sidebar.activity")
+        let newChat = anyElement("sidebar.newSession")
         XCTAssertTrue(destination.waitForExistence(timeout: 3))
+        XCTAssertTrue(newChat.exists)
+        XCTAssertLessThanOrEqual(abs(destination.frame.midY - newChat.frame.midY), 2)
+        XCTAssertGreaterThan(destination.frame.minX, newChat.frame.maxX)
         XCTAssertTrue("\(destination.value ?? "")".contains("1 needs attention"))
         destination.click()
         XCTAssertTrue(anyElement("activity.center").waitForExistence(timeout: 3))
         XCTAssertTrue(anyElement("activity.run.seed-run").waitForExistence(timeout: 3))
+        XCTAssertTrue(app.textViews["composer.input"].exists)
         XCTAssertTrue("\(destination.value ?? "")".contains("No new activity"))
 
-        anyElement("session.seed-current").click()
-        XCTAssertTrue(app.textViews["composer.input"].waitForExistence(timeout: 3))
+        destination.click()
         XCTAssertFalse(anyElement("activity.center").exists)
+        XCTAssertTrue(app.textViews["composer.input"].exists)
 
         destination.click()
         let remove = anyElement("activity.remove.seed-run")
         XCTAssertTrue(remove.waitForExistence(timeout: 3))
+        XCTAssertTrue(waitUntilHittable(remove))
         remove.click()
         XCTAssertTrue(app.staticTexts["No Activity Yet"].waitForExistence(timeout: 3))
     }
@@ -980,7 +1054,13 @@ final class LocusUITests: XCTestCase {
 
         let transcript = anyElement("conversation.scroll")
         XCTAssertTrue(transcript.waitForExistence(timeout: 3))
+        let group = anyElement(
+            "toolActivity.group.00000000-0000-0000-0000-000000000101"
+        )
+        XCTAssertTrue(group.waitForExistence(timeout: 3))
         let firstTool = anyElement("tool.scroll-tool-0.toggle")
+        XCTAssertFalse(firstTool.exists, "collapsed mode starts with one request-level row")
+        group.click()
         XCTAssertTrue(firstTool.waitForExistence(timeout: 3))
         firstTool.click()
 
@@ -1005,6 +1085,44 @@ final class LocusUITests: XCTestCase {
         }
         XCTAssertTrue(firstMessage.waitForExistence(timeout: 3))
         XCTAssertTrue(firstMessage.isHittable)
+    }
+
+    func testCollapsedToolActivityGroupsAndExpands() {
+        relaunchWithScrollFixture()
+
+        let group = anyElement(
+            "toolActivity.group.00000000-0000-0000-0000-000000000101"
+        )
+        XCTAssertTrue(group.waitForExistence(timeout: 3))
+        XCTAssertTrue(group.label.contains("12 tool calls"))
+
+        let firstTool = anyElement("tool.scroll-tool-0.toggle")
+        XCTAssertFalse(firstTool.exists)
+        group.click()
+        XCTAssertTrue(firstTool.waitForExistence(timeout: 3))
+    }
+
+    func testVerboseToolActivityView() {
+        relaunchWithScrollFixture(toolActivityMode: "verbose")
+
+        XCTAssertTrue(anyElement("tool.scroll-tool-0.toggle").waitForExistence(timeout: 3))
+        XCTAssertFalse(
+            anyElement("toolActivity.group.00000000-0000-0000-0000-000000000101").exists
+        )
+    }
+
+    func testHiddenToolActivityView() {
+        relaunchWithScrollFixture(toolActivityMode: "hidden")
+
+        let hidden = anyElement(
+            "toolActivity.hidden.00000000-0000-0000-0000-000000000101"
+        )
+        XCTAssertTrue(hidden.waitForExistence(timeout: 3))
+        XCTAssertEqual(hidden.label, "Actions complete")
+        XCTAssertFalse(anyElement("tool.scroll-tool-0.toggle").exists)
+        XCTAssertFalse(
+            anyElement("toolActivity.group.00000000-0000-0000-0000-000000000101").exists
+        )
     }
 
     func testReviewAndLandShowsDiffChecksAndBothDestinations() {
@@ -1106,5 +1224,24 @@ final class LocusUITests: XCTestCase {
         // back on its own so "tell Locus what to do differently" just works.
         app.typeText("use a dry run instead")
         XCTAssertTrue((composer.value as? String)?.contains("use a dry run instead") == true)
+    }
+
+    func testHiddenToolActivityKeepsThePermissionPanelUsable() {
+        relaunchWithPendingPermission(toolActivityMode: "hidden")
+
+        XCTAssertTrue(anyElement("permission.panel").waitForExistence(timeout: 3))
+        let hidden = anyElement(
+            "toolActivity.hidden.00000000-0000-0000-0000-000000000201"
+        )
+        XCTAssertTrue(hidden.waitForExistence(timeout: 3))
+        XCTAssertEqual(hidden.label, "Action needs approval")
+        XCTAssertFalse(anyElement("tool.seed-tool-permission.toggle").exists)
+        XCTAssertTrue(anyElement("permission.once").exists)
+        XCTAssertTrue(anyElement("permission.always").exists)
+        XCTAssertTrue(anyElement("permission.deny").exists)
+        XCTAssertFalse(
+            anyElement("workspace.workStatus").label.localizedCaseInsensitiveContains("bash"),
+            "hidden mode must not leak the tool name through the persistent status strip"
+        )
     }
 }

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -1044,8 +1044,11 @@ final class LocusUITests: XCTestCase {
         destination.click()
         let remove = anyElement("activity.remove.seed-run")
         XCTAssertTrue(remove.waitForExistence(timeout: 3))
-        XCTAssertTrue(waitUntilHittable(remove))
-        remove.click()
+        // The activity center is a SwiftUI overlay. macOS 15 and 26 can mark
+        // its visible buttons non-hittable in XCUI even though AppKit routes a
+        // pointer at the same frame correctly. Exercise the real hit-testing
+        // path at the button's center and verify the resulting removal.
+        remove.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
         XCTAssertTrue(app.staticTexts["No Activity Yet"].waitForExistence(timeout: 3))
     }
 
@@ -1066,22 +1069,24 @@ final class LocusUITests: XCTestCase {
 
         // Begin the gesture over selectable tool output. It must continue on
         // the transcript instead of being swallowed by the nested responder.
-        firstTool.scroll(byDeltaX: 0, deltaY: -2_400)
         let lastTool = anyElement("tool.scroll-tool-11.toggle")
-        // Hosted macOS 15 runners can report a shorter wheel distance for the
-        // same synthesized gesture. Continue from the transcript until its
-        // final fixture item enters the accessibility viewport.
-        for _ in 0..<3 where !lastTool.isHittable {
-            transcript.scroll(byDeltaX: 0, deltaY: -2_400)
+        // Grouping puts the tool cards next to one another. Move through them
+        // in bounded steps so a single synthetic wheel event cannot jump past
+        // the lazy stack and evict the final card from accessibility.
+        firstTool.scroll(byDeltaX: 0, deltaY: -320)
+        for _ in 0..<8 {
+            if lastTool.exists, lastTool.isHittable { break }
+            transcript.scroll(byDeltaX: 0, deltaY: -320)
         }
         XCTAssertTrue(lastTool.waitForExistence(timeout: 3))
         XCTAssertTrue(lastTool.isHittable)
         lastTool.click()
 
-        lastTool.scroll(byDeltaX: 0, deltaY: 2_400)
         let firstMessage = anyElement("message.00000000-0000-0000-0000-000000000101")
-        for _ in 0..<3 where !firstMessage.isHittable {
-            transcript.scroll(byDeltaX: 0, deltaY: 2_400)
+        lastTool.scroll(byDeltaX: 0, deltaY: 320)
+        for _ in 0..<8 {
+            if firstMessage.exists, firstMessage.isHittable { break }
+            transcript.scroll(byDeltaX: 0, deltaY: 320)
         }
         XCTAssertTrue(firstMessage.waitForExistence(timeout: 3))
         XCTAssertTrue(firstMessage.isHittable)


### PR DESCRIPTION
## Summary

- refine the workspace header, sidebar, composer, activity center, and inspector title-bar tabs
- reorganize the Plan inspector and shared visual styling for clearer compact layouts
- add persisted Verbose, Collapsed, and Hidden tool-activity transcript modes
- keep hidden activity generic while preserving the full permission preview and underlying transcript data
- expand unit and UI coverage for settings compatibility, grouping, status aggregation, accessibility, and each display mode

## Validation

- `xcodebuild ... build-for-testing` succeeded for the app, unit-test, and UI-test targets
- focused settings, transcript-grouping, stable-identity, and status-precedence unit tests passed
- focused Collapsed, Verbose, Hidden, and hidden-permission UI tests passed
- `git diff --check` passed
