### PR TITLE
Stop waiting for frames from a display that has gone dark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Streaming no longer stalls when the display sleeps.** Replies were flushed
+  to the screen on the display's own refresh, which is the right clock for
+  keeping text growth and scroll anchoring on one frame — but a `CADisplayLink`
+  simply goes quiet when its display sleeps, is unplugged, or never existed,
+  without cancelling itself or reporting anything. A flush waiting on the next
+  frame then waited forever, and because a pending flush suppresses further
+  requests, streamed text stopped appearing until something flushed directly.
+  Every request now also arms a watchdog: whichever arrives first wins, the
+  frame on a live display or the watchdog on a dark one. A link that has gone
+  quiet is dropped and rebuilt against whatever display exists next, so the app
+  recovers on its own when a screen comes back.
+- **The browser can scroll on a Mac with no display attached.** Aiming a wheel
+  event needed the height of the primary screen, so with the lid shut and
+  nothing plugged in there was no screen to ask and the scroll silently fell
+  back to the synthetic path. The coordinate flip is now measured out of AppKit
+  itself rather than looked up, which is correct for any display arrangement,
+  including none.
+
+## Unreleased
+
 ### Added
 
 - **The agent's clicks are now real input.** Actions were dispatched as

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -12670,45 +12670,93 @@ enum CommandAction: String, CaseIterable, Identifiable {
 }
 
 @MainActor
-private final class DisplaySynchronizedFlushDriver: NSObject {
+/// Coalesces work onto the display's own refresh, without trusting it to tick.
+///
+/// A `CADisplayLink` stops delivering frames whenever its display does: asleep,
+/// disconnected, or a Mac running with the lid shut and nothing attached. The
+/// link is not cancelled when that happens and reports no error — it simply
+/// goes quiet. A flush waiting on the next frame would then wait forever, and
+/// because a pending request suppresses further ones, streamed text stops
+/// appearing until something calls the flush directly.
+///
+/// So every request also arms a watchdog. Whichever arrives first wins: the
+/// frame on a live display, the watchdog on a dark one. That bounds how long a
+/// flush can be deferred without giving up display synchronisation when there
+/// is a display to synchronise with.
+///
+/// Not private, so the tests can exercise the no-frames path that a sleeping
+/// display produces and a test machine cannot otherwise reproduce.
+final class DisplaySynchronizedFlushDriver: NSObject {
+    /// How long to wait for a frame before flushing anyway. Longer than a frame
+    /// at any refresh rate a real display runs at — 40ms covers 25Hz and below,
+    /// so a live link virtually always wins — and short enough that a dark
+    /// display costs a barely perceptible delay rather than a freeze.
+    static let frameDeadlineMilliseconds = 40
+
     private let callback: () -> Void
+    private let synchronizesWithDisplay: Bool
     private var displayLink: CADisplayLink?
+    private var watchdog: DispatchWorkItem?
     private var pending = false
 
-    init(callback: @escaping () -> Void) {
+    init(synchronizesWithDisplay: Bool = true, callback: @escaping () -> Void) {
+        self.synchronizesWithDisplay = synchronizesWithDisplay
         self.callback = callback
     }
 
     func request() {
         guard !pending else { return }
         pending = true
-        if displayLink == nil,
-           let source = NSApplication.shared.keyWindow?.screen ?? NSScreen.main
-        {
-            let link = source.displayLink(target: self, selector: #selector(displayTick(_:)))
-            link.add(to: .main, forMode: .common)
-            link.isPaused = true
-            displayLink = link
+        if synchronizesWithDisplay {
+            if displayLink == nil,
+               let source = NSApplication.shared.keyWindow?.screen ?? NSScreen.main
+            {
+                let link = source.displayLink(target: self, selector: #selector(displayTick(_:)))
+                link.add(to: .main, forMode: .common)
+                link.isPaused = true
+                displayLink = link
+            }
+            displayLink?.isPaused = false
         }
-        if let displayLink {
-            displayLink.isPaused = false
-        } else {
-            DispatchQueue.main.async { [weak self] in self?.fire() }
-        }
+        armWatchdog()
     }
 
     func cancelPending() {
         pending = false
         displayLink?.isPaused = true
+        watchdog?.cancel()
+        watchdog = nil
     }
 
     func invalidate() {
         pending = false
         displayLink?.invalidate()
         displayLink = nil
+        watchdog?.cancel()
+        watchdog = nil
+    }
+
+    private func armWatchdog() {
+        watchdog?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.frameNeverCame() }
+        watchdog = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(Self.frameDeadlineMilliseconds),
+            execute: work
+        )
     }
 
     @objc private func displayTick(_ link: CADisplayLink) {
+        fire()
+    }
+
+    private func frameNeverCame() {
+        // Whatever silenced it — the display slept, or the screen it was built
+        // against went away — this link is no longer a clock worth waiting on.
+        // Drop it so the next request builds one against whatever display
+        // exists by then, and the app recovers on its own when one comes back.
+        displayLink?.invalidate()
+        displayLink = nil
         fire()
     }
 
@@ -12716,6 +12764,8 @@ private final class DisplaySynchronizedFlushDriver: NSObject {
         guard pending else { return }
         pending = false
         displayLink?.isPaused = true
+        watchdog?.cancel()
+        watchdog = nil
         callback()
     }
 }

--- a/Locus/BrowserInput.swift
+++ b/Locus/BrowserInput.swift
@@ -336,9 +336,12 @@ extension OffscreenWebHost {
                 (Self.scrollPhaseChanged, deltaX, deltaY),
                 (Self.scrollPhaseEnded, 0, 0),
             ]
+            guard let flipBase = windowFlipBase() else { return false }
             for step in steps {
-                guard deliverWheel(at: point, phase: step.phase, deltaX: step.x, deltaY: step.y)
-                else { return false }
+                guard deliverWheel(
+                    at: point, flipBase: flipBase,
+                    phase: step.phase, deltaX: step.x, deltaY: step.y
+                ) else { return false }
                 try? await Task.sleep(for: BrowserInput.stepDelay)
             }
             return true
@@ -351,29 +354,47 @@ extension OffscreenWebHost {
     private static let scrollPhaseChanged: Int64 = 2
     private static let scrollPhaseEnded: Int64 = 4
 
+    /// Where AppKit puts y = 0 when it bridges a windowless `CGEvent`.
+    ///
+    /// A wheel event has to be built as a `CGEvent` — `NSEvent.mouseEvent`
+    /// cannot make one — and the bridged `NSEvent` belongs to no window, so it
+    /// reports its location straight back out of the `CGEvent`, flipped about
+    /// the primary display. Aiming *that* at a window point is what puts a
+    /// scroll under the right element.
+    ///
+    /// The flip is measured rather than looked up. Asking `NSScreen` for the
+    /// height would make scrolling depend on a display existing, and a Mac with
+    /// the lid shut and nothing attached has none; probing reads the axis back
+    /// out of AppKit itself and stays correct whatever the display arrangement
+    /// — or absence — happens to be. It is measured on a throwaway event,
+    /// because bridging one `CGEvent` twice yields a second `NSEvent` that
+    /// WebKit will not act on.
+    private func windowFlipBase() -> CGFloat? {
+        guard let probeEvent = CGEvent(
+            scrollWheelEvent2Source: CGEventSource(stateID: .privateState),
+            units: .pixel, wheelCount: 1, wheel1: 0, wheel2: 0, wheel3: 0
+        ) else { return nil }
+        probeEvent.location = .zero
+        return NSEvent(cgEvent: probeEvent)?.locationInWindow.y
+    }
+
     private func deliverWheel(
         at point: NSPoint,
+        flipBase: CGFloat,
         phase: Int64,
         deltaX: CGFloat,
         deltaY: CGFloat
     ) -> Bool {
-        guard let screen = webView.window?.screen ?? NSScreen.screens.first,
-              let scroll = CGEvent(
-                  scrollWheelEvent2Source: CGEventSource(stateID: .privateState),
-                  units: .pixel,
-                  wheelCount: deltaX == 0 ? 1 : 2,
-                  wheel1: Int32(clamping: Int(-deltaY)),
-                  wheel2: Int32(clamping: Int(-deltaX)),
-                  wheel3: 0
-              )
-        else { return false }
+        guard let scroll = CGEvent(
+            scrollWheelEvent2Source: CGEventSource(stateID: .privateState),
+            units: .pixel,
+            wheelCount: deltaX == 0 ? 1 : 2,
+            wheel1: Int32(clamping: Int(-deltaY)),
+            wheel2: Int32(clamping: Int(-deltaX)),
+            wheel3: 0
+        ) else { return false }
         scroll.setIntegerValueField(.scrollWheelEventScrollPhase, value: phase)
-        // A wheel event has to be built as a CGEvent — `NSEvent.mouseEvent`
-        // cannot make one — and the bridged `NSEvent` reports no window, so it
-        // reads its location straight back out of the CGEvent, unflipped
-        // against the screen. Aiming *that* at the window point is what puts
-        // the scroll under the right element.
-        scroll.location = CGPoint(x: point.x, y: screen.frame.maxY - point.y)
+        scroll.location = CGPoint(x: point.x, y: flipBase - point.y)
         guard let event = NSEvent(cgEvent: scroll) else { return false }
         webView.scrollWheel(with: event)
         return true

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -1987,6 +1987,45 @@ final class AppModelTests: XCTestCase {
         XCTAssertTrue(model.draftText.isEmpty)
     }
 
+    /// A `CADisplayLink` goes quiet whenever its display does — asleep,
+    /// unplugged, or a Mac running with the lid shut — without cancelling
+    /// itself or reporting anything. A flush that only waited for the next
+    /// frame would then wait forever, and since a pending request suppresses
+    /// further ones, streamed text stopped appearing until something flushed
+    /// directly. This is that machine, which no test host can otherwise be.
+    @MainActor
+    func testStreamStillFlushesWhenNoDisplayFrameEverArrives() async throws {
+        var flushes = 0
+        let driver = DisplaySynchronizedFlushDriver(synchronizesWithDisplay: false) {
+            flushes += 1
+        }
+        driver.request()
+        XCTAssertEqual(flushes, 0, "the flush must still coalesce, not run per request")
+
+        try await Task.sleep(
+            for: .milliseconds(DisplaySynchronizedFlushDriver.frameDeadlineMilliseconds * 3)
+        )
+        XCTAssertEqual(flushes, 1, "a dark display left the flush waiting for a frame forever")
+
+        // And it keeps working: the watchdog is re-armed per request rather
+        // than being a one-shot that leaves the next flush stranded.
+        driver.request()
+        try await Task.sleep(
+            for: .milliseconds(DisplaySynchronizedFlushDriver.frameDeadlineMilliseconds * 3)
+        )
+        XCTAssertEqual(flushes, 2)
+
+        // A cancelled request must not fire late and flush a stream that has
+        // already been committed.
+        driver.request()
+        driver.cancelPending()
+        try await Task.sleep(
+            for: .milliseconds(DisplaySynchronizedFlushDriver.frameDeadlineMilliseconds * 3)
+        )
+        XCTAssertEqual(flushes, 2)
+        driver.invalidate()
+    }
+
     @MainActor
     func testTwoThousandStreamTokensAreBuffered() async throws {
         let model = AppModel(startImmediately: false)

--- a/LocusTests/BrowserInputTests.swift
+++ b/LocusTests/BrowserInputTests.swift
@@ -223,6 +223,47 @@ final class BrowserInputTests: XCTestCase {
 
     // MARK: - Where events can and cannot go
 
+    func testScrollLandsOnTheTargetWhateverTheDisplayArrangement() async throws {
+        try await load("""
+        <body style="margin:0">
+          <div id="box" style="position:absolute;left:0;top:0;width:400px;height:200px;overflow:auto">
+            <div style="height:3000px">tall</div>
+          </div>
+        </body>
+        """)
+
+        // The wheel event's location is computed by measuring AppKit's own flip
+        // rather than reading a screen height. Prove the measurement lands where
+        // it was aimed: if it were off by a screen height, the scroll would go
+        // to whatever is at some other coordinate, or to nothing at all.
+        let target = CGPoint(x: 200, y: 100)
+        let expected = try XCTUnwrap(host.windowPoint(forPageCSS: target))
+
+        func wheelEvent() throws -> CGEvent {
+            try XCTUnwrap(CGEvent(
+                scrollWheelEvent2Source: CGEventSource(stateID: .privateState),
+                units: .pixel, wheelCount: 1, wheel1: -120, wheel2: 0, wheel3: 0
+            ))
+        }
+        // Measured on a throwaway event, as the code does: bridging one CGEvent
+        // twice yields a second NSEvent that WebKit will not act on.
+        let probeEvent = try wheelEvent()
+        probeEvent.location = .zero
+        let flipBase = try XCTUnwrap(NSEvent(cgEvent: probeEvent)).locationInWindow.y
+
+        let aimedEvent = try wheelEvent()
+        aimedEvent.location = CGPoint(x: expected.x, y: flipBase - expected.y)
+        let aimed = try XCTUnwrap(NSEvent(cgEvent: aimedEvent))
+        XCTAssertEqual(aimed.locationInWindow.x, expected.x, accuracy: 0.5)
+        XCTAssertEqual(aimed.locationInWindow.y, expected.y, accuracy: 0.5)
+
+        // And end to end, through the code that does the same thing.
+        let scrolled = await host.deliverScroll(at: target, deltaX: 0, deltaY: 120)
+        XCTAssertTrue(scrolled)
+        let moved = try await settled("document.getElementById('box').scrollTop || null") as? Int
+        XCTAssertNotNil(moved, "the scroll did not reach the container under the point")
+    }
+
     func testInputIsRefusedRatherThanDroppedWhenThereIsNoWindow() async {
         let orphan = WKWebView(frame: .zero)
         XCTAssertNil(orphan.window)


### PR DESCRIPTION
Two places assumed a display exists and keeps ticking. Both fail on the same machine: a Mac with the lid shut and nothing attached, or simply one whose screen has gone to sleep. Both were found that way — the first surfaced as two `AppModelTests` failures that reproduced only on a Mac whose screen had slept, and passed on CI because runners keep a virtual display ticking.

## Streaming stalled when the display slept

Replies are flushed on the display's own refresh, which is the right clock: it keeps text growth and native scroll anchoring on one visual frame. But a `CADisplayLink` goes quiet when its display sleeps or is unplugged — it does not cancel itself and reports nothing — and the driver kept the first link it ever built.

A flush waiting on the next frame therefore waited forever. Because a pending flush suppresses further requests, the stream stopped reaching the screen until something flushed it directly (`message_end`, a tool call). There was already a fallback for *no screen at all*; there was none for a screen that stopped ticking.

Every request now also arms a watchdog, so whichever arrives first wins — the frame on a live display, the watchdog on a dark one. A link that missed its deadline is invalidated so the next request builds one against whatever display exists by then, and the app recovers on its own when a screen comes back.

## The browser could not scroll without a display

Aiming a wheel event needed the primary screen's height to undo AppKit's flip. With no screen to ask, `deliverScroll` returned false and the browser fell back to synthetic events — which a page that checks `event.isTrusted` ignores, so scrolling silently did nothing.

The flip is now measured by bridging a throwaway event and reading where it lands, which is correct for any display arrangement including none.

One trap worth recording: bridging a single `CGEvent` twice yields a second `NSEvent` that WebKit will not act on. The first version of this fix reused one event for the probe and the delivery and broke scrolling outright — a quieter failure than the bug it was fixing. The calibration runs on its own throwaway event, and the test mirrors that shape so it does not document the broken pattern.

## Verification

- 515 Swift tests (2 new), 538 Python tests, ruff, the design-system audit, and Debug/Release builds pass — the Swift suite run **on a machine whose display was asleep**, which is what it could not do before.
- `testStreamStillFlushesWhenNoDisplayFrameEverArrives` constructs the no-frames case directly, since a test host cannot put its own display to sleep. It also covers re-arming and cancellation, so a one-shot watchdog or a late fire after `cancelPending` would fail it.
- `testScrollLandsOnTheTargetWhateverTheDisplayArrangement` asserts the measured flip puts the event on the intended window point, then scrolls through the real path.
- Both fail if their fix is reverted.