### PR TITLE
Use coordinate-driven transcript wheel coverage

### DIFF
--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -2356,6 +2356,9 @@ final class LocusUITests: XCTestCase {
         // must move the transcript by the same amount as a gesture over its
         // scrollbar or empty background.
         let messageYBeforeWheel = firstMessage.frame.minY
+        let messageWheelCoordinate = firstMessage.coordinate(
+            withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)
+        )
         var messageMoved = false
         // XCUITest occasionally drops the first synthetic wheel packet on
         // macOS 15. Keep the retries bounded and alternate direction so the
@@ -2366,7 +2369,7 @@ final class LocusUITests: XCTestCase {
                 messageMoved = true
                 break
             }
-            firstMessage.scroll(byDeltaX: 0, deltaY: delta)
+            messageWheelCoordinate.scroll(byDeltaX: 0, deltaY: delta)
             messageMoved = waitUntil(timeout: 1.5) {
                 // A short row can leave the accessibility viewport entirely;
                 // that is conclusive evidence that its owning transcript moved.


### PR DESCRIPTION
## Summary
- synthesize the transcript wheel gesture at the message text’s screen coordinate
- avoid macOS 15’s unreliable element-directed scroll action for non-scrollable accessibility text
- preserve the same assertion that vertical scrolling over selectable message text moves the transcript

## Validation
- focused UI test passed four consecutive local executions
- UI test target build succeeded
- full push and pull-request CI required before merge