### PR TITLE
Offer Copy and Search in Google on highlighted transcript text

### DIFF
--- a/Locus.xcodeproj/project.pbxproj
+++ b/Locus.xcodeproj/project.pbxproj
@@ -109,9 +109,11 @@
 		B402C210FA2E1DD2FB8282E0 /* InspectorFilesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D6D002C03E3AA6EB9FEFD0 /* InspectorFilesTab.swift */; };
 		B47489F53435C4FB56730215 /* CredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D427058C21A8F1993C532E8 /* CredentialStore.swift */; };
 		B53008519AEC1D4829A97385 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BE7F27B06F0AA98E893C2E9B /* Info.plist */; };
+		B767AB277BBF93D100B7E66F /* TextSelectionMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB36421DC413C2F3F5BDA72 /* TextSelectionMenu.swift */; };
 		BA8DA9BA54151EC2C57851CD /* PlanApprovalPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF0BEF00F2EA8083877CC21 /* PlanApprovalPromptView.swift */; };
 		BEAFCBFDAE33591C970B5E98 /* BackendProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38285B85EFF71F02AF0DDB3 /* BackendProcess.swift */; };
 		BFD9B220064B1A7D36E1D116 /* HostedScreenshotConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319231FBA55F2DE9A5EB9377 /* HostedScreenshotConsent.swift */; };
+		C0888AD9C1A69FEDBCF58E8E /* TextSelectionMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB36421DC413C2F3F5BDA72 /* TextSelectionMenu.swift */; };
 		C0E82F8A928841455031CFA2 /* ProxyConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F29AE63F7A646BB5043E54 /* ProxyConfigurator.swift */; };
 		C0EB8EF86FF9954D89CC082E /* InspectorPlanTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD0CDE34355390B1AB4691E /* InspectorPlanTab.swift */; };
 		C0F305A78BD17AAC4C3CE7F8 /* SessionOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4414AFBD9717B5359B81CE8B /* SessionOverviewView.swift */; };
@@ -183,6 +185,7 @@
 		0204C24A0102A8D20E3A23CE /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		06DD9A63C8FBDB42368F8A0C /* GitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitClient.swift; sourceTree = "<group>"; };
 		0B46A04DBC2F15987A189E7A /* ThirdPartyNotices.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ThirdPartyNotices.md; sourceTree = "<group>"; };
+		0DB36421DC413C2F3F5BDA72 /* TextSelectionMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSelectionMenu.swift; sourceTree = "<group>"; };
 		0F07D2B0078D88B65F9AA0FE /* BrowserAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserAnnotationTests.swift; sourceTree = "<group>"; };
 		10D6D002C03E3AA6EB9FEFD0 /* InspectorFilesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorFilesTab.swift; sourceTree = "<group>"; };
 		1616CD8FA01FCC15741F95EF /* TaskWorkerRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskWorkerRuntime.swift; sourceTree = "<group>"; };
@@ -392,6 +395,7 @@
 				78188AFFEC80498E68C2EE3A /* SlashCommands.swift */,
 				1616CD8FA01FCC15741F95EF /* TaskWorkerRuntime.swift */,
 				F95947ACE0751337457A57CD /* TerminalSession.swift */,
+				0DB36421DC413C2F3F5BDA72 /* TextSelectionMenu.swift */,
 				0204C24A0102A8D20E3A23CE /* Theme.swift */,
 				A5CC6B3A08FFA65A82439731 /* UsageDashboardView.swift */,
 				EAAE8017A82BDD5DBCA5F587 /* WorkspaceAccess.swift */,
@@ -750,6 +754,7 @@
 				686A434D611B736A8BC449A2 /* SlashCommands.swift in Sources */,
 				938383A0E816F7A0C1B97A10 /* TaskWorkerRuntime.swift in Sources */,
 				3C3E46189C3441DA21CB8E5A /* TerminalSession.swift in Sources */,
+				B767AB277BBF93D100B7E66F /* TextSelectionMenu.swift in Sources */,
 				62A955375EBFA6E5A70A6C85 /* Theme.swift in Sources */,
 				6FDB5F37C36EE733A8A7DD43 /* UsageDashboardView.swift in Sources */,
 				C214A77B64E488AE82DCFB59 /* WorkspaceAccess.swift in Sources */,
@@ -816,6 +821,7 @@
 				5C41A50A32A3D69CCC0BB9A2 /* SlashCommands.swift in Sources */,
 				01DCA647E6FC8E205FEBA724 /* TaskWorkerRuntime.swift in Sources */,
 				7FB9CA10129643CE5198F806 /* TerminalSession.swift in Sources */,
+				C0888AD9C1A69FEDBCF58E8E /* TextSelectionMenu.swift in Sources */,
 				473A0EEF2BC977577C962850 /* Theme.swift in Sources */,
 				C702DDBC94CDC2241F409353 /* UsageDashboardView.swift in Sources */,
 				06A23CF5AE9CED9B211FAA4B /* WorkspaceAccess.swift in Sources */,

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -8342,6 +8342,20 @@ final class AppModel: ObservableObject {
         }
     }
 
+    /// "Search in Google" on highlighted conversation text. A Locus Browser
+    /// tab is not used when the user has turned browsing off, or in Ask mode
+    /// where the inspector refuses to open one — the search still has to land
+    /// somewhere, so it falls back to the default browser.
+    func searchWebForSelection(_ selection: String) {
+        guard let url = WebSearchQuery.url(for: selection) else { return }
+        let wantsBrowserTab = settings.resolvedWebSearchDestination == .locusBrowser
+        if wantsBrowserTab, settings.browserEnabled, !justChatEnabled {
+            openURLInBrowserTab(url)
+        } else {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
     func openSummaryOutput(_ row: PinnedSummary.OutputRow) {
         switch row.kind {
         case .file:

--- a/Locus/LocusApp.swift
+++ b/Locus/LocusApp.swift
@@ -230,6 +230,9 @@ final class LocusApplicationDelegate: NSObject, NSApplicationDelegate,
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         UNUserNotificationCenter.current().delegate = self
+        TranscriptSelectionMenu.shared.start { [weak self] selection in
+            self?.model?.searchWebForSelection(selection)
+        }
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(windowWillClose(_:)),

--- a/Locus/Models.swift
+++ b/Locus/Models.swift
@@ -1800,6 +1800,9 @@ struct AppSettings: Codable, Hashable {
     /// default forgets everything when the app quits, because an agent that
     /// can browse anywhere should not quietly accumulate a signed-in profile.
     var browserPersistProfile = false
+    /// Where "Search in Google" on highlighted conversation text opens. Raw
+    /// string for the same forward-compatibility reason as the viewport.
+    var webSearchDestinationRaw = WebSearchDestination.defaultBrowser.rawValue
     /// Every executing chat owns a worker. This bounds active turns, not idle
     /// worker processes, and intentionally differs from per-team model calls.
     var maximumActiveChats = 2
@@ -1939,6 +1942,10 @@ struct AppSettings: Codable, Hashable {
         BrowserViewport(rawValue: browserViewportRaw) ?? .desktop
     }
 
+    var resolvedWebSearchDestination: WebSearchDestination {
+        WebSearchDestination(rawValue: webSearchDestinationRaw) ?? .defaultBrowser
+    }
+
     var resolvedProxyMode: ProxyMode {
         ProxyMode(rawValue: proxyModeRaw) ?? .off
     }
@@ -2072,6 +2079,10 @@ struct AppSettings: Codable, Hashable {
             Bool.self,
             forKey: .browserPersistProfile
         ) ?? defaults.browserPersistProfile
+        webSearchDestinationRaw = try container.decodeIfPresent(
+            String.self,
+            forKey: .webSearchDestinationRaw
+        ) ?? defaults.webSearchDestinationRaw
         maximumActiveChats = Self.clampMaximumActiveChats(
             try container.decodeIfPresent(Int.self, forKey: .maximumActiveChats)
                 ?? defaults.maximumActiveChats

--- a/Locus/Sheets.swift
+++ b/Locus/Sheets.swift
@@ -1810,6 +1810,20 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
+            Section("Highlighted text") {
+                Picker("Search in Google opens in", selection: $draft.webSearchDestinationRaw) {
+                    ForEach(WebSearchDestination.allCases) { destination in
+                        Text(destination.title).tag(destination.rawValue)
+                    }
+                }
+                .accessibilityIdentifier("settings.browser.webSearchDestination")
+
+                Text("Right-clicking highlighted text in a conversation offers Copy and Search in Google. The Browser tab is used only while the agent’s browser is on.")
+                    .font(.locus(size: 9))
+                    .foregroundStyle(LocusTheme.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             Section("Privacy & data") {
                 Picker("Browsing profile", selection: $draft.browserPersistProfile) {
                     Text("Forget when Locus quits").tag(false)

--- a/Locus/TextSelectionMenu.swift
+++ b/Locus/TextSelectionMenu.swift
@@ -1,0 +1,232 @@
+import AppKit
+import SwiftUI
+
+/// Where a web search started from highlighted text opens.
+///
+/// Stored as a raw string, like the browser viewport: a destination added by a
+/// future version must not fail the whole settings decode.
+enum WebSearchDestination: String, CaseIterable, Codable, Identifiable {
+    case defaultBrowser
+    case locusBrowser
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .defaultBrowser: "Default browser"
+        case .locusBrowser: "Locus Browser tab"
+        }
+    }
+}
+
+/// Turns a text selection into the Google search it stands for.
+enum WebSearchQuery {
+    /// Google stops reading a query long before this, and a URL carrying a
+    /// whole message is refused somewhere along the way. A longer selection
+    /// searches its leading words rather than failing to search at all.
+    static let characterLimit = 512
+
+    /// Transcript selections routinely span several lines. Google reads a
+    /// query as words, so newlines and runs of spaces collapse to one space —
+    /// what gets searched is then what the menu said it would search.
+    static func normalize(_ selection: String) -> String {
+        selection
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    /// Truncation lands on a word boundary when the query has one. Cutting
+    /// mid-word would search for a fragment the user never highlighted.
+    static func truncate(_ query: String, limit: Int = characterLimit) -> String {
+        guard query.count > limit else { return query }
+        let head = query.prefix(limit)
+        if let lastSpace = head.lastIndex(of: " ") {
+            let trimmed = head[..<lastSpace]
+            if !trimmed.isEmpty { return String(trimmed) }
+        }
+        return String(head)
+    }
+
+    static func url(for selection: String) -> URL? {
+        let query = truncate(normalize(selection))
+        guard !query.isEmpty else { return nil }
+        // `URLComponents` leaves a literal "+" in a query value, which Google
+        // decodes back as a space — so a selection containing "+" would be
+        // searched as something else. Percent-encoding everything outside the
+        // unreserved set keeps the query byte-for-byte what was highlighted.
+        let unreserved = CharacterSet(
+            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+        )
+        guard let encoded = query.addingPercentEncoding(withAllowedCharacters: unreserved) else {
+            return nil
+        }
+        return URL(string: "https://www.google.com/search?q=\(encoded)")
+    }
+}
+
+/// The right-click menu for highlighted conversation text: Copy, and Search in
+/// Google.
+///
+/// SwiftUI never exposes what `.textSelection(.enabled)` has selected, but it
+/// draws that text as a non-editable `NSTextField`, so highlighting promotes
+/// the window's field editor — a real `NSTextView` — to first responder. The
+/// selection can be read straight off it, with no pasteboard round-trip to
+/// clobber the user's clipboard.
+///
+/// A local right-mouse monitor is what makes replacing the menu possible: it
+/// sees the click before AppKit reaches the field editor, which would
+/// otherwise put up the system text menu (Look Up, Translate, Writing Tools,
+/// Font, Speech…) and leave no room for ours.
+@MainActor
+final class TranscriptSelectionMenu {
+    static let shared = TranscriptSelectionMenu()
+
+    /// Scroll views whose highlighted text this menu covers — the conversation
+    /// transcripts. Held weakly, so a torn-down transcript stops matching
+    /// without anything having to deregister it.
+    private let scopes = NSHashTable<NSScrollView>.weakObjects()
+    private var monitor: Any?
+    private var search: ((String) -> Void)?
+
+    private init() {}
+
+    /// Idempotent: the scene calls this on every appearance, and only the
+    /// first one installs a monitor.
+    func start(onSearch: @escaping (String) -> Void) {
+        search = onSearch
+        guard monitor == nil else { return }
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
+            guard let self, let target = self.target(for: event) else { return event }
+            self.present(for: target, event: event)
+            // Swallowing the click stops AppKit from following our menu with
+            // the field editor's own.
+            return nil
+        }
+    }
+
+    func stop() {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+        monitor = nil
+        search = nil
+    }
+
+    func registerScope(_ scrollView: NSScrollView) {
+        scopes.add(scrollView)
+    }
+
+    // MARK: - Deciding whether the click is on a selection we own
+
+    private struct Target {
+        let editor: NSTextView
+        let text: String
+    }
+
+    private func target(for event: NSEvent) -> Target? {
+        guard let window = event.window,
+              let editor = window.firstResponder as? NSTextView,
+              editor.isFieldEditor,
+              // The composer and the settings fields keep their editing menu,
+              // which carries Cut and Paste. This one is for material being
+              // read, not written.
+              !editor.isEditable
+        else { return nil }
+
+        let range = editor.selectedRange()
+        guard range.length > 0, Self.isInScope(editor, scopes: scopes) else { return nil }
+
+        // Only a click on the highlight itself. Right-clicking anywhere else
+        // in the message still gets the message's own menu.
+        guard editor.bounds.contains(editor.convert(event.locationInWindow, from: nil)) else {
+            return nil
+        }
+
+        let text = (editor.string as NSString).substring(with: range)
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return Target(editor: editor, text: text)
+    }
+
+    /// Scope is tested by ancestry rather than by `enclosingScrollView`: a code
+    /// block's text sits inside its own horizontal scroll view, so the nearest
+    /// enclosing scroll view is not the transcript's.
+    private static func isInScope(_ view: NSView, scopes: NSHashTable<NSScrollView>) -> Bool {
+        var candidate: NSView? = view
+        while let current = candidate {
+            if let scrollView = current as? NSScrollView, scopes.contains(scrollView) {
+                return true
+            }
+            candidate = current.superview
+        }
+        return false
+    }
+
+    // MARK: - The menu
+
+    private func present(for target: Target, event: NSEvent) {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let copy = NSMenuItem(
+            title: "Copy",
+            action: #selector(copySelection(_:)),
+            keyEquivalent: ""
+        )
+        copy.target = self
+        copy.representedObject = target.text
+        menu.addItem(copy)
+
+        let search = NSMenuItem(
+            title: "Search in Google",
+            action: #selector(searchSelection(_:)),
+            keyEquivalent: ""
+        )
+        search.target = self
+        search.representedObject = target.text
+        // A selection that cannot form a query — punctuation only, say — would
+        // otherwise open a blank results page.
+        search.isEnabled = WebSearchQuery.url(for: target.text) != nil
+        menu.addItem(search)
+
+        menu.popUp(
+            positioning: nil,
+            at: target.editor.convert(event.locationInWindow, from: nil),
+            in: target.editor
+        )
+    }
+
+    @objc private func copySelection(_ sender: NSMenuItem) {
+        guard let text = sender.representedObject as? String else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    @objc private func searchSelection(_ sender: NSMenuItem) {
+        guard let text = sender.representedObject as? String else { return }
+        search?(text)
+    }
+}
+
+/// Marks the conversation transcript as the region whose highlighted text gets
+/// the selection menu. Sits in the transcript content's background so that
+/// `enclosingScrollView` resolves to the transcript's own scroll view.
+struct TranscriptSelectionScope: NSViewRepresentable {
+    func makeNSView(context: Context) -> TranscriptSelectionScopeView {
+        TranscriptSelectionScopeView(frame: .zero)
+    }
+
+    func updateNSView(_ nsView: TranscriptSelectionScopeView, context: Context) {
+        nsView.registerScope()
+    }
+}
+
+final class TranscriptSelectionScopeView: NSView {
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        registerScope()
+    }
+
+    func registerScope() {
+        guard let scrollView = enclosingScrollView else { return }
+        TranscriptSelectionMenu.shared.registerScope(scrollView)
+    }
+}

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -1479,6 +1479,7 @@ private struct ConversationView: View {
                 }
                 .accessibilityElement(children: .contain)
                 .accessibilityLabel("Conversation transcript")
+                .background { TranscriptSelectionScope() }
                 .frame(maxWidth: 740)
                 .padding(.horizontal, 28)
                 .padding(.top, model.blocks.isEmpty ? 0 : 26)

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -3671,4 +3671,74 @@ final class FeatureLogicTests: XCTestCase {
             ChatPasteboardClassifier.imagePayload(pngData: Data(), tiffData: Data([0x00]))
         )
     }
+
+    // MARK: - Highlighted-text search
+
+    func testWebSearchQueryCollapsesMultiLineSelections() {
+        XCTAssertEqual(
+            WebSearchQuery.normalize("  swift\n  actor   isolation \n"),
+            "swift actor isolation"
+        )
+        XCTAssertEqual(WebSearchQuery.normalize("   \n\t "), "")
+    }
+
+    func testWebSearchQueryTruncatesOnAWordBoundary() {
+        let query = String(repeating: "alpha ", count: 40).trimmingCharacters(in: .whitespaces)
+        let truncated = WebSearchQuery.truncate(query, limit: 12)
+        XCTAssertEqual(truncated, "alpha alpha")
+        // A single word longer than the limit has no boundary to cut on, so it
+        // is cut where the limit falls rather than dropped entirely.
+        XCTAssertEqual(WebSearchQuery.truncate("abcdefghij", limit: 4), "abcd")
+        XCTAssertEqual(WebSearchQuery.truncate("short", limit: 64), "short")
+    }
+
+    func testWebSearchURLEncodesTheSelectionItself() {
+        let url = WebSearchQuery.url(for: "swift c++ & rust")
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://www.google.com/search?q=swift%20c%2B%2B%20%26%20rust"
+        )
+        // Round-tripping matters more than the exact escaping: a literal "+"
+        // decoded back as a space would search for something else.
+        XCTAssertEqual(
+            URLComponents(url: url!, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "q" })?.value,
+            "swift c++ & rust"
+        )
+    }
+
+    func testWebSearchURLRefusesASelectionWithNoQueryInIt() {
+        XCTAssertNil(WebSearchQuery.url(for: "   \n  "))
+        XCTAssertNil(WebSearchQuery.url(for: ""))
+    }
+
+    func testWebSearchURLStaysWithinTheQueryLimit() {
+        let selection = String(repeating: "locus ", count: 400)
+        let url = WebSearchQuery.url(for: selection)
+        let query = URLComponents(url: url!, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "q" })?.value
+        XCTAssertNotNil(query)
+        XCTAssertLessThanOrEqual(query!.count, WebSearchQuery.characterLimit)
+        XCTAssertTrue(query!.hasPrefix("locus locus"))
+    }
+
+    func testWebSearchDestinationDefaultsToTheDefaultBrowser() throws {
+        XCTAssertEqual(AppSettings().resolvedWebSearchDestination, .defaultBrowser)
+
+        // Settings written before this preference existed must decode without
+        // losing the rest of the file.
+        let legacy = Data(#"{"browserEnabled":false}"#.utf8)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: legacy)
+        XCTAssertEqual(decoded.resolvedWebSearchDestination, .defaultBrowser)
+        XCTAssertFalse(decoded.browserEnabled)
+
+        var settings = AppSettings()
+        settings.webSearchDestinationRaw = WebSearchDestination.locusBrowser.rawValue
+        XCTAssertEqual(settings.resolvedWebSearchDestination, .locusBrowser)
+
+        // An unknown destination from a future version falls back rather than
+        // failing the decode.
+        settings.webSearchDestinationRaw = "quantumBrowser"
+        XCTAssertEqual(settings.resolvedWebSearchDestination, .defaultBrowser)
+    }
 }


### PR DESCRIPTION
Highlighting a passage in a conversation and right-clicking it produced macOS's own text menu — twenty items deep, with Look Up, Translate, Writing Tools, Font, Spelling and Speech ahead of the two things anyone actually wants from a transcript.

Right-clicking a highlight now offers **Copy** and **Search in Google**.

## How the selection is reached

SwiftUI never exposes what `.textSelection(.enabled)` has selected. But it draws selectable text as a non-editable `NSTextField`, so highlighting promotes the window's field editor — a real `NSTextView` — to first responder, and the selected substring reads straight off it. No `copy:` down the responder chain, so the user's clipboard is never clobbered just to find out what is highlighted.

A local right-mouse monitor takes the click before AppKit can raise the system menu. Scope is tested by view ancestry rather than `enclosingScrollView`, because a code block's text lives inside its own horizontal scroll view. Editable field editors are untouched — the composer and settings fields keep Cut/Paste.

## Destination

Settings → Browser → "Highlighted text" chooses the system browser (default) or the Locus Browser tab, falling back to the system browser whenever a Browser tab is unavailable (browsing off, or Ask mode).

## Scope

Conversation transcript only: user messages, replies, thinking blocks, code blocks. Widening it later is one `registerScope` call.

## Tradeoff

The two items replace the system menu for transcript selections, so Look Up, Translate, Share and Writing Tools no longer appear there.

## Verification

- `LocusTests`: 487 tests, 0 failures, including 6 new ones covering `+`/`&` encoding round-trips (`URLComponents` would turn `c++` into a space-separated query), multi-line collapsing, word-boundary truncation, and decoding settings files written before this preference existed.
- The shipped `TextSelectionMenu.swift` was compiled into a harness and driven with real right-clicks: transcript prose and code blocks raise `["Copy", "Search in Google"]` and fire with the exact selected text; out-of-scope text and the composer correctly keep their system menus.