### PR TITLE
Keep the model picker on the route the agent accepted

### DIFF
--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -954,7 +954,21 @@ final class AppModel: ObservableObject {
         guard let account = activeAccount else {
             return localModels.isEmpty && models.isEmpty ? "Auto" : selectedModel
         }
-        return "\(account.shortName) · \(selectedModel)"
+        return "\(account.shortName) · \(routedModel(for: account))"
+    }
+
+    /// What an account actually routes to. `selectedModel` is whatever the
+    /// agent last reported, which is still the *previous* provider's model
+    /// until this account connects — pairing the two names then advertises a
+    /// route that does not exist ("Kimi · gpt-5.6-sol"). Fall back to the
+    /// model this account is configured to run.
+    func routedModel(for account: ProviderAccount) -> String {
+        if modelBelongsToAccount(selectedModel, account: account) { return selectedModel }
+        if let preferred = account.preferredModel
+            .trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
+            return preferred
+        }
+        return account.kind.curatedModels.first ?? selectedModel
     }
 
     var selectedTeamModelNames: [String] {
@@ -3625,6 +3639,10 @@ final class AppModel: ObservableObject {
     }
 
     private func applyProviderSwitch(accountID: UUID?, model: String) {
+        // The route is committed before the agent has accepted it, because the
+        // request body is built from these fields.
+        let previousAccountID = settings.activeAccountID
+        let previousProvider = settings.provider
         if let accountID, let account = providerAccounts.first(where: { $0.id == accountID }) {
             rememberPreferredModel(model, for: account)
             settings.activeAccountID = accountID.uuidString
@@ -3635,7 +3653,17 @@ final class AppModel: ObservableObject {
         }
         persistSettings()
         Task {
-            await applyProvider()
+            guard await applyProvider() else {
+                // The agent kept the provider it had. Leaving the new account
+                // committed would leave the app pointing at an account that
+                // never connected while every turn still runs on the old
+                // route — visible as an account paired with another
+                // provider's model.
+                settings.activeAccountID = previousAccountID
+                settings.provider = previousProvider
+                persistSettings()
+                return
+            }
             // The remote provider adopts its configured model as it connects;
             // the local runtime keeps whatever it had, so name it explicitly.
             if accountID == nil, !model.isEmpty, model != selectedModel {

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -1693,6 +1693,58 @@ final class AppModelTests: XCTestCase {
     }
 
     @MainActor
+    func testAProviderSwitchTheAgentRejectsDoesNotLeaveTheAccountSelected() async {
+        let model = AppModel(startImmediately: false)
+        let account = seedAccount(model, kind: .kimiCode, name: "Kimi", preferredModel: "k3")
+
+        model.selectModel(account: account, model: "k3")
+        // The route is committed up front because the provider request body is
+        // built from it.
+        XCTAssertEqual(model.settings.activeAccountID, account.id.uuidString)
+
+        // No agent is listening, so the provider call fails. The app must fall
+        // back to the route that is still live rather than claim this one.
+        for _ in 0..<80 where model.settings.activeAccountID != nil {
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertNil(
+            model.settings.activeAccountID,
+            "an account the agent never adopted must not stay selected"
+        )
+        XCTAssertEqual(model.settings.provider, .ollama)
+    }
+
+    @MainActor
+    func testTheClosedPickerNeverPairsAnAccountWithAnotherProvidersModel() {
+        let model = AppModel(startImmediately: false)
+        let account = seedAccount(model, kind: .kimiCode, name: "Kimi", preferredModel: "k3")
+        model.settings.activeAccountID = account.id.uuidString
+        model.settings.provider = .remote
+        // What the agent reports while it is still on the previous route.
+        model.sessionInfo = SessionInfo(
+            model: "gpt-5.6-sol", host: "h", cwd: "/tmp", session: "s", sessionID: "s",
+            messages: 1, approxTokens: 0, promptTokens: 0, completionTokens: 0,
+            contextLimit: 0, maxIterations: 40, hasProjectContext: false,
+            permissions: SessionPermissions(skipAll: false, allowed: [])
+        )
+
+        XCTAssertEqual(
+            model.modelPickerLabel, "Kimi · k3",
+            "the chip must not advertise a route that does not exist"
+        )
+        XCTAssertEqual(model.routedModel(for: account), "k3")
+
+        // Once the agent is really on this account, its own report wins.
+        model.sessionInfo = SessionInfo(
+            model: "kimi-for-coding", host: "h", cwd: "/tmp", session: "s", sessionID: "s",
+            messages: 1, approxTokens: 0, promptTokens: 0, completionTokens: 0,
+            contextLimit: 0, maxIterations: 40, hasProjectContext: false,
+            permissions: SessionPermissions(skipAll: false, allowed: [])
+        )
+        XCTAssertEqual(model.modelPickerLabel, "Kimi · kimi-for-coding")
+    }
+
+    @MainActor
     func testChoosingAnAccountWithNoKeyOpensSettingsInsteadOfSwitching() {
         let model = AppModel(startImmediately: false)
         let account = ProviderAccount(kind: .codex, name: "Unconfigured")


### PR DESCRIPTION
Switching to a provider account committed the route before the agent had taken it: `applyProviderSwitch` wrote `activeAccountID`, persisted, then posted the provider to the agent and ignored the result. When that post failed, nothing put the setting back — the app claimed the new account while every turn still ran on the old one.

The closed picker made it visible: its left half comes from the committed account, its right half from `sessionInfo.model` (whatever the agent last reported), so a failed switch to Kimi read **"Kimi · gpt-5.6-sol"** — an account paired with another provider's model.

## Changes

- `applyProviderSwitch` restores `activeAccountID`/`provider` when `applyProvider()` reports the agent did not adopt the provider. The failure already surfaces as a toast and `accountStatus[...] = .failed`; now the route matches it.
- `routedModel(for:)` resolves the picker's model against the active account — while a switch is in flight the agent has not reported the new model, so it falls back to the model that account is configured to run instead of borrowing the previous provider's.

## Tests

- `testAProviderSwitchTheAgentRejectsDoesNotLeaveTheAccountSelected`
- `testTheClosedPickerNeverPairsAnAccountWithAnotherProvidersModel`

Verified locally with `xcodebuild build-for-testing` and `Tools/AuditDesignSystem.sh`; the unit suite could not be launched on this machine because a copy of the app was running (same bundle id), so CI is the check.