### PR TITLE
Wallet P0-P3 security rollout

### DIFF
--- a/Docs/WalletActivation.md
+++ b/Docs/WalletActivation.md
@@ -47,7 +47,13 @@ Native wallet tools may also call a method from a contract added under
 canonical function signature, typed string arguments, and optional native
 value. `WalletSigner.xpc` re-encodes the call from the normalized ABI, checks
 the selector, and requires exact confirmation. Unknown contract effects cannot
-use an autonomous budget.
+use an autonomous budget. A verified ABI can be classified automatically for
+the reviewed ERC-20 transfer/finite-approval adapter or the separate narrow
+Universal Router V2 exact-input adapter. Those calls become policy-eligible
+only after you authorize an exact contract, asset, counterparty, amount, fee,
+and expiry budget in Wallet Settings. Unlimited approvals, extra router
+commands, allow-revert, zero minimum output, native wrapping, and stale swaps
+still require exact confirmation.
 
 ## Lock or turn it off
 
@@ -74,4 +80,7 @@ recoverable only with the 24-word phrase.
   unknown autonomous contract effects are disabled.
 - Saved policy templates contain no authorization and must be approved again
   after each launch.
+- External MetaMask, Phantom, and Slush connector definitions are present, but
+  their live connection buttons remain security gated. Never enter one of
+  those wallets' recovery phrases into Locus.
 - The Mac App Store build intentionally does not contain `WalletSigner.xpc`.

--- a/Docs/WalletSecurityGate.md
+++ b/Docs/WalletSecurityGate.md
@@ -17,7 +17,11 @@ Direct-download builds now ship the private, sandboxed `WalletSigner.xpc`
 service. The service has no network entitlement, seals the 256-bit vault
 entropy with AES-GCM, protects its wrapping key with device-only Keychain user
 presence, and keeps decrypted material, intents, policies, and budgets only in
-its memory. The Mac App Store target does not embed the signer.
+its memory. It validates the signed Locus host before accepting XPC, creates a
+separate signer instance for every connection, requires the active session and
+request source on every privileged message, bounds pending state, and clears
+secrets when that connection ends. The Mac App Store target does not embed the
+signer.
 
 The experimental runtime gate is still off by default. Activation and recovery
 instructions are in [WalletActivation.md](WalletActivation.md).
@@ -41,11 +45,15 @@ Before the signer can satisfy the native protocol, it must:
    public accounts, native EVM Sepolia transactions, signer-owned budgets,
    registered ABI calls with signer-owned calldata and exact confirmation, and
    a session-scoped EIP-1193/EIP-6963 provider for Sepolia native transfers.
-2. **Security gated:** autonomous reviewed ERC-20 and Uniswap effect adapters
-   and their pinned testnet acceptance fixtures.
-3. **Security gated:** EVM mainnet and MetaMask Connect.
-4. **Security gated:** Solana signing and Phantom Connect.
-5. **Security gated:** Sui signing and Slush Wallet Standard.
+2. **Implemented behind experimental gates:** signer-derived ERC-20 semantics
+   and a separate, narrow Universal Router V2 exact-input adapter, each with
+   exact contract, asset, counterparty, fee, cumulative budget, and expiry
+   constraints. Unknown effects and unlimited approvals stay exact-confirmation.
+3. **Foundation implemented, live connection gated:** MetaMask Connect metadata
+   and Sepolia boundary, followed by Phantom Connect on devnet and Slush Wallet
+   Standard on Sui testnet. External wallets retain their keys and confirmation.
+4. **Security gated:** EVM mainnet and live MetaMask connection.
+5. **Security gated:** native Solana/Sui signing and live Phantom/Slush connections.
 
 Each mainnet gate remains off until local-chain integration tests, dependency and SBOM review, secret scanning, threat-model review, and an external security audit have passed.
 
@@ -53,3 +61,7 @@ The current RustSec audit reports no vulnerability advisories. It does report
 two transitive maintenance warnings (`derivative` 2.2.0 and `paste` 1.0.15);
 those crates are captured in the locked SBOM and must be removed or explicitly
 accepted during the dependency review before any mainnet gate can open.
+
+The formal trust boundaries, adapter language, adversarial checks, release
+criteria, and incident procedure are in
+[WalletThreatModel.md](WalletThreatModel.md).

--- a/Docs/WalletThreatModel.md
+++ b/Docs/WalletThreatModel.md
@@ -1,0 +1,119 @@
+# Locus Vault threat model and response plan
+
+Status: experimental, test networks only
+Last reviewed: 2026-08-28
+
+## Security objective
+
+Locus Vault protects a dedicated, limited-fund recovery phrase from the UI,
+browser content, agent runtime, network stack, and unrelated local processes.
+It authorizes only transactions whose network, account, semantic action,
+simulation, fee, nonce, contract identity, decoded effects, request source, and
+session capability have been checked by the native app and the network-isolated
+signer. It is not a general message-signing or raw-transaction API.
+
+## Assets and trust boundaries
+
+| Asset or authority | Owner | Boundary |
+| --- | --- | --- |
+| BIP-39 entropy and derived private keys | `WalletSigner.xpc` only | AES-GCM at rest; device-only Keychain wrapping key with user presence; zeroized in memory on lock or connection loss |
+| Signing-session capability | One accepted XPC connection | Random session ID required on every privileged request; never sent to Python, web content, or a model |
+| Prepared intent and policy budget | The same signer connection | In-memory only; maximum 32 pending intents and 32 active policies; removed on use, expiry, lock, interruption, invalidation, or process exit |
+| RPC endpoint and chain evidence | Native app | HTTPS only; Sepolia chain ID checked; JSON-RPC version, request ID, envelope shape, and response size validated |
+| Browser origin grant | Native app session | Main-frame origin derived from WebKit, never accepted from page payload; revoked on navigation, lock, interruption, update, or exit |
+| Contract classification | Native app and signer | Runtime code hash, normalized ABI digest, exact functions/selectors, and signer-derived adapter identity |
+| Durable activity | Native app preferences | Public metadata only: hash, intent ID, network/account IDs, summary, timestamps, receipt state, and bounded error detail; never raw signed bytes or secrets |
+
+The XPC listener accepts only the signed Locus host identifier and production
+team identifier. Each accepted connection receives a new signer service
+instance, so authorization state cannot be shared with a second client. Debug
+builds permit ad-hoc signing for local development but still require the Locus
+bundle identifier.
+
+## Request-source policy
+
+Agent and browser requests are different capabilities. Their source is included
+in the session-authorized envelope and copied into the immutable prepared
+intent. It must match during preparation, re-simulation, confirmation, and
+execution.
+
+- Agent requests may use an active signer-owned policy when every decoded
+  effect is covered.
+- Browser requests always require exact confirmation. A browser cannot create,
+  inspect, clear, or consume an autonomous policy.
+- Origin access grants expose only the Sepolia address and the supported narrow
+  RPC surface. Raw signing, personal-message signing, chain addition, contract
+  calldata, and mainnet remain unavailable.
+
+## Reviewed effect adapters
+
+Adapter identity is derived from the normalized ABI and exact permitted
+function set; a registry request cannot self-assert a reviewed label. The signer
+revalidates this classification before using it.
+
+1. `native-eth-transfer-v1`: Sepolia native value to one explicit recipient.
+2. `erc20-v1`: `transfer(address,uint256)` and finite
+   `approve(address,uint256)` effects. Unlimited approval is always exact
+   confirmation.
+3. `uniswap-universal-router-v2-exact-in-v1`: exactly one `0x08`
+   `V2_SWAP_EXACT_IN` command through
+   `execute(bytes,bytes[],uint256)`, without allow-revert, Permit2, native
+   wrapping, sub-plans, partial fills, exact-output, or extra commands. The
+   signer requires a nonzero minimum output, two to four path tokens, the vault
+   account as recipient, and a deadline no more than 20 minutes away.
+
+Contract policies additionally bind the registry ID, observed runtime code
+hash, adapter, one input asset, decoded recipient or spender, per-action amount,
+cumulative session amount, fee ceiling, account, network, and expiry. Unknown,
+stale, mismatched, or additional effects fall back to exact confirmation.
+
+## Primary threats and controls
+
+| Threat | Required control and fail-closed behavior |
+| --- | --- |
+| Malicious page forges an origin or reuses a policy | Derive main-frame origin from WebKit; source-bind every intent; browser always exact confirmation |
+| Model or app substitutes fields after review | Execute by opaque intent ID; signer stores canonical fields and rechecks digest, nonce, fee, simulation, code hash, source, and expiry |
+| Unrelated process connects to signer | Validate host code identity before accepting; create per-connection service state |
+| Stale or stolen session capability | Require protocol version and active per-connection session on every privileged request; clear on invalidation |
+| RPC returns a different or ambiguous response | Require HTTPS, Sepolia, JSON-RPC `2.0`, exact numeric ID, exactly one result/error, and a 1 MiB response cap |
+| Caller labels arbitrary code as reviewed | Derive adapter from normalized ABI and exact function set; bind runtime hash and registry ID |
+| Router hides extra commands or weak output bounds | Decode only one exact-input command; reject allow-revert, zero minimum output, extra inputs, invalid payer, bad recipient, or stale deadline |
+| Broadcast succeeds but client loses the response | Consume before signing; record `broadcast_unknown` with locally derived hash; reconcile through transaction receipt without allowing replay |
+| Recovery phrase confusion or import phishing | Never provide in-app import; show phrase only at creation; identify standard paths and warn never to enter an external-wallet phrase |
+| Activity log leaks signing material | Persist public transaction metadata only; cap records and error detail; never persist raw transaction bytes |
+
+## Verification and release gates
+
+Every wallet change must run the Rust signer tests, focused Swift wallet tests,
+Python bridge tests, SBOM generation, dependency advisory review, secret scan,
+binary export audit, and a clean Xcode build. Direct-download verification also
+launches the embedded signer process and checks that a new connection starts
+without an unlocked session.
+
+No gate opens native EVM mainnet, Solana signing, or Sui signing. MetaMask is the
+first external connector target, followed by Phantom and Slush; the current
+code defines their test-network and transport contracts but exposes no live
+connection button. Each connector needs pinned dependencies, callback/session
+tests, origin/account-change tests, denial and disconnect tests, threat-model
+review, and external audit before enablement.
+
+## Incident response
+
+1. Disable wallet discovery and browser injection in the next build; instruct
+   users to lock the vault and stop funding affected test accounts.
+2. Preserve public hashes, versions, timestamps, signer crash reports, RPC
+   error categories, and code-signing information. Never request a recovery
+   phrase, private key, raw Keychain item, or decrypted vault file.
+3. Classify whether exposure affects the host, XPC caller boundary, dependency,
+   adapter decoder, RPC evidence, external connector, or user-confirmation UI.
+4. Reproduce with a dedicated limited-fund vault. Add the failing case as an
+   adversarial boundary test before preparing a fix.
+5. Rotate or revoke affected test accounts and external sessions. If secret
+   confidentiality might have failed, treat the phrase as compromised and move
+   funds with a known-good wallet; deleting local storage is not sufficient.
+6. Ship a signed fix, verify the full gate, document scope and recovery steps,
+   and require a new external review before reopening any affected feature.
+
+Security reports should contain app version, macOS version, exact action,
+network, public transaction hash if any, and sanitized logs. They must not
+contain wallet recovery words or private signing material.

--- a/Locus/Sheets.swift
+++ b/Locus/Sheets.swift
@@ -1278,6 +1278,7 @@ private struct WalletSettingsView: View {
     @State private var deletePresented = false
     @State private var policyPresented = false
     @State private var registryPresented = false
+    @State private var contractPolicyEntry: WalletContractRegistryEntry?
 
     var body: some View {
         ScrollView {
@@ -1299,6 +1300,7 @@ private struct WalletSettingsView: View {
             gateway.configureRPCURL(rpcURL)
             await gateway.refreshStatus()
             await gateway.checkRPCHealth()
+            await gateway.refreshTransactionHistory()
         }
         .onChange(of: rpcURL) { _, value in gateway.configureRPCURL(value) }
         .sheet(isPresented: $recoveryPresented) {
@@ -1309,6 +1311,9 @@ private struct WalletSettingsView: View {
         .sheet(isPresented: $deletePresented) { WalletVaultDeleteSheet(gateway: gateway) }
         .sheet(isPresented: $policyPresented) { WalletNativePolicySheet(gateway: gateway) }
         .sheet(isPresented: $registryPresented) { WalletContractRegistrySheet(gateway: gateway) }
+        .sheet(item: $contractPolicyEntry) { entry in
+            WalletContractPolicySheet(gateway: gateway, entry: entry)
+        }
         .sheet(item: Binding(
             get: { gateway.pendingBrowserOriginGrant },
             set: { value in if value == nil { gateway.denyBrowserOrigin() } }
@@ -1380,6 +1385,9 @@ private struct WalletSettingsView: View {
                             .foregroundStyle(LocusTheme.muted).textSelection(.enabled)
                         Text(account.chain == .evm ? "Sepolia signing available" : "Public account · signing is security gated")
                             .font(.locus(size: 8)).foregroundStyle(LocusTheme.textTertiary)
+                        Text(derivationPath(for: account.chain))
+                            .font(.system(size: 8, design: .monospaced))
+                            .foregroundStyle(LocusTheme.textTertiary)
                     }
                 }
             }
@@ -1415,7 +1423,7 @@ private struct WalletSettingsView: View {
             }
             Label("Native ETH transfer adapter active", systemImage: "checkmark.shield.fill")
                 .font(.locus(size: 9)).foregroundStyle(LocusTheme.success)
-            Label("Registered ABI calls use signer-produced calldata and exact confirmation. Autonomous ERC-20 and Uniswap adapters remain locked until separately reviewed.", systemImage: "checkmark.shield.fill")
+            Label("ERC-20 transfer/approval and one-command Universal Router exact-input calls receive reviewed semantics only when their verified ABI matches exactly.", systemImage: "checkmark.shield.fill")
                 .font(.locus(size: 9)).foregroundStyle(LocusTheme.muted)
             Text(gateway.activePolicies.isEmpty
                  ? "No active budgets. Every Sepolia transfer requires exact confirmation."
@@ -1424,7 +1432,7 @@ private struct WalletSettingsView: View {
             ForEach(gateway.activePolicyStatuses) { status in
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Native ETH → \(status.policy.allowedRecipients.sorted().joined(separator: ", "))")
+                        Text("\(policyLabel(status.policy)) → \(status.policy.allowedRecipients.sorted().joined(separator: ", "))")
                             .font(.locus(size: 9, weight: .semibold)).lineLimit(1)
                         Text("Used \(status.spentBaseUnits) / \(status.policy.maximumSessionBaseUnits) wei · expires \(status.policy.expiresAt.formatted(date: .omitted, time: .shortened))")
                             .font(.locus(size: 8)).foregroundStyle(LocusTheme.muted)
@@ -1458,8 +1466,16 @@ private struct WalletSettingsView: View {
                         Text(entry.checksumAddress).font(.system(size: 8, design: .monospaced))
                         Text("\(entry.permittedFunctions.count) approved method(s) · code \(entry.runtimeCodeHash.prefix(12))…")
                             .font(.locus(size: 8)).foregroundStyle(LocusTheme.muted)
+                        if let adapterID = entry.reviewedAdapterID {
+                            Label(adapterLabel(adapterID), systemImage: "checkmark.shield.fill")
+                                .font(.locus(size: 8)).foregroundStyle(LocusTheme.success)
+                        }
                     }
                     Spacer()
+                    if entry.reviewedAdapterID != nil {
+                        Button("New budget") { contractPolicyEntry = entry }
+                            .font(.locus(size: 8)).disabled(gateway.status != .unlocked)
+                    }
                     Button("Remove", role: .destructive) {
                         Task { await gateway.removeContractRegistryEntry(id: entry.id) }
                     }.font(.locus(size: 8))
@@ -1471,13 +1487,30 @@ private struct WalletSettingsView: View {
 
     private var historyCard: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Transaction history").font(.locus(size: 12, weight: .semibold))
-            ForEach(Array(gateway.transactionHistory.enumerated()), id: \.offset) { _, item in
+            HStack {
+                Text("Transaction activity").font(.locus(size: 12, weight: .semibold))
+                Spacer()
+                Button("Refresh") { Task { await gateway.refreshTransactionHistory() } }
+                    .font(.locus(size: 8))
+            }
+            ForEach(gateway.transactionHistory) { item in
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(item["summary"] ?? "Sepolia transaction").font(.locus(size: 9, weight: .semibold))
-                    Text(item["hash"] ?? "").font(.system(size: 8, design: .monospaced))
+                    Text(item.summary).font(.locus(size: 9, weight: .semibold))
+                    Text(item.transactionHash).font(.system(size: 8, design: .monospaced))
                         .foregroundStyle(LocusTheme.muted).textSelection(.enabled)
-                    Text(item["status"] ?? "submitted").font(.locus(size: 8)).foregroundStyle(LocusTheme.success)
+                    HStack(spacing: 6) {
+                        Text(activityLabel(item.state)).font(.locus(size: 8, weight: .semibold))
+                            .foregroundStyle(activityColor(item.state))
+                        Text(item.submittedAt.formatted(date: .abbreviated, time: .shortened))
+                            .font(.locus(size: 8)).foregroundStyle(LocusTheme.textTertiary)
+                        if let block = item.blockNumber {
+                            Text("block \(block)").font(.system(size: 8, design: .monospaced))
+                                .foregroundStyle(LocusTheme.textTertiary)
+                        }
+                    }
+                    if let detail = item.detail {
+                        Text(detail).font(.locus(size: 8)).foregroundStyle(LocusTheme.warning)
+                    }
                 }
             }
         }
@@ -1487,10 +1520,10 @@ private struct WalletSettingsView: View {
     private var externalWalletsCard: some View {
         VStack(alignment: .leading, spacing: 9) {
             Text("External approval wallets").font(.locus(size: 12, weight: .semibold))
-            connector("MetaMask", detail: "EVM approval through MetaMask Connect.", destination: "https://docs.metamask.io/metamask-connect/")
-            connector("Phantom", detail: "User-approved Solana sessions through Phantom Connect.", destination: "https://docs.phantom.com/sdks/browser-sdk/index")
-            connector("Slush", detail: "Sui Wallet Standard and web-wallet approval.", destination: "https://my.slush.app/")
-            Text("External wallets always retain their own keys and confirmation experience.")
+            ForEach(WalletExternalConnectorCatalog.connectors) { descriptor in
+                connector(descriptor)
+            }
+            Text("Connector contracts and test-network boundaries are defined. Connection buttons remain closed until each transport dependency and callback path passes its security audit. External wallets always retain their own keys and confirmation experience.")
                 .font(.locus(size: 8)).foregroundStyle(LocusTheme.muted)
         }
         .padding(14).locusCard(radius: 10)
@@ -1502,8 +1535,9 @@ private struct WalletSettingsView: View {
             rollout("1", "Native ETH on Sepolia", ready: true)
             rollout("2", "Registered ABI calls with exact confirmation", ready: true)
             rollout("3", "Session-scoped Sepolia browser provider", ready: gateway.browserProviderEnabled)
-            rollout("4", "EVM mainnet + MetaMask", ready: false)
-            rollout("5", "Solana/Phantom and Sui/Slush", ready: false)
+            rollout("4", "Reviewed ERC-20 and narrow Uniswap budgets", ready: true)
+            rollout("5", "External wallet connector foundations", ready: true)
+            rollout("6", "Mainnet, Solana, and Sui signing", ready: false)
             if gateway.isExperimentalEnabled && !gateway.browserProviderEnabled {
                 Text("Browser access has a separate experimental activation gate. Registered contract calls remain exact-confirmation-only until their effect adapters are reviewed.")
                     .font(.locus(size: 8)).foregroundStyle(LocusTheme.textTertiary)
@@ -1524,14 +1558,57 @@ private struct WalletSettingsView: View {
         .padding(14).locusCard(radius: 10)
     }
 
-    private func connector(_ name: String, detail: String, destination: String) -> some View {
+    private func connector(_ descriptor: WalletExternalConnectorDescriptor) -> some View {
         HStack(spacing: 10) {
             VStack(alignment: .leading, spacing: 2) {
-                Text(name).font(.locus(size: 10, weight: .semibold))
-                Text(detail).font(.locus(size: 9)).foregroundStyle(LocusTheme.muted)
+                Text(descriptor.name).font(.locus(size: 10, weight: .semibold))
+                Text(descriptor.transport).font(.locus(size: 9)).foregroundStyle(LocusTheme.muted)
+                Text("Foundation ready · external signing security gated")
+                    .font(.locus(size: 8, weight: .semibold)).foregroundStyle(LocusTheme.warning)
             }
             Spacer()
-            if let url = URL(string: destination) { Link("Setup guide", destination: url).font(.locus(size: 9)) }
+            Link("Setup guide", destination: descriptor.documentationURL).font(.locus(size: 9))
+        }
+    }
+
+    private func derivationPath(for chain: WalletChain) -> String {
+        switch chain {
+        case .evm: "Recovery path m/44'/60'/0'/0/0"
+        case .solana: "Recovery path m/44'/501'/0'/0'"
+        case .sui: "Recovery path m/44'/784'/0'/0'/0'"
+        }
+    }
+
+    private func policyLabel(_ policy: WalletSessionPolicy) -> String {
+        guard let adapterID = policy.allowedAdapterIDs.first else { return "Wallet budget" }
+        return adapterLabel(adapterID)
+    }
+
+    private func adapterLabel(_ adapterID: String) -> String {
+        switch adapterID {
+        case "native-eth-transfer-v1": "Native ETH"
+        case WalletReviewedAdapters.erc20: "ERC-20"
+        case WalletReviewedAdapters.uniswapUniversalRouterV2ExactIn:
+            "Uniswap exact input"
+        default: "Reviewed adapter"
+        }
+    }
+
+    private func activityLabel(_ state: WalletActivityState) -> String {
+        switch state {
+        case .submitted: "Pending"
+        case .confirmed: "Confirmed"
+        case .failed: "Failed"
+        case .broadcastUnknown: "Broadcast uncertain"
+        }
+    }
+
+    private func activityColor(_ state: WalletActivityState) -> Color {
+        switch state {
+        case .confirmed: LocusTheme.success
+        case .submitted: LocusTheme.warning
+        case .failed: LocusTheme.coral
+        case .broadcastUnknown: LocusTheme.warning
         }
     }
 
@@ -1658,6 +1735,119 @@ private struct WalletNativePolicySheet: View {
     }
 }
 
+private struct WalletContractPolicySheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var gateway: WalletGateway
+    let entry: WalletContractRegistryEntry
+    @State private var counterparty = ""
+    @State private var inputToken = ""
+    @State private var perTransaction = ""
+    @State private var sessionCap = ""
+    @State private var feeCap = ""
+    @State private var durationMinutes = "30"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 13) {
+            Text("Authorize a reviewed contract budget")
+                .font(.locus(size: 16, weight: .bold))
+            Text("\(entry.label) · \(adapterName)")
+                .font(.locus(size: 10, weight: .semibold))
+            Text(entry.checksumAddress).font(.system(size: 9, design: .monospaced))
+                .foregroundStyle(LocusTheme.muted).textSelection(.enabled)
+            Text("This authorization is bound to this registry ID, runtime code hash, adapter, token asset, counterparty, fee ceiling, and signer session.")
+                .font(.locus(size: 9)).foregroundStyle(LocusTheme.muted)
+            if entry.reviewedAdapterID == WalletReviewedAdapters.uniswapUniversalRouterV2ExactIn {
+                field("Input token address", placeholder: "0x…", text: $inputToken)
+            }
+            field(counterpartyTitle, placeholder: "0x…", text: $counterparty)
+            field("Maximum per action (token base units)", placeholder: "1000000", text: $perTransaction)
+            field("Total session budget (token base units)", placeholder: "5000000", text: $sessionCap)
+            field("Maximum fee per action (wei)", placeholder: "2000000000000000", text: $feeCap)
+            field("Expires after (minutes, max 480)", placeholder: "30", text: $durationMinutes)
+            Label(adapterWarning, systemImage: "shield.lefthalf.filled")
+                .font(.locus(size: 9)).foregroundStyle(LocusTheme.warning)
+            HStack {
+                Button("Cancel") { dismiss() }
+                Spacer()
+                Button("Authorize budget") { activate() }.buttonStyle(.borderedProminent)
+                    .disabled(!valid)
+            }
+            if let error = gateway.lastError {
+                Text(error).font(.locus(size: 9)).foregroundStyle(LocusTheme.coral)
+            }
+        }
+        .padding(22).frame(width: 520)
+    }
+
+    private var adapterName: String {
+        switch entry.reviewedAdapterID {
+        case WalletReviewedAdapters.erc20: "ERC-20 transfer / finite approval"
+        case WalletReviewedAdapters.uniswapUniversalRouterV2ExactIn:
+            "Universal Router V2 exact-input"
+        default: "Exact confirmation only"
+        }
+    }
+
+    private var counterpartyTitle: String {
+        entry.reviewedAdapterID == WalletReviewedAdapters.erc20
+            ? "Approved recipient or spender" : "Approved swap recipient"
+    }
+
+    private var adapterWarning: String {
+        if entry.reviewedAdapterID == WalletReviewedAdapters.erc20 {
+            return "Unlimited approvals and any unrecognized side effect still require exact confirmation."
+        }
+        return "Only one V2 exact-input command, a nonzero minimum output, the current account as recipient, and a 20-minute deadline are eligible."
+    }
+
+    private var assetAddress: String {
+        entry.reviewedAdapterID == WalletReviewedAdapters.erc20
+            ? entry.checksumAddress : inputToken
+    }
+
+    private var valid: Bool {
+        guard entry.reviewedAdapterID != nil,
+              isAddress(counterparty), isAddress(assetAddress),
+              WalletBaseUnits.normalize(perTransaction) != nil,
+              WalletBaseUnits.normalize(sessionCap) != nil,
+              WalletBaseUnits.normalize(feeCap) != nil,
+              let minutes = Int(durationMinutes), (1...480).contains(minutes),
+              gateway.accounts.contains(where: { $0.chain == .evm }) else { return false }
+        return WalletBaseUnits.lessThanOrEqual(perTransaction, sessionCap)
+    }
+
+    private func field(_ title: String, placeholder: String, text: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title).font(.locus(size: 9, weight: .semibold))
+            TextField(placeholder, text: text).textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private func isAddress(_ value: String) -> Bool {
+        value.count == 42 && value.hasPrefix("0x")
+            && value.dropFirst(2).allSatisfy(\.isHexDigit)
+    }
+
+    private func activate() {
+        guard let account = gateway.accounts.first(where: { $0.chain == .evm }),
+              let adapterID = entry.reviewedAdapterID,
+              let minutes = Int(durationMinutes) else { return }
+        let policy = WalletSessionPolicy(
+            id: UUID().uuidString.lowercased(), accountID: account.id,
+            networkID: WalletGateway.sepoliaNetworkID,
+            allowedAssetIDs: [
+                "eip155:11155111/erc20:\(assetAddress.lowercased())"
+            ],
+            allowedRecipients: [counterparty], allowedContractIDs: [entry.id],
+            allowedAdapterIDs: [adapterID],
+            maximumTransactionBaseUnits: perTransaction,
+            maximumSessionBaseUnits: sessionCap, maximumFeeBaseUnits: feeCap,
+            expiresAt: Date().addingTimeInterval(TimeInterval(minutes * 60))
+        )
+        Task { if await gateway.activatePolicy(policy) { dismiss() } }
+    }
+}
+
 private struct WalletContractRegistrySheet: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject var gateway: WalletGateway
@@ -1718,6 +1908,11 @@ private struct WalletVaultBackupSheet: View {
                  ? "Enter the six requested words. Paste and clipboard actions are disabled."
                  : "This is the only time Locus shows the phrase. Keep it offline and private.")
                 .font(.locus(size: 10)).foregroundStyle(LocusTheme.muted)
+            if !confirming {
+                Text("This phrase belongs only to Locus Vault. Never enter a MetaMask, Phantom, Slush, or other wallet phrase here. Standard recovery paths: EVM m/44'/60'/0'/0/0 · Solana m/44'/501'/0'/0' · Sui m/44'/784'/0'/0'/0'.")
+                    .font(.locus(size: 9)).foregroundStyle(LocusTheme.warning)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             if confirming {
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
                     ForEach(creation.verificationIndices, id: \.self) { index in
@@ -1831,6 +2026,10 @@ private struct WalletTransactionConfirmationSheet: View {
             } else {
                 row("Method", "Native ETH transfer")
                 row("Recipient", transaction.action.recipient ?? "Unknown")
+                if let amount = transaction.action.amountBaseUnits,
+                   let formatted = WalletAmountFormatter.ether(wei: amount) {
+                    row("Amount", "\(formatted) · \(amount) wei")
+                }
             }
             row("Effects", transaction.effects.map {
                 let destination = $0.spender.map { "spender \($0)" } ?? ($0.to ?? "unknown")

--- a/Locus/WalletGateway.swift
+++ b/Locus/WalletGateway.swift
@@ -1,5 +1,63 @@
 import Foundation
 
+enum WalletExternalConnectorKind: String, Codable, CaseIterable, Sendable {
+    case metamask
+    case phantom
+    case slush
+}
+
+enum WalletExternalConnectorState: String, Codable, Sendable {
+    case foundationReady = "foundation_ready"
+    case enabledAfterAudit = "enabled_after_audit"
+}
+
+struct WalletExternalConnectorDescriptor: Identifiable, Equatable, Sendable {
+    var id: String { kind.rawValue }
+    let kind: WalletExternalConnectorKind
+    let name: String
+    let supportedTestNetworks: Set<String>
+    let transport: String
+    let documentationURL: URL
+    let state: WalletExternalConnectorState
+}
+
+/// Non-secret connector metadata and rollout order. The connector foundations
+/// deliberately expose no generic signing primitive and do not enable native
+/// mainnet, Solana, or Sui signing.
+enum WalletExternalConnectorCatalog {
+    static let connectors: [WalletExternalConnectorDescriptor] = [
+        WalletExternalConnectorDescriptor(
+            kind: .metamask, name: "MetaMask",
+            supportedTestNetworks: ["eip155:11155111"],
+            transport: "MetaMask Connect · wallet-owned confirmation",
+            documentationURL: URL(string: "https://docs.metamask.io/")!,
+            state: .foundationReady
+        ),
+        WalletExternalConnectorDescriptor(
+            kind: .phantom, name: "Phantom",
+            supportedTestNetworks: ["solana:devnet"],
+            transport: "Phantom Connect · encrypted session · signTransaction",
+            documentationURL: URL(
+                string: "https://docs.phantom.com/phantom-deeplinks/provider-methods/signtransaction"
+            )!,
+            state: .foundationReady
+        ),
+        WalletExternalConnectorDescriptor(
+            kind: .slush, name: "Slush",
+            supportedTestNetworks: ["sui:testnet"],
+            transport: "Sui Wallet Standard · wallet-owned confirmation",
+            documentationURL: URL(string: "https://docs.sui.io/standards/wallet-standard")!,
+            state: .foundationReady
+        ),
+    ]
+
+    static let nativeSigningNetworks: Set<String> = ["eip155:11155111"]
+
+    static func canUseNativeSigner(on networkID: String) -> Bool {
+        nativeSigningNetworks.contains(networkID)
+    }
+}
+
 struct WalletPolicyTemplate: Codable, Equatable, Identifiable, Sendable {
     let id: String
     let name: String
@@ -29,6 +87,40 @@ struct WalletBrowserOriginGrant: Identifiable, Equatable, Sendable {
     let origin: String
 }
 
+enum WalletActivityState: String, Codable, Equatable, Sendable {
+    case submitted
+    case confirmed
+    case failed
+    case broadcastUnknown = "broadcast_unknown"
+}
+
+struct WalletActivityRecord: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let intentID: String
+    let transactionHash: String
+    let networkID: String
+    let accountID: String
+    let summary: String
+    let submittedAt: Date
+    var state: WalletActivityState
+    var blockNumber: String?
+    var lastCheckedAt: Date?
+    var detail: String?
+}
+
+enum WalletAmountFormatter {
+    static func ether(wei: String) -> String? {
+        guard let normalized = WalletBaseUnits.normalize(wei) else { return nil }
+        let padded = String(repeating: "0", count: max(0, 19 - normalized.count)) + normalized
+        let split = padded.index(padded.endIndex, offsetBy: -18)
+        let whole = String(padded[..<split])
+        let fraction = String(padded[split...]).replacingOccurrences(
+            of: "0+$", with: "", options: .regularExpression
+        )
+        return fraction.isEmpty ? "\(whole) ETH" : "\(whole).\(fraction) ETH"
+    }
+}
+
 enum WalletPolicyDecision: Equatable, Sendable {
     case automatic
     case requiresApproval(String)
@@ -39,7 +131,8 @@ enum WalletPolicyDecision: Equatable, Sendable {
 /// must not round through Decimal, Double, locale formatting, or token decimals.
 enum WalletBaseUnits {
     static func normalize(_ value: String) -> String? {
-        guard !value.isEmpty, value.allSatisfy(\.isNumber) else { return nil }
+        guard !value.isEmpty,
+              value.utf8.allSatisfy({ (48...57).contains($0) }) else { return nil }
         let trimmed = value.drop(while: { $0 == "0" })
         return trimmed.isEmpty ? "0" : String(trimmed)
     }
@@ -102,6 +195,9 @@ enum WalletPolicyEngine {
     ) -> WalletPolicyDecision {
         guard transaction.expiresAt > now else { return .denied("The prepared transaction has expired.") }
         guard transaction.simulationSucceeded else { return .denied("The transaction simulation failed.") }
+        guard transaction.source.kind == .agent else {
+            return .requiresApproval("Browser transactions require an exact confirmation.")
+        }
         if transaction.riskFlags.contains(.codeHashMismatch) {
             return .denied("The observed contract code no longer matches the approved registry entry.")
         }
@@ -126,9 +222,37 @@ enum WalletPolicyEngine {
               policy.allowedAssetIDs.contains(transaction.budgetAssetID) else {
             return .requiresApproval("The asset or effect adapter is outside the active policy.")
         }
-        if let recipient = transaction.action.recipient,
-           !policy.allowedRecipients.contains(recipient) {
-            return .requiresApproval("The recipient is outside the active policy.")
+        let counterparties: [String]
+        switch adapterID {
+        case "native-eth-transfer-v1":
+            counterparties = transaction.action.recipient.map { [$0] } ?? []
+        case WalletReviewedAdapters.erc20:
+            counterparties = transaction.effects.compactMap { effect in
+                if effect.kind == "token_transfer" { return effect.to }
+                if effect.kind == "approval" || effect.kind == "approval_revoke" {
+                    return effect.spender
+                }
+                return nil
+            }
+        case WalletReviewedAdapters.uniswapUniversalRouterV2ExactIn:
+            counterparties = transaction.effects.filter {
+                $0.kind == "minimum_receive"
+            }.compactMap(\.to)
+            guard transaction.action.arguments.count == 3,
+                  let deadline = UInt64(transaction.action.arguments[2].value),
+                  deadline >= UInt64(max(0, now.timeIntervalSince1970.rounded(.down))) else {
+                return .requiresApproval("The swap quote is stale.")
+            }
+        default:
+            counterparties = []
+        }
+        guard !counterparties.isEmpty,
+              counterparties.allSatisfy({ counterparty in
+                  policy.allowedRecipients.contains(where: {
+                      $0.caseInsensitiveCompare(counterparty) == .orderedSame
+                  })
+              }) else {
+            return .requiresApproval("A transaction counterparty is outside the active policy.")
         }
         if let contractID = transaction.action.contractID,
            !policy.allowedContractIDs.contains(contractID) {
@@ -244,6 +368,7 @@ final class WalletGateway: ObservableObject {
         case intentNotFound
         case policyDenied(String)
         case approvalRequired(String)
+        case broadcastUnknown(transactionHash: String, message: String)
 
         var errorDescription: String? {
             switch self {
@@ -253,12 +378,15 @@ final class WalletGateway: ObservableObject {
             case .intentNotFound: "The prepared transaction is missing or expired. Prepare it again."
             case .policyDenied(let message): message
             case .approvalRequired(let message): message
+            case .broadcastUnknown(let transactionHash, let message):
+                "The signed transaction \(transactionHash) may not have reached Sepolia: \(message)"
             }
         }
     }
 
     static let protocolVersion = 1
     static let sepoliaNetworkID = "eip155:11155111"
+    private static let maximumPreparedIntents = 32
     static let allowedOperations = [
         "wallet_list_accounts", "wallet_get_balance", "wallet_get_activity",
         "wallet_prepare_transaction", "wallet_simulate_transaction",
@@ -273,19 +401,21 @@ final class WalletGateway: ObservableObject {
     @Published private(set) var vaultCreation: WalletVaultCreation?
     @Published private(set) var rpcHealthText = "Not checked"
     @Published private(set) var lastError: String?
-    @Published private(set) var transactionHistory: [[String: String]] = []
+    @Published private(set) var transactionHistory: [WalletActivityRecord] = []
     @Published private(set) var activePolicyStatuses: [WalletActivePolicyStatus] = []
     @Published private(set) var contractRegistry: [WalletContractRegistryEntry] = []
     @Published private(set) var savedPolicyTemplates: [WalletPolicyTemplate] = []
     @Published private(set) var pendingBrowserOriginGrant: WalletBrowserOriginGrant?
 
     private let signer: WalletSignerClient
+    private let userDefaults: UserDefaults
     private let experimentalEnabled: Bool
     let browserProviderEnabled: Bool
     private var prepared: [String: WalletPreparedTransaction] = [:]
     private var confirmedIntentIDs: Set<String> = []
     private let registryDefaultsKey = "LocusWalletContractRegistryV1"
     private let policyTemplatesDefaultsKey = "LocusWalletPolicyTemplatesV1"
+    private let activityDefaultsKey = "LocusWalletActivityV1"
     private var browserOriginGrants: Set<String> = []
     private var browserIntentOrigins: [String: String] = [:]
     private var browserGrantContinuation: CheckedContinuation<Bool, Never>?
@@ -294,22 +424,51 @@ final class WalletGateway: ObservableObject {
     var onBrowserGrantsRevoked: ((String?) -> Void)?
 
     init(signer: WalletSignerClient? = nil,
-         environment: [String: String] = ProcessInfo.processInfo.environment) {
+         environment: [String: String] = ProcessInfo.processInfo.environment,
+         userDefaults: UserDefaults = .standard) {
         let signer = signer ?? WalletSignerClientFactory.make()
         self.signer = signer
+        self.userDefaults = userDefaults
         experimentalEnabled = environment["LOCUS_ENABLE_EXPERIMENTAL_WALLET"] == "1"
         browserProviderEnabled = experimentalEnabled
             && environment["LOCUS_ENABLE_EXPERIMENTAL_WALLET_BROWSER"] == "1"
         status = signer.isAvailable ? .locked : .securityReviewRequired
-        if let data = UserDefaults.standard.data(forKey: registryDefaultsKey),
+        if let data = userDefaults.data(forKey: registryDefaultsKey),
            let registry = try? JSONDecoder().decode([WalletContractRegistryEntry].self, from: data) {
-            contractRegistry = registry
+            contractRegistry = registry.map(Self.sanitizedRegistryEntry)
+            if contractRegistry != registry,
+               let upgraded = try? JSONEncoder().encode(contractRegistry) {
+                userDefaults.set(upgraded, forKey: registryDefaultsKey)
+            }
         }
-        if let data = UserDefaults.standard.data(forKey: policyTemplatesDefaultsKey),
+        if let data = userDefaults.data(forKey: policyTemplatesDefaultsKey),
            let templates = try? JSONDecoder().decode([WalletPolicyTemplate].self, from: data) {
             savedPolicyTemplates = templates
         }
+        if let data = userDefaults.data(forKey: activityDefaultsKey),
+           let activity = try? JSONDecoder().decode([WalletActivityRecord].self, from: data) {
+            transactionHistory = Array(activity.prefix(250))
+        }
         signer.invalidationHandler = { [weak self] in self?.handleSignerInvalidation() }
+    }
+
+    private static func sanitizedRegistryEntry(
+        _ entry: WalletContractRegistryEntry
+    ) -> WalletContractRegistryEntry {
+        let reviewedAdapterID = WalletReviewedAdapters.classify(
+            normalizedABI: entry.normalizedABI,
+            permittedFunctions: entry.permittedFunctions
+        )
+        guard entry.reviewedAdapterID != reviewedAdapterID else { return entry }
+        return WalletContractRegistryEntry(
+            id: entry.id, networkID: entry.networkID,
+            checksumAddress: entry.checksumAddress, label: entry.label,
+            normalizedABI: entry.normalizedABI, abiDigest: entry.abiDigest,
+            runtimeCodeHash: entry.runtimeCodeHash,
+            permittedFunctions: entry.permittedFunctions,
+            permittedSelectors: entry.permittedSelectors,
+            reviewedAdapterID: reviewedAdapterID, verifiedAt: entry.verifiedAt
+        )
     }
 
     var agentToolingAvailable: Bool {
@@ -419,6 +578,47 @@ final class WalletGateway: ObservableObject {
         catch { rpcHealthText = error.localizedDescription }
     }
 
+    func refreshTransactionHistory() async {
+        guard signer.isAvailable else { return }
+        var changed = false
+        let recordIDs = transactionHistory.filter {
+            $0.state == .submitted || $0.state == .broadcastUnknown
+        }.map(\.id)
+        for recordID in recordIDs {
+            guard let original = transactionHistory.first(where: { $0.id == recordID }) else {
+                continue
+            }
+            do {
+                let result = try await signer.browserRPC(
+                    method: "eth_getTransactionReceipt",
+                    params: [original.transactionHash]
+                )
+                guard let index = transactionHistory.firstIndex(where: { $0.id == recordID }) else {
+                    continue
+                }
+                transactionHistory[index].lastCheckedAt = Date()
+                if result is NSNull {
+                    changed = true
+                    continue
+                }
+                guard let receipt = result as? [String: Any],
+                      let status = receipt["status"] as? String else { continue }
+                transactionHistory[index].state = status.lowercased() == "0x1" ? .confirmed : .failed
+                transactionHistory[index].blockNumber = receipt["blockNumber"] as? String
+                transactionHistory[index].detail = nil
+                changed = true
+            } catch {
+                guard let index = transactionHistory.firstIndex(where: { $0.id == recordID }) else {
+                    continue
+                }
+                transactionHistory[index].lastCheckedAt = Date()
+                transactionHistory[index].detail = String(error.localizedDescription.prefix(512))
+                changed = true
+            }
+        }
+        if changed { persistActivity() }
+    }
+
     var statusText: String {
         if signer.isAvailable && !experimentalEnabled { return "Experimental feature is off" }
         if vaultState == .missing { return "Not created" }
@@ -525,7 +725,7 @@ final class WalletGateway: ObservableObject {
 
     private func persistPolicyTemplates() {
         if let data = try? JSONEncoder().encode(savedPolicyTemplates) {
-            UserDefaults.standard.set(data, forKey: policyTemplatesDefaultsKey)
+            userDefaults.set(data, forKey: policyTemplatesDefaultsKey)
         }
     }
 
@@ -538,7 +738,7 @@ final class WalletGateway: ObservableObject {
             contractRegistry.append(entry)
             contractRegistry.sort { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
             if let data = try? JSONEncoder().encode(contractRegistry) {
-                UserDefaults.standard.set(data, forKey: registryDefaultsKey)
+                userDefaults.set(data, forKey: registryDefaultsKey)
             }
             if changed { await clearPolicies() }
             lastError = nil
@@ -552,7 +752,7 @@ final class WalletGateway: ObservableObject {
     func removeContractRegistryEntry(id: String) async {
         contractRegistry.removeAll { $0.id == id }
         if let data = try? JSONEncoder().encode(contractRegistry) {
-            UserDefaults.standard.set(data, forKey: registryDefaultsKey)
+            userDefaults.set(data, forKey: registryDefaultsKey)
         }
         await clearPolicies()
     }
@@ -636,6 +836,7 @@ final class WalletGateway: ObservableObject {
                 "The experimental browser provider accepts Sepolia native transfers only; contract calldata and signing methods are disabled."
             )
         }
+        let browserSource = WalletRequestSource.browser(origin: normalizedOrigin)
         let preparedResult = await perform(tool: "wallet_prepare_transaction", arguments: [
             "network_id": Self.sepoliaNetworkID,
             "account_id": accounts.first(where: { $0.chain == .evm })?.id ?? "",
@@ -646,7 +847,7 @@ final class WalletGateway: ObservableObject {
             // Testnet-only ceiling. The exact native sheet still displays and
             // approves the authoritative simulated fee before execution.
             "maximum_fee_base_units": "10000000000000000",
-        ])
+        ], source: browserSource)
         if let message = preparedResult["error"] as? String { throw Error.policyDenied(message) }
         guard let intentID = preparedResult["intent_id"] as? String else {
             throw Error.invalidArguments("The wallet did not return a transaction intent.")
@@ -663,7 +864,11 @@ final class WalletGateway: ObservableObject {
             cancelConfirmation(intentID: intentID)
             throw Error.approvalRequired("The website grant was revoked before signing.")
         }
-        let result = await perform(tool: "wallet_execute_transaction", arguments: ["intent_id": intentID])
+        let result = await perform(
+            tool: "wallet_execute_transaction",
+            arguments: ["intent_id": intentID],
+            source: browserSource
+        )
         if let message = result["error"] as? String { throw Error.policyDenied(message) }
         guard let hash = result["transaction_hash"] as? String else {
             throw Error.invalidArguments("The Sepolia RPC did not return a transaction hash.")
@@ -716,7 +921,11 @@ final class WalletGateway: ObservableObject {
         return "\(scheme)://\(host)\(port)"
     }
 
-    func perform(tool: String, arguments: [String: Any]) async -> [String: Any] {
+    func perform(
+        tool: String,
+        arguments: [String: Any],
+        source: WalletRequestSource = .agent
+    ) async -> [String: Any] {
         do {
             if tool == "wallet_lock" {
                 lock()
@@ -734,9 +943,9 @@ final class WalletGateway: ObservableObject {
                 return ["text": text, "accounts": try dictionary(accounts)]
             case "wallet_get_balance", "wallet_get_activity":
                 return try await signer.performRead(tool: tool, arguments: arguments)
-            case "wallet_simulate_transaction": return try await simulate(arguments)
-            case "wallet_prepare_transaction": return response(for: try await prepare(arguments))
-            case "wallet_execute_transaction": return try await execute(arguments)
+            case "wallet_simulate_transaction": return try await simulate(arguments, source: source)
+            case "wallet_prepare_transaction": return response(for: try await prepare(arguments, source: source))
+            case "wallet_execute_transaction": return try await execute(arguments, source: source)
             default: throw Error.invalidArguments("Unknown wallet tool \(tool).")
             }
         } catch {
@@ -744,8 +953,20 @@ final class WalletGateway: ObservableObject {
         }
     }
 
-    private func prepare(_ arguments: [String: Any]) async throws -> WalletPreparedTransaction {
-        let request = try parsePrepareRequest(arguments)
+    private func prepare(
+        _ arguments: [String: Any],
+        source: WalletRequestSource
+    ) async throws -> WalletPreparedTransaction {
+        let now = Date()
+        prepared = prepared.filter { $0.value.expiresAt > now }
+        confirmedIntentIDs = confirmedIntentIDs.intersection(Set(prepared.keys))
+        if let pendingConfirmation, pendingConfirmation.expiresAt <= now {
+            self.pendingConfirmation = nil
+        }
+        guard prepared.count < Self.maximumPreparedIntents else {
+            throw Error.policyDenied("Too many wallet intents are pending for this session.")
+        }
+        let request = try parsePrepareRequest(arguments, source: source)
         let contract: WalletContractRegistryEntry?
         if request.action.type == .contractCall {
             guard let contractID = request.action.contractID,
@@ -764,10 +985,15 @@ final class WalletGateway: ObservableObject {
         let transaction = try await signer.prepare(request, contract: contract)
         guard transaction.networkID == request.networkID,
               transaction.accountID == request.accountID,
+              transaction.source == request.source,
               transaction.action == request.action,
               transaction.maximumFeeBaseUnits == request.maximumFeeBaseUnits,
               transaction.expiresAt.timeIntervalSince(transaction.createdAt) <= 120.5 else {
             throw Error.invalidArguments("WalletSigner returned a preparation for a different semantic request.")
+        }
+        if request.source.kind == .browser,
+           transaction.policyDecision == "allowed_by_session_policy" {
+            throw Error.policyDenied("Browser transactions require an exact confirmation.")
         }
         if transaction.policyDecision != "allowed_by_session_policy" {
             pendingConfirmation = transaction
@@ -778,7 +1004,10 @@ final class WalletGateway: ObservableObject {
         return transaction
     }
 
-    private func parsePrepareRequest(_ arguments: [String: Any]) throws -> WalletPrepareRequest {
+    private func parsePrepareRequest(
+        _ arguments: [String: Any],
+        source: WalletRequestSource
+    ) throws -> WalletPrepareRequest {
         guard let networkID = nonempty(arguments["network_id"]),
               networkID == Self.sepoliaNetworkID,
               let accountID = nonempty(arguments["account_id"]),
@@ -821,13 +1050,22 @@ final class WalletGateway: ObservableObject {
             action = .contractCall(contractID: contractID, function: function,
                                    arguments: typedArguments, valueBaseUnits: value)
         }
-        return WalletPrepareRequest(networkID: networkID, accountID: accountID,
-                                    action: action, maximumFeeBaseUnits: maximumFee)
+        return WalletPrepareRequest(
+            networkID: networkID,
+            accountID: accountID,
+            source: source,
+            action: action,
+            maximumFeeBaseUnits: maximumFee
+        )
     }
 
-    private func simulate(_ arguments: [String: Any]) async throws -> [String: Any] {
+    private func simulate(
+        _ arguments: [String: Any],
+        source: WalletRequestSource
+    ) async throws -> [String: Any] {
         guard let intentID = nonempty(arguments["intent_id"]),
-              let known = prepared[intentID], known.expiresAt > Date() else { throw Error.intentNotFound }
+              let known = prepared[intentID], known.expiresAt > Date(),
+              known.source == source else { throw Error.intentNotFound }
         let transaction = try await signer.simulate(intentID: intentID)
         guard transaction.id == known.id, transaction.digest == known.digest else {
             throw Error.policyDenied("The signer returned a different transaction during re-simulation.")
@@ -836,9 +1074,13 @@ final class WalletGateway: ObservableObject {
         return response(for: transaction)
     }
 
-    private func execute(_ arguments: [String: Any]) async throws -> [String: Any] {
+    private func execute(
+        _ arguments: [String: Any],
+        source: WalletRequestSource
+    ) async throws -> [String: Any] {
         guard let intentID = nonempty(arguments["intent_id"]),
-              let transaction = prepared[intentID], transaction.expiresAt > Date() else {
+              let transaction = prepared[intentID], transaction.expiresAt > Date(),
+              transaction.source == source else {
             throw Error.intentNotFound
         }
         if transaction.policyDecision != "allowed_by_session_policy" {
@@ -849,20 +1091,64 @@ final class WalletGateway: ObservableObject {
             try await signer.confirmExecution(intentID: intentID)
         }
         // The signer owns the bytes; execution accepts the opaque ID only.
-        let result = try await signer.execute(intentID: intentID)
+        let result: [String: Any]
+        do {
+            result = try await signer.execute(intentID: intentID)
+        } catch let Error.broadcastUnknown(transactionHash, message) {
+            recordActivity(
+                transaction: transaction,
+                transactionHash: transactionHash,
+                state: .broadcastUnknown,
+                detail: message
+            )
+            prepared[intentID] = nil
+            pendingConfirmation = nil
+            throw Error.broadcastUnknown(transactionHash: transactionHash, message: message)
+        }
         activePolicyStatuses = (try? await signer.listPolicies()) ?? activePolicyStatuses
         activePolicies = activePolicyStatuses.map(\.policy)
         prepared[intentID] = nil
         pendingConfirmation = nil
         if let hash = result["transaction_hash"] as? String {
-            transactionHistory.insert([
-                "hash": hash,
-                "summary": transaction.summary,
-                "status": result["status"] as? String ?? "submitted",
-                "date": ISO8601DateFormatter().string(from: Date()),
-            ], at: 0)
+            recordActivity(
+                transaction: transaction,
+                transactionHash: hash,
+                state: .submitted,
+                detail: nil
+            )
         }
         return result
+    }
+
+    private func recordActivity(
+        transaction: WalletPreparedTransaction,
+        transactionHash: String,
+        state: WalletActivityState,
+        detail: String?
+    ) {
+        let record = WalletActivityRecord(
+            id: transactionHash.lowercased(),
+            intentID: transaction.id,
+            transactionHash: transactionHash,
+            networkID: transaction.networkID,
+            accountID: transaction.accountID,
+            summary: transaction.summary,
+            submittedAt: Date(),
+            state: state,
+            blockNumber: nil,
+            lastCheckedAt: nil,
+            detail: detail.map { String($0.prefix(512)) }
+        )
+        transactionHistory.removeAll { $0.id == record.id }
+        transactionHistory.insert(record, at: 0)
+        if transactionHistory.count > 250 { transactionHistory.removeLast(transactionHistory.count - 250) }
+        persistActivity()
+    }
+
+    private func persistActivity() {
+        if let data = try? JSONEncoder().encode(transactionHistory) {
+            userDefaults.set(data, forKey: activityDefaultsKey)
+        }
     }
 
     private func response(for transaction: WalletPreparedTransaction) -> [String: Any] {
@@ -872,6 +1158,7 @@ final class WalletGateway: ObservableObject {
             "digest": transaction.digest,
             "network_id": transaction.networkID,
             "account_id": transaction.accountID,
+            "request_source": transaction.source.kind.rawValue,
             "decoded_effects": (try? dictionary(transaction.effects)) ?? [],
             "risk_flags": transaction.riskFlags.map(\.rawValue),
             "maximum_fee_base_units": transaction.maximumFeeBaseUnits,
@@ -882,6 +1169,7 @@ final class WalletGateway: ObservableObject {
             "nonce": transaction.nonce,
             "expires_at": transaction.expiresAt.timeIntervalSince1970,
         ]
+        if let origin = transaction.source.origin { result["request_origin"] = origin }
         if let contract = transaction.contract { result["contract"] = try? dictionary(contract) }
         return result
     }

--- a/Locus/WalletRPCClient.swift
+++ b/Locus/WalletRPCClient.swift
@@ -297,6 +297,15 @@ actor WalletSepoliaRPCClient {
             }
             selectors.append(String(digest.prefix(10)).lowercased())
         }
+        let reviewedAdapterID = WalletReviewedAdapters.classify(
+            normalizedABI: normalizedABI, permittedFunctions: functions
+        )
+        if let requestedAdapterID = draft.reviewedAdapterID,
+           requestedAdapterID != reviewedAdapterID {
+            throw WalletGateway.Error.invalidArguments(
+                "The requested adapter does not match the verified ABI and permitted methods."
+            )
+        }
         return WalletContractRegistryEntry(
             id: draft.id.trimmingCharacters(in: .whitespacesAndNewlines),
             networkID: draft.networkID,
@@ -307,7 +316,7 @@ actor WalletSepoliaRPCClient {
             runtimeCodeHash: runtimeCodeHash.lowercased(),
             permittedFunctions: functions,
             permittedSelectors: selectors,
-            reviewedAdapterID: draft.reviewedAdapterID,
+            reviewedAdapterID: reviewedAdapterID,
             verifiedAt: Date()
         )
     }
@@ -403,31 +412,57 @@ actor WalletSepoliaRPCClient {
 
     private func rpc(method: String, params: [Any]) async throws -> Any {
         let id = nextID
-        nextID += 1
+        nextID = nextID == Int.max ? 1 : nextID + 1
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 20
-        request.httpBody = try JSONSerialization.data(withJSONObject: [
+        let body = try JSONSerialization.data(withJSONObject: [
             "jsonrpc": "2.0", "id": id, "method": method, "params": params,
         ])
+        guard body.count <= 256 * 1024 else {
+            throw WalletRPCError.invalidResponse("request exceeded the 256 KiB wallet limit")
+        }
+        request.httpBody = body
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw WalletRPCError.invalidResponse("HTTP request failed")
         }
+        guard data.count <= 1_048_576 else {
+            throw WalletRPCError.invalidResponse("response exceeded the 1 MiB wallet limit")
+        }
         guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw WalletRPCError.invalidResponse("response is not JSON-RPC")
         }
-        if let error = object["error"] as? [String: Any] {
+        guard object["jsonrpc"] as? String == "2.0",
+              let responseID = object["id"] as? NSNumber,
+              CFGetTypeID(responseID) != CFBooleanGetTypeID(),
+              responseID.decimalValue == Decimal(id) else {
+            throw WalletRPCError.invalidResponse("JSON-RPC version or response ID did not match the request")
+        }
+        let hasResult = object.keys.contains("result")
+        let hasError = object.keys.contains("error")
+        guard hasResult != hasError else {
+            throw WalletRPCError.invalidResponse("response must contain exactly one of result or error")
+        }
+        if hasError {
+            guard let error = object["error"] as? [String: Any],
+                  let code = error["code"] as? NSNumber,
+                  CFGetTypeID(code) != CFBooleanGetTypeID(),
+                  code.decimalValue == Decimal(code.intValue),
+                  let rawMessage = error["message"] as? String else {
+                throw WalletRPCError.invalidResponse("error payload was malformed")
+            }
+            let message = String(rawMessage.prefix(512))
             throw WalletRPCError.rpc(
-                code: error["code"] as? Int ?? -1,
-                message: error["message"] as? String ?? "Unknown RPC failure"
+                code: code.intValue,
+                message: message
             )
         }
-        guard object.keys.contains("result") else {
-            throw WalletRPCError.invalidResponse("response has no result")
+        guard let result = object["result"] else {
+            throw WalletRPCError.invalidResponse("result payload was missing")
         }
-        return object["result"] as Any
+        return result
     }
 
     private static func validatedEndpoint(_ value: String) -> URL? {

--- a/Locus/WalletSignerProtocol.swift
+++ b/Locus/WalletSignerProtocol.swift
@@ -32,6 +32,22 @@ enum WalletActionKind: String, Codable, Sendable {
     case contractCall = "contract_call"
 }
 
+enum WalletRequestSourceKind: String, Codable, Sendable {
+    case agent
+    case browser
+}
+
+struct WalletRequestSource: Codable, Equatable, Sendable {
+    let kind: WalletRequestSourceKind
+    let origin: String?
+
+    static let agent = Self(kind: .agent, origin: nil)
+
+    static func browser(origin: String) -> Self {
+        Self(kind: .browser, origin: origin)
+    }
+}
+
 /// Semantic transaction input. This wire type intentionally has no raw
 /// calldata, digest, decoded-effect, or caller-supplied safety fields.
 struct WalletSemanticAction: Codable, Equatable, Sendable {
@@ -63,8 +79,22 @@ struct WalletSemanticAction: Codable, Equatable, Sendable {
 struct WalletPrepareRequest: Codable, Equatable, Sendable {
     let networkID: String
     let accountID: String
+    let source: WalletRequestSource
     let action: WalletSemanticAction
     let maximumFeeBaseUnits: String
+}
+
+struct WalletAuthorizedRequest<Payload: Codable & Equatable & Sendable>: Codable, Equatable, Sendable {
+    let protocolVersion: Int
+    let sessionID: String
+    let source: WalletRequestSource
+    let payload: Payload
+}
+
+struct WalletSessionRequest: Codable, Equatable, Sendable {
+    let protocolVersion: Int
+    let sessionID: String
+    let source: WalletRequestSource
 }
 
 enum WalletRiskFlag: String, Codable, Equatable, Sendable {
@@ -99,6 +129,7 @@ struct WalletPreparedTransaction: Codable, Equatable, Identifiable, Sendable {
     let digest: String
     let networkID: String
     let accountID: String
+    let source: WalletRequestSource
     let action: WalletSemanticAction
     let summary: String
     let effects: [WalletDecodedEffect]
@@ -160,6 +191,201 @@ struct WalletContractRegistryEntry: Codable, Equatable, Identifiable, Sendable {
     let permittedSelectors: [String]
     let reviewedAdapterID: String?
     let verifiedAt: Date
+}
+
+/// Adapter classification is derived from the normalized ABI and the exact
+/// permitted function set. A registry caller cannot turn an arbitrary ABI into
+/// a reviewed adapter by supplying a label.
+enum WalletReviewedAdapters {
+    static let erc20 = "erc20-v1"
+    static let uniswapUniversalRouterV2ExactIn =
+        "uniswap-universal-router-v2-exact-in-v1"
+
+    private struct FunctionShape: Equatable {
+        let inputs: [String]
+        let stateMutability: String
+    }
+
+    private static let erc20Functions: [String: FunctionShape] = [
+        "approve(address,uint256)": FunctionShape(
+            inputs: ["address", "uint256"], stateMutability: "nonpayable"
+        ),
+        "transfer(address,uint256)": FunctionShape(
+            inputs: ["address", "uint256"], stateMutability: "nonpayable"
+        ),
+    ]
+    private static let universalRouterFunctions: [String: FunctionShape] = [
+        "execute(bytes,bytes[],uint256)": FunctionShape(
+            inputs: ["bytes", "bytes[]", "uint256"], stateMutability: "payable"
+        ),
+    ]
+
+    static func classify(normalizedABI: String, permittedFunctions: [String]) -> String? {
+        guard let definitions = functionDefinitions(in: normalizedABI) else { return nil }
+        let permitted = Set(permittedFunctions)
+        if !permitted.isEmpty, permitted.isSubset(of: Set(erc20Functions.keys)),
+           permitted.allSatisfy({ definitions[$0] == erc20Functions[$0] }) {
+            return erc20
+        }
+        if permitted == Set(universalRouterFunctions.keys),
+           permitted.allSatisfy({ definitions[$0] == universalRouterFunctions[$0] }) {
+            return uniswapUniversalRouterV2ExactIn
+        }
+        return nil
+    }
+
+    static func validatedID(for entry: WalletContractRegistryEntry) -> String? {
+        guard let claimed = entry.reviewedAdapterID,
+              claimed == classify(
+                normalizedABI: entry.normalizedABI,
+                permittedFunctions: entry.permittedFunctions
+              ) else { return nil }
+        return claimed
+    }
+
+    private static func functionDefinitions(in normalizedABI: String) -> [String: FunctionShape]? {
+        guard normalizedABI.utf8.count <= 256 * 1024,
+              let data = normalizedABI.data(using: .utf8),
+              let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return nil
+        }
+        var definitions: [String: FunctionShape] = [:]
+        for item in items where item["type"] as? String == "function" {
+            guard let name = item["name"] as? String,
+                  let stateMutability = item["stateMutability"] as? String,
+                  let inputs = item["inputs"] as? [[String: Any]],
+                  inputs.count <= 64 else { return nil }
+            let types = inputs.compactMap { $0["type"] as? String }
+            guard types.count == inputs.count else { return nil }
+            let signature = "\(name)(\(types.joined(separator: ",")))"
+            // Ambiguous duplicate definitions are never adapter-reviewed.
+            guard definitions[signature] == nil else { return nil }
+            definitions[signature] = FunctionShape(
+                inputs: types, stateMutability: stateMutability
+            )
+        }
+        return definitions
+    }
+}
+
+struct WalletUniversalRouterV2Swap: Equatable, Sendable {
+    let inputAssetID: String
+    let outputAssetID: String
+    let amountIn: String
+    let minimumAmountOut: String
+    let recipient: String
+}
+
+enum WalletUniversalRouterV2Adapter {
+    /// Decodes one Universal Router v2 `V2_SWAP_EXACT_IN` command. Composite
+    /// programs, allow-revert, Permit2 commands, exact-output swaps, and native
+    /// wrapping are intentionally outside this adapter.
+    static func decode(
+        action: WalletSemanticAction,
+        accountAddress: String,
+        now: Date = Date()
+    ) -> WalletUniversalRouterV2Swap? {
+        guard action.function == "execute(bytes,bytes[],uint256)",
+              action.arguments.count == 3,
+              action.arguments[0].type == "bytes",
+              action.arguments[0].value.lowercased() == "0x08",
+              action.arguments[1].type == "bytes[]",
+              let encodedInput = singleBytesArray(action.arguments[1].value),
+              action.arguments[2].type == "uint256",
+              let deadline = UInt64(normalizedDecimal(action.arguments[2].value) ?? "") else {
+            return nil
+        }
+        let timestamp = UInt64(max(0, now.timeIntervalSince1970.rounded(.down)))
+        guard deadline >= timestamp, deadline <= timestamp + 20 * 60 else { return nil }
+
+        let raw = encodedInput.lowercased().hasPrefix("0x")
+            ? String(encodedInput.dropFirst(2)) : encodedInput
+        guard raw.count >= 8 * 64, raw.count.isMultiple(of: 64),
+              raw.allSatisfy(\.isHexDigit) else { return nil }
+        let words = stride(from: 0, to: raw.count, by: 64).map { offset -> String in
+            let start = raw.index(raw.startIndex, offsetBy: offset)
+            let end = raw.index(start, offsetBy: 64)
+            return String(raw[start..<end])
+        }
+        guard words.count >= 8,
+              let recipient = address(fromABIWord: words[0]),
+              let amountIn = decimal(fromABIWord: words[1]), amountIn != "0",
+              let minimumOut = decimal(fromABIWord: words[2]), minimumOut != "0",
+              decimal(fromABIWord: words[3]) == "160",
+              decimal(fromABIWord: words[4]) == "1",
+              let pathCountText = decimal(fromABIWord: words[5]),
+              let pathCount = Int(pathCountText), (2...4).contains(pathCount),
+              words.count == 6 + pathCount else { return nil }
+        let path = words[6...].compactMap(address(fromABIWord:))
+        guard path.count == pathCount,
+              path.first?.caseInsensitiveCompare(path.last ?? "") != .orderedSame,
+              recipient.caseInsensitiveCompare(accountAddress) == .orderedSame else { return nil }
+        return WalletUniversalRouterV2Swap(
+            inputAssetID: "eip155:11155111/erc20:\(path[0].lowercased())",
+            outputAssetID: "eip155:11155111/erc20:\(path[path.count - 1].lowercased())",
+            amountIn: amountIn, minimumAmountOut: minimumOut, recipient: recipient
+        )
+    }
+
+    private static func singleBytesArray(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.first == "[", trimmed.last == "]" else { return nil }
+        let inner = trimmed.dropFirst().dropLast()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !inner.isEmpty, !inner.contains(","),
+              inner.lowercased().hasPrefix("0x"),
+              inner.dropFirst(2).count.isMultiple(of: 2),
+              inner.dropFirst(2).allSatisfy(\.isHexDigit) else { return nil }
+        return inner
+    }
+
+    private static func normalizedDecimal(_ value: String) -> String? {
+        guard !value.isEmpty,
+              value.utf8.allSatisfy({ (48...57).contains($0) }) else { return nil }
+        let trimmed = value.drop(while: { $0 == "0" })
+        return trimmed.isEmpty ? "0" : String(trimmed)
+    }
+
+    private static func decimal(fromABIWord word: String) -> String? {
+        guard word.count == 64, word.allSatisfy(\.isHexDigit) else { return nil }
+        var result = "0"
+        for character in word.lowercased() {
+            guard let digit = Int(String(character), radix: 16),
+                  let next = multiplyAndAdd(result, multiplier: 16, addend: digit) else {
+                return nil
+            }
+            result = next
+        }
+        return result
+    }
+
+    private static func multiplyAndAdd(
+        _ value: String, multiplier: Int, addend: Int
+    ) -> String? {
+        guard multiplier >= 0, addend >= 0, !value.isEmpty,
+              value.utf8.allSatisfy({ (48...57).contains($0) }) else { return nil }
+        var carry = addend
+        var digits: [Int] = []
+        for character in value.reversed() {
+            guard let digit = character.wholeNumberValue else { return nil }
+            let total = digit * multiplier + carry
+            digits.append(total % 10)
+            carry = total / 10
+        }
+        while carry > 0 {
+            digits.append(carry % 10)
+            carry /= 10
+        }
+        return digits.reversed().map(String.init).joined()
+    }
+
+    private static func address(fromABIWord word: String) -> String? {
+        guard word.count == 64,
+              word.prefix(24).allSatisfy({ $0 == "0" }),
+              word.suffix(40).allSatisfy(\.isHexDigit) else { return nil }
+        let value = "0x" + String(word.suffix(40))
+        return value.count == 42 ? value : nil
+    }
 }
 
 struct WalletContractEncodingRequest: Codable, Equatable, Sendable {
@@ -254,11 +480,11 @@ struct WalletSignerErrorPayload: Codable, Equatable, Sendable {
     func encodeEVMContract(_ request: Data, reply: @escaping (Data) -> Void)
     func prepareEVM(_ request: Data, reply: @escaping (Data) -> Void)
     func simulateEVM(_ request: Data, reply: @escaping (Data) -> Void)
-    func confirmEVM(_ intentID: String, reply: @escaping (Data) -> Void)
+    func confirmEVM(_ request: Data, reply: @escaping (Data) -> Void)
     func executeEVM(_ request: Data, reply: @escaping (Data) -> Void)
     func activatePolicy(_ request: Data, reply: @escaping (Data) -> Void)
-    func listPolicies(reply: @escaping (Data) -> Void)
-    func clearPolicies(reply: @escaping (Data) -> Void)
+    func listPolicies(_ request: Data, reply: @escaping (Data) -> Void)
+    func clearPolicies(_ request: Data, reply: @escaping (Data) -> Void)
     func lock(reply: @escaping (Data) -> Void)
     func deleteVault(_ confirmation: String, reply: @escaping (Data) -> Void)
 }

--- a/Locus/WalletSignerXPCClient.swift
+++ b/Locus/WalletSignerXPCClient.swift
@@ -105,7 +105,7 @@ final class XPCWalletSignerClient: WalletSignerClient {
             let encodingRequest = WalletContractEncodingRequest(
                 action: request.action, registryEntry: contract
             )
-            let requestData = try encoder.encode(encodingRequest)
+            let requestData = try authorized(encodingRequest, source: request.source)
             encodedContract = try await call { proxy, reply in
                 proxy.encodeEVMContract(requestData, reply: reply)
             }
@@ -118,7 +118,7 @@ final class XPCWalletSignerClient: WalletSignerClient {
             contract: contract,
             encodedContract: encodedContract
         )
-        let data = try encoder.encode(packet)
+        let data = try authorized(packet, source: request.source)
         let transaction: WalletPreparedTransaction = try await call { proxy, reply in
             proxy.prepareEVM(data, reply: reply)
         }
@@ -131,13 +131,17 @@ final class XPCWalletSignerClient: WalletSignerClient {
             throw WalletGateway.Error.intentNotFound
         }
         let recheck = try await rpc.recheck(intentID: intentID, packet: packet)
-        let data = try encoder.encode(recheck)
+        let data = try authorized(recheck, source: packet.request.source)
         return try await call { proxy, reply in proxy.simulateEVM(data, reply: reply) }
     }
 
     func confirmExecution(intentID: String) async throws {
+        guard let packet = preparationPackets[intentID] else {
+            throw WalletGateway.Error.intentNotFound
+        }
+        let request = try authorized(intentID, source: packet.request.source)
         let _: WalletPreparedTransaction = try await call { proxy, reply in
-            proxy.confirmEVM(intentID, reply: reply)
+            proxy.confirmEVM(request, reply: reply)
         }
     }
 
@@ -146,17 +150,26 @@ final class XPCWalletSignerClient: WalletSignerClient {
             throw WalletGateway.Error.intentNotFound
         }
         let recheck = try await rpc.recheck(intentID: intentID, packet: packet)
-        let request = try encoder.encode(recheck)
+        let request = try authorized(recheck, source: packet.request.source)
         let signed: WalletEVMSignedTransaction = try await call { proxy, reply in
             proxy.executeEVM(request, reply: reply)
         }
         // The intent is consumed as soon as signed bytes cross the XPC boundary.
         // A broadcast failure must never make the same intent signable again.
         preparationPackets[intentID] = nil
-        let broadcastHash = try await rpc.broadcast(rawTransaction: signed.rawTransaction)
+        let broadcastHash: String
+        do {
+            broadcastHash = try await rpc.broadcast(rawTransaction: signed.rawTransaction)
+        } catch {
+            throw WalletGateway.Error.broadcastUnknown(
+                transactionHash: signed.transactionHash,
+                message: error.localizedDescription
+            )
+        }
         guard broadcastHash.caseInsensitiveCompare(signed.transactionHash) == .orderedSame else {
-            throw WalletGateway.Error.policyDenied(
-                "Sepolia returned a transaction hash that does not match the signed bytes."
+            throw WalletGateway.Error.broadcastUnknown(
+                transactionHash: signed.transactionHash,
+                message: "Sepolia returned a transaction hash that does not match the signed bytes."
             )
         }
         return [
@@ -169,17 +182,19 @@ final class XPCWalletSignerClient: WalletSignerClient {
     }
 
     func activatePolicy(_ policy: WalletSessionPolicy) async throws -> [WalletActivePolicyStatus] {
-        let request = try encoder.encode(policy)
+        let request = try authorized(policy, source: .agent)
         return try await call { proxy, reply in proxy.activatePolicy(request, reply: reply) }
     }
 
     func listPolicies() async throws -> [WalletActivePolicyStatus] {
-        try await call { proxy, reply in proxy.listPolicies(reply: reply) }
+        let request = try sessionRequest(source: .agent)
+        return try await call { proxy, reply in proxy.listPolicies(request, reply: reply) }
     }
 
     func clearPolicies() async throws {
+        let request = try sessionRequest(source: .agent)
         let _: [WalletActivePolicyStatus] = try await call { proxy, reply in
-            proxy.clearPolicies(reply: reply)
+            proxy.clearPolicies(request, reply: reply)
         }
     }
 
@@ -248,6 +263,28 @@ final class XPCWalletSignerClient: WalletSignerClient {
                           userInfo: [NSLocalizedDescriptionKey: error.error])
         }
         return try decoder.decode(T.self, from: data)
+    }
+
+    private func authorized<Payload: Codable & Equatable & Sendable>(
+        _ payload: Payload,
+        source: WalletRequestSource
+    ) throws -> Data {
+        guard let sessionID else { throw WalletGateway.Error.vaultLocked }
+        return try encoder.encode(WalletAuthorizedRequest(
+            protocolVersion: WalletGateway.protocolVersion,
+            sessionID: sessionID,
+            source: source,
+            payload: payload
+        ))
+    }
+
+    private func sessionRequest(source: WalletRequestSource) throws -> Data {
+        guard let sessionID else { throw WalletGateway.Error.vaultLocked }
+        return try encoder.encode(WalletSessionRequest(
+            protocolVersion: WalletGateway.protocolVersion,
+            sessionID: sessionID,
+            source: source
+        ))
     }
 
     private func rawCall(

--- a/LocusTests/WalletGatewayTests.swift
+++ b/LocusTests/WalletGatewayTests.swift
@@ -1,6 +1,31 @@
 import XCTest
 @testable import Locus
 
+private final class WalletRPCURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (status: Int, data: Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        do {
+            guard let handler = Self.handler else {
+                throw URLError(.badServerResponse)
+            }
+            let result = try handler(request)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: result.status,
+                httpVersion: "HTTP/1.1", headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: result.data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+    override func stopLoading() {}
+}
+
 @MainActor
 private final class FakeWalletSigner: WalletSignerClient {
     let isAvailable = true
@@ -14,6 +39,10 @@ private final class FakeWalletSigner: WalletSignerClient {
     var invalidationHandler: (() -> Void)?
     var riskFlags: [WalletRiskFlag] = []
     var adapterID: String? = "native-eth-transfer-v1"
+    var policyDecision = "signer_pending"
+    var policyID: String?
+    var executionError: WalletGateway.Error?
+    var browserRPCResponse: Any = "0x1"
 
     func signerStatus() async throws -> WalletSignerStatus {
         WalletSignerStatus(protocolVersion: 1, vaultState: sessionID == nil ? .locked : .unlocked,
@@ -55,6 +84,7 @@ private final class FakeWalletSigner: WalletSignerClient {
 
     func execute(intentID: String) async throws -> [String: Any] {
         executedIntentIDs.append(intentID)
+        if let executionError { throw executionError }
         return ["text": "Submitted 0xtx", "transaction_hash": "0xtx", "status": "submitted"]
     }
 
@@ -74,7 +104,7 @@ private final class FakeWalletSigner: WalletSignerClient {
             verifiedAt: Date()
         )
     }
-    func browserRPC(method: String, params: [Any]) async throws -> Any { "0x1" }
+    func browserRPC(method: String, params: [Any]) async throws -> Any { browserRPCResponse }
 
     func performRead(tool: String, arguments: [String: Any]) async throws -> [String: Any] {
         ["text": "ok"]
@@ -93,7 +123,7 @@ private final class FakeWalletSigner: WalletSignerClient {
         WalletPreparedTransaction(
             id: "intent-1", digest: "canonical-digest",
             networkID: request.networkID, accountID: request.accountID,
-            action: request.action, summary: "Send 1 wei",
+            source: request.source, action: request.action, summary: "Send 1 wei",
             effects: [WalletDecodedEffect(id: "effect-1", kind: "debit",
                                           assetID: "slip44:60", amountBaseUnits: "1",
                                           from: "0xabc", to: "0xrecipient", spender: nil)],
@@ -102,7 +132,7 @@ private final class FakeWalletSigner: WalletSignerClient {
             maximumFeeBaseUnits: request.maximumFeeBaseUnits,
             feeQuoteBaseUnits: "10", simulation: "Success", simulationSucceeded: true,
             nonce: "42", createdAt: Date(), expiresAt: Date().addingTimeInterval(120),
-            policyDecision: "signer_pending", policyID: nil
+            policyDecision: policyDecision, policyID: policyID
         )
     }
 }
@@ -116,7 +146,8 @@ final class WalletGatewayTests: XCTestCase {
     ) -> WalletPreparedTransaction {
         WalletPreparedTransaction(
             id: "intent-1", digest: "digest", networkID: WalletGateway.sepoliaNetworkID,
-            accountID: "account-1", action: .nativeTransfer(recipient: "0xrecipient", amountBaseUnits: "10"),
+            accountID: "account-1", source: .agent,
+            action: .nativeTransfer(recipient: "0xrecipient", amountBaseUnits: "10"),
             summary: "Transfer", effects: [], riskFlags: riskFlags, contract: nil,
             adapterID: adapterID, budgetAssetID: "slip44:60", spendBaseUnits: "10",
             maximumFeeBaseUnits: "20", feeQuoteBaseUnits: "15", simulation: "Success",
@@ -143,6 +174,7 @@ final class WalletGatewayTests: XCTestCase {
                        "18446744073709551616000000000")
         XCTAssertTrue(WalletBaseUnits.lessThanOrEqual("18446744073709551616", "18446744073709551617"))
         XCTAssertFalse(WalletBaseUnits.lessThanOrEqual("1.0", "2"))
+        XCTAssertNil(WalletBaseUnits.normalize("١٠"))
         XCTAssertEqual(WalletEthereumQuantity.decimalToHex("18446744073709551616"),
                        "0x10000000000000000")
         XCTAssertEqual(WalletEthereumQuantity.hexToDecimal("0x10000000000000000"),
@@ -158,12 +190,188 @@ final class WalletGatewayTests: XCTestCase {
         XCTAssertEqual(address, "0x52908400098527886E0F7030069857D2E4169EE7")
     }
 
+    func testReviewedAdapterClassificationCannotBeSelfAsserted() {
+        let erc20ABI = #"[{"type":"function","name":"transfer","stateMutability":"nonpayable","inputs":[{"name":"to","type":"address"},{"name":"amount","type":"uint256"}],"outputs":[{"name":"","type":"bool"}]}]"#
+        XCTAssertEqual(
+            WalletReviewedAdapters.classify(
+                normalizedABI: erc20ABI,
+                permittedFunctions: ["transfer(address,uint256)"]
+            ),
+            WalletReviewedAdapters.erc20
+        )
+        let mismatchedABI = #"[{"type":"function","name":"transfer","inputs":[{"name":"to","type":"address"},{"name":"amount","type":"bytes32"}],"outputs":[]}]"#
+        XCTAssertNil(WalletReviewedAdapters.classify(
+            normalizedABI: mismatchedABI,
+            permittedFunctions: ["transfer(address,uint256)"]
+        ))
+
+        let routerABI = #"[{"type":"function","name":"execute","stateMutability":"payable","inputs":[{"name":"commands","type":"bytes"},{"name":"inputs","type":"bytes[]"},{"name":"deadline","type":"uint256"}],"outputs":[]}]"#
+        XCTAssertEqual(
+            WalletReviewedAdapters.classify(
+                normalizedABI: routerABI,
+                permittedFunctions: ["execute(bytes,bytes[],uint256)"]
+            ),
+            WalletReviewedAdapters.uniswapUniversalRouterV2ExactIn
+        )
+        XCTAssertNil(WalletReviewedAdapters.classify(
+            normalizedABI: routerABI,
+            permittedFunctions: ["execute(bytes,bytes[],uint256)", "execute(bytes,bytes[])"]
+        ))
+    }
+
+    func testPersistedRegistryAdapterLabelsAreRecomputedOnLoad() throws {
+        let suiteName = "WalletRegistryMigrationTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let invalid = WalletContractRegistryEntry(
+            id: "spoofed", networkID: WalletGateway.sepoliaNetworkID,
+            checksumAddress: "0x1111111111111111111111111111111111111111",
+            label: "Spoofed", normalizedABI: "[]", abiDigest: "sha256:test",
+            runtimeCodeHash: "0xcode", permittedFunctions: ["transfer(address,uint256)"],
+            permittedSelectors: ["0xa9059cbb"],
+            reviewedAdapterID: WalletReviewedAdapters.erc20, verifiedAt: Date()
+        )
+        defaults.set(try JSONEncoder().encode([invalid]), forKey: "LocusWalletContractRegistryV1")
+        let gateway = WalletGateway(
+            signer: FakeWalletSigner(), environment: [:], userDefaults: defaults
+        )
+        XCTAssertNil(gateway.contractRegistry.first?.reviewedAdapterID)
+    }
+
+    func testUniversalRouterAdapterDecodesOnlyOneBoundedExactInputCommand() throws {
+        let account = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        let inputToken = "1111111111111111111111111111111111111111"
+        let outputToken = "2222222222222222222222222222222222222222"
+        let encodedInput = [
+            abiWord(String(account.dropFirst(2))), abiWord("a"), abiWord("9"),
+            abiWord("a0"), abiWord("1"), abiWord("2"),
+            abiWord(inputToken), abiWord(outputToken),
+        ].joined()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let action = WalletSemanticAction.contractCall(
+            contractID: "uniswap.router", function: "execute(bytes,bytes[],uint256)",
+            arguments: [
+                WalletTypedArgument(type: "bytes", value: "0x08"),
+                WalletTypedArgument(type: "bytes[]", value: "[0x\(encodedInput)]"),
+                WalletTypedArgument(type: "uint256", value: "1100"),
+            ]
+        )
+        let swap = try XCTUnwrap(WalletUniversalRouterV2Adapter.decode(
+            action: action, accountAddress: account, now: now
+        ))
+        XCTAssertEqual(swap.amountIn, "10")
+        XCTAssertEqual(swap.minimumAmountOut, "9")
+        XCTAssertEqual(swap.recipient, account)
+        XCTAssertTrue(swap.inputAssetID.hasSuffix(inputToken))
+        XCTAssertTrue(swap.outputAssetID.hasSuffix(outputToken))
+
+        let allowRevert = WalletSemanticAction.contractCall(
+            contractID: "uniswap.router", function: "execute(bytes,bytes[],uint256)",
+            arguments: [
+                WalletTypedArgument(type: "bytes", value: "0x88"),
+                action.arguments[1], action.arguments[2],
+            ]
+        )
+        XCTAssertNil(WalletUniversalRouterV2Adapter.decode(
+            action: allowRevert, accountAddress: account, now: now
+        ))
+        let stale = WalletSemanticAction.contractCall(
+            contractID: "uniswap.router", function: "execute(bytes,bytes[],uint256)",
+            arguments: [action.arguments[0], action.arguments[1],
+                        WalletTypedArgument(type: "uint256", value: "999")]
+        )
+        XCTAssertNil(WalletUniversalRouterV2Adapter.decode(
+            action: stale, accountAddress: account, now: now
+        ))
+    }
+
+    private func abiWord(_ value: String) -> String {
+        String(repeating: "0", count: 64 - value.count) + value.lowercased()
+    }
+
+    func testRPCRejectsMismatchedResponseIDAndAmbiguousEnvelope() async throws {
+        let client = makeRPCClient { _ in
+            return try JSONSerialization.data(withJSONObject: [
+                "jsonrpc": "2.0", "id": 2, "result": "0xaa36a7",
+            ])
+        }
+        do {
+            _ = try await client.publicRead(method: "eth_blockNumber", params: [])
+            XCTFail("A mismatched JSON-RPC ID must fail closed.")
+        } catch WalletRPCError.invalidResponse(let message) {
+            XCTAssertTrue(message.contains("response ID"))
+        }
+
+        let ambiguous = makeRPCClient { _ in
+            return try JSONSerialization.data(withJSONObject: [
+                "jsonrpc": "2.0", "id": 1, "result": "0xaa36a7",
+                "error": ["code": -1, "message": "ambiguous"],
+            ])
+        }
+        do {
+            _ = try await ambiguous.publicRead(method: "eth_blockNumber", params: [])
+            XCTFail("A response with both result and error must fail closed.")
+        } catch WalletRPCError.invalidResponse(let message) {
+            XCTAssertTrue(message.contains("exactly one"))
+        }
+    }
+
+    func testRPCRejectsOversizedResponseBeforeParsing() async throws {
+        let client = makeRPCClient { _ in Data(repeating: 0x20, count: 1_048_577) }
+        do {
+            _ = try await client.publicRead(method: "eth_blockNumber", params: [])
+            XCTFail("An oversized wallet RPC response must fail closed.")
+        } catch WalletRPCError.invalidResponse(let message) {
+            XCTAssertTrue(message.contains("1 MiB"))
+        }
+    }
+
+    func testRPCPreservesJSONNullResultForReceiptReconciliation() async throws {
+        var responseID = 0
+        let client = makeRPCClient { _ in
+            responseID += 1
+            let result: Any = responseID == 1 ? "0xaa36a7" : NSNull()
+            return try JSONSerialization.data(withJSONObject: [
+                "jsonrpc": "2.0", "id": responseID, "result": result,
+            ])
+        }
+        let value = try await client.publicRead(
+            method: "eth_getTransactionReceipt", params: ["0xtx"]
+        )
+        XCTAssertTrue(value is NSNull)
+    }
+
+    private func makeRPCClient(
+        response: @escaping (URLRequest) throws -> Data
+    ) -> WalletSepoliaRPCClient {
+        WalletRPCURLProtocol.handler = { request in (200, try response(request)) }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [WalletRPCURLProtocol.self]
+        return WalletSepoliaRPCClient(
+            endpoint: "https://wallet-rpc.test", session: URLSession(configuration: configuration)
+        )
+    }
+
     func testXPCReplyGateConsumesExactlyOneReply() {
         let gate = WalletXPCReplyGate()
         XCTAssertTrue(gate.take())
         XCTAssertFalse(gate.take())
         XCTAssertFalse(gate.take())
     }
+
+    #if LOCUS_DIRECT_DOWNLOAD
+    func testEmbeddedSignerProcessReportsAConnectionLocalLockedSession() async throws {
+        let client = XPCWalletSignerClient()
+        guard client.isAvailable else {
+            throw XCTSkip("The direct-download test host did not embed WalletSigner.xpc.")
+        }
+        let status = try await client.signerStatus()
+        XCTAssertEqual(status.protocolVersion, WalletGateway.protocolVersion)
+        XCTAssertNil(status.sessionID)
+        XCTAssertNotEqual(status.vaultState, .unlocked)
+        client.lock()
+    }
+    #endif
 
     func testUnknownEffectsAndUnlimitedApprovalCanNeverBeAutonomous() {
         for flag in [WalletRiskFlag.unknownEffect, .undecodableCall, .unlimitedApproval] {
@@ -176,6 +384,23 @@ final class WalletGatewayTests: XCTestCase {
         ) else { return XCTFail("missing adapter must require exact approval") }
     }
 
+    func testBrowserSourceCanNeverUseAnAutonomousPolicy() {
+        let browser = WalletPreparedTransaction(
+            id: "browser-intent", digest: "digest", networkID: WalletGateway.sepoliaNetworkID,
+            accountID: "account-1", source: .browser(origin: "https://dapp.test"),
+            action: .nativeTransfer(recipient: "0xrecipient", amountBaseUnits: "10"),
+            summary: "Transfer", effects: [], riskFlags: [], contract: nil,
+            adapterID: "native-eth-transfer-v1", budgetAssetID: "slip44:60",
+            spendBaseUnits: "10", maximumFeeBaseUnits: "20", feeQuoteBaseUnits: "15",
+            simulation: "Success", simulationSucceeded: true, nonce: "1",
+            createdAt: Date(), expiresAt: Date().addingTimeInterval(120),
+            policyDecision: "", policyID: nil
+        )
+        guard case .requiresApproval = WalletPolicyEngine.evaluate(
+            transaction: browser, policy: policy(), spentThisSession: "0"
+        ) else { return XCTFail("Browser-originated transactions must require exact confirmation") }
+    }
+
     func testPolicyUsesUnsignedBaseUnitCaps() {
         XCTAssertEqual(WalletPolicyEngine.evaluate(
             transaction: prepared(), policy: policy(), spentThisSession: "5"
@@ -183,6 +408,88 @@ final class WalletGatewayTests: XCTestCase {
         guard case .requiresApproval = WalletPolicyEngine.evaluate(
             transaction: prepared(), policy: policy(), spentThisSession: "45"
         ) else { return XCTFail("cumulative cap must be enforced") }
+    }
+
+    func testReviewedContractPoliciesRequireExactContractAssetAndCounterparty() {
+        let token = "0x1111111111111111111111111111111111111111"
+        let recipient = "0x2222222222222222222222222222222222222222"
+        let transaction = WalletPreparedTransaction(
+            id: "erc20-intent", digest: "digest", networkID: WalletGateway.sepoliaNetworkID,
+            accountID: "account-1", source: .agent,
+            action: .contractCall(
+                contractID: "token.test", function: "transfer(address,uint256)",
+                arguments: [
+                    WalletTypedArgument(type: "address", value: recipient),
+                    WalletTypedArgument(type: "uint256", value: "10"),
+                ]
+            ),
+            summary: "Token transfer",
+            effects: [WalletDecodedEffect(
+                id: "effect", kind: "token_transfer",
+                assetID: "eip155:11155111/erc20:\(token)", amountBaseUnits: "10",
+                from: "0x3333333333333333333333333333333333333333",
+                to: recipient, spender: nil
+            )],
+            riskFlags: [],
+            contract: WalletContractIdentity(
+                registryID: "token.test", address: token, label: "Token",
+                function: "transfer(address,uint256)", abiDigest: "sha256:test",
+                runtimeCodeHash: "0xcode"
+            ),
+            adapterID: WalletReviewedAdapters.erc20,
+            budgetAssetID: "eip155:11155111/erc20:\(token)", spendBaseUnits: "10",
+            maximumFeeBaseUnits: "20", feeQuoteBaseUnits: "15", simulation: "Success",
+            simulationSucceeded: true, nonce: "1", createdAt: Date(),
+            expiresAt: Date().addingTimeInterval(120), policyDecision: "", policyID: nil
+        )
+        let exactPolicy = WalletSessionPolicy(
+            id: "erc20-policy", accountID: "account-1",
+            networkID: WalletGateway.sepoliaNetworkID,
+            allowedAssetIDs: ["eip155:11155111/erc20:\(token)"],
+            allowedRecipients: [recipient], allowedContractIDs: ["token.test"],
+            allowedAdapterIDs: [WalletReviewedAdapters.erc20],
+            maximumTransactionBaseUnits: "10", maximumSessionBaseUnits: "20",
+            maximumFeeBaseUnits: "20", expiresAt: Date().addingTimeInterval(300)
+        )
+        XCTAssertEqual(WalletPolicyEngine.evaluate(
+            transaction: transaction, policy: exactPolicy, spentThisSession: "0"
+        ), .automatic)
+
+        let wrongCounterparty = WalletSessionPolicy(
+            id: exactPolicy.id, accountID: exactPolicy.accountID,
+            networkID: exactPolicy.networkID, allowedAssetIDs: exactPolicy.allowedAssetIDs,
+            allowedRecipients: ["0x4444444444444444444444444444444444444444"],
+            allowedContractIDs: exactPolicy.allowedContractIDs,
+            allowedAdapterIDs: exactPolicy.allowedAdapterIDs,
+            maximumTransactionBaseUnits: exactPolicy.maximumTransactionBaseUnits,
+            maximumSessionBaseUnits: exactPolicy.maximumSessionBaseUnits,
+            maximumFeeBaseUnits: exactPolicy.maximumFeeBaseUnits,
+            expiresAt: exactPolicy.expiresAt
+        )
+        guard case .requiresApproval = WalletPolicyEngine.evaluate(
+            transaction: transaction, policy: wrongCounterparty, spentThisSession: "0"
+        ) else { return XCTFail("A contract adapter must enforce its decoded counterparty.") }
+    }
+
+    func testExternalConnectorCatalogKeepsNativeSigningOnSepolia() {
+        XCTAssertEqual(
+            WalletExternalConnectorCatalog.connectors.map(\.kind),
+            [.metamask, .phantom, .slush]
+        )
+        XCTAssertTrue(WalletExternalConnectorCatalog.canUseNativeSigner(on: "eip155:11155111"))
+        XCTAssertFalse(WalletExternalConnectorCatalog.canUseNativeSigner(on: "eip155:1"))
+        XCTAssertFalse(WalletExternalConnectorCatalog.canUseNativeSigner(on: "solana:mainnet"))
+        XCTAssertTrue(WalletExternalConnectorCatalog.connectors.allSatisfy {
+            $0.state == .foundationReady && $0.documentationURL.scheme == "https"
+        })
+    }
+
+    func testHumanEtherFormatterNeverUsesFloatingPoint() {
+        XCTAssertEqual(WalletAmountFormatter.ether(wei: "0"), "0 ETH")
+        XCTAssertEqual(WalletAmountFormatter.ether(wei: "1000000000000000000"), "1 ETH")
+        XCTAssertEqual(WalletAmountFormatter.ether(wei: "1234500000000000000"), "1.2345 ETH")
+        XCTAssertEqual(WalletAmountFormatter.ether(wei: "1"), "0.000000000000000001 ETH")
+        XCTAssertNil(WalletAmountFormatter.ether(wei: "1.5"))
     }
 
     @MainActor
@@ -326,6 +633,34 @@ final class WalletGatewayTests: XCTestCase {
         XCTAssertNil(accounts)
     }
 
+    func testGatewayRejectsSignerAutonomyForBrowserSource() async {
+        let signer = FakeWalletSigner()
+        signer.policyDecision = "allowed_by_session_policy"
+        signer.policyID = "policy-1"
+        let gateway = WalletGateway(signer: signer, environment: [
+            "LOCUS_ENABLE_EXPERIMENTAL_WALLET": "1",
+            "LOCUS_ENABLE_EXPERIMENTAL_WALLET_BROWSER": "1",
+        ])
+        let authorized = await gateway.authorizeSession()
+        XCTAssertTrue(authorized)
+        let accountRequest = Task {
+            await gateway.requestBrowserAccounts(origin: "https://dapp.test")
+        }
+        await Task.yield()
+        gateway.approveBrowserOrigin()
+        _ = await accountRequest.value
+        do {
+            _ = try await gateway.browserSendTransaction(
+                origin: "https://dapp.test",
+                transaction: ["from": "0xabc", "to": "0xrecipient", "value": "0x1"]
+            )
+            XCTFail("Browser requests must never consume an autonomous policy.")
+        } catch {
+            XCTAssertTrue(signer.executedIntentIDs.isEmpty)
+            XCTAssertNil(gateway.pendingConfirmation)
+        }
+    }
+
     func testSignerInterruptionWithdrawsAgentCapabilityAndBrowserGrants() async {
         let signer = FakeWalletSigner()
         let gateway = WalletGateway(signer: signer, environment: [
@@ -378,6 +713,51 @@ final class WalletGatewayTests: XCTestCase {
         } catch {
             XCTAssertTrue(signer.executedIntentIDs.isEmpty)
         }
+    }
+
+    func testBroadcastUnknownActivityPersistsAndReconcilesByReceipt() async {
+        let signer = FakeWalletSigner()
+        signer.executionError = .broadcastUnknown(
+            transactionHash: "0xuncertain", message: "connection closed after submission"
+        )
+        let suiteName = "WalletGatewayTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let gateway = WalletGateway(
+            signer: signer,
+            environment: ["LOCUS_ENABLE_EXPERIMENTAL_WALLET": "1"],
+            userDefaults: defaults
+        )
+        let authorized = await gateway.authorizeSession()
+        XCTAssertTrue(authorized)
+        _ = await gateway.perform(tool: "wallet_prepare_transaction", arguments: [
+            "network_id": WalletGateway.sepoliaNetworkID,
+            "account_id": "account-1",
+            "action": [
+                "type": "native_transfer", "recipient": "0xrecipient",
+                "amount_base_units": "1",
+            ],
+            "maximum_fee_base_units": "20",
+        ])
+        gateway.confirm(intentID: "intent-1")
+        let result = await gateway.perform(
+            tool: "wallet_execute_transaction", arguments: ["intent_id": "intent-1"]
+        )
+        XCTAssertNotNil(result["error"])
+        XCTAssertEqual(gateway.transactionHistory.first?.state, .broadcastUnknown)
+        XCTAssertEqual(gateway.transactionHistory.first?.transactionHash, "0xuncertain")
+
+        let reloaded = WalletGateway(
+            signer: signer,
+            environment: ["LOCUS_ENABLE_EXPERIMENTAL_WALLET": "1"],
+            userDefaults: defaults
+        )
+        XCTAssertEqual(reloaded.transactionHistory.first?.state, .broadcastUnknown)
+        signer.browserRPCResponse = ["status": "0x1", "blockNumber": "0x2a"]
+        await reloaded.refreshTransactionHistory()
+        XCTAssertEqual(reloaded.transactionHistory.first?.state, .confirmed)
+        XCTAssertEqual(reloaded.transactionHistory.first?.blockNumber, "0x2a")
+        XCTAssertNil(reloaded.transactionHistory.first?.detail)
     }
 
     func testProviderScriptAnnouncesLocusWithoutImpersonatingOtherWallets() {

--- a/LocusTests/WorkspaceFileModelTests.swift
+++ b/LocusTests/WorkspaceFileModelTests.swift
@@ -41,8 +41,8 @@ final class WorkspaceFileModelTests: XCTestCase {
 
         isReady = true
         model.refresh()
-        for _ in 0..<20 where model.files.isEmpty {
-            await Task.yield()
+        for _ in 0..<40 where model.files.isEmpty {
+            try? await Task.sleep(for: .milliseconds(25))
         }
         XCTAssertEqual(model.files, [expected])
     }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ paid route.
 - **Works from your phone.** The optional [Locus Mobile](https://github.com/nahid-sparktales/locus-mobile) companion for iOS and Android pairs directly over your LAN or Tailscale, with no Locus cloud relay.
 - **Supports local and hosted models.** Use Ollama, a ChatGPT plan, OpenAI, Anthropic Claude, Moonshot Kimi, or an OpenAI-compatible endpoint.
 - **Stores work locally by default.** Sessions, run records, and encrypted memory live on your Mac. Hosted providers receive prompts only when you select them.
+- **Experiments with guarded wallet actions.** Direct-download builds can opt into a separate, limited-fund Locus Vault for Sepolia transfers and reviewed contract actions, with signer isolation, exact confirmations, and session-scoped budgets.
 
 ![Scheduled tasks in the Locus Activity Center](Docs/locus-schedules-dark.png)
 
@@ -137,9 +138,36 @@ The helpers behind ChatGPT-plan accounts are a separate download. They are large
 
 Direct-download builds from 1.14.0 onward check the stable release channel and can install signed updates when Locus quits. Mac App Store installations use the App Store update service.
 
-Experimental direct-download builds can enable the isolated, Sepolia-only
-[Locus Vault](Docs/WalletActivation.md). The feature is off by default;
-mainnet and external-wallet connectors remain security gated.
+### Experimental Locus Vault
+
+Direct-download builds can opt into the isolated, Sepolia-only
+[Locus Vault](Docs/WalletActivation.md). It creates a separate 24-word recovery
+phrase for limited test funds and keeps signing material inside a sandboxed,
+network-isolated XPC service. Every privileged request is bound to the active
+app session and its agent or browser source; the signer rechecks the prepared
+transaction immediately before signing.
+
+| Area | Current boundary |
+| --- | --- |
+| Vault | Creates a separate 24-word phrase and derives EVM, Solana, and Sui public accounts; decrypted keys never leave the signer |
+| Native EVM | Sepolia transfers, exact-confirmed registered-contract calls, finite ERC-20 transfers and approvals, and one narrow Universal Router V2 exact-input path |
+| Policy actions | Reviewed agent actions can use signer-owned limits for contract, asset, counterparty, amount, fee, expiry, and session totals; unknown effects and unlimited approvals require exact confirmation |
+| Browser provider | Session-scoped EIP-1193/EIP-6963 access for approved origins and Sepolia native transfers only; every browser transaction requires exact confirmation |
+| Activity | Stores bounded public transaction metadata, marks uncertain broadcasts, and reconciles receipt status without retaining raw signed transactions or secrets |
+| Solana and Sui | Derived public addresses are visible, but native signing remains disabled |
+| External wallets | MetaMask/Sepolia, Phantom/devnet, and Slush/Sui-testnet connector definitions exist; live connection buttons remain disabled |
+
+Locking the vault, sleeping, quitting, updating, relaunching, or losing the
+signer connection clears decrypted material, prepared transactions, origin
+grants, active policies, and session budgets. Saved policy templates contain
+no authorization and must be approved again after launch. Locus does not
+import MetaMask, Phantom, or Slush recovery phrases.
+
+The feature is off by default. EVM mainnet, native Solana and Sui signing, and
+live MetaMask, Phantom, and Slush connections remain security gated. See the
+[security gate](Docs/WalletSecurityGate.md) and
+[threat model](Docs/WalletThreatModel.md) for the current boundaries, reviewed
+adapters, verification requirements, and incident response plan.
 
 ## ChatGPT plan support
 

--- a/WalletSignerCore/src/lib.rs
+++ b/WalletSignerCore/src/lib.rs
@@ -557,6 +557,21 @@ mod tests {
     }
 
     #[test]
+    fn universal_router_outer_call_encodes_typed_bytes_array() {
+        let request = CString::new(
+            r#"{"normalized_abi":"[{\"type\":\"function\",\"name\":\"execute\",\"stateMutability\":\"payable\",\"inputs\":[{\"name\":\"commands\",\"type\":\"bytes\"},{\"name\":\"inputs\",\"type\":\"bytes[]\"},{\"name\":\"deadline\",\"type\":\"uint256\"}],\"outputs\":[]}]","function":"execute(bytes,bytes[],uint256)","arguments":[{"type":"bytes","value":"0x08"},{"type":"bytes[]","value":"[0x00]"},{"type":"uint256","value":"2000000000"}]}"#,
+        )
+        .unwrap();
+        let pointer = unsafe { locus_wallet_encode_contract_call_json(request.as_ptr()) };
+        let json = unsafe { CStr::from_ptr(pointer) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { locus_wallet_string_free(pointer) };
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value["input"].as_str().unwrap().starts_with("0x3593564c"));
+    }
+
+    #[test]
     fn registered_abi_call_rejects_mismatched_argument_type() {
         let request = CString::new(
             r#"{"normalized_abi":"[{\"type\":\"function\",\"name\":\"set\",\"stateMutability\":\"nonpayable\",\"inputs\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"outputs\":[]}]","function":"set(uint256)","arguments":[{"type":"address","value":"0x1111111111111111111111111111111111111111"}]}"#,

--- a/WalletSignerService/WalletSignerService.swift
+++ b/WalletSignerService/WalletSignerService.swift
@@ -86,7 +86,8 @@ private struct SignerActivePolicy {
 
 private enum SignerUnsignedInteger {
     static func normalize(_ value: String) -> String? {
-        guard !value.isEmpty, value.allSatisfy(\.isNumber) else { return nil }
+        guard !value.isEmpty,
+              value.utf8.allSatisfy({ (48...57).contains($0) }) else { return nil }
         let trimmed = value.drop(while: { $0 == "0" })
         return trimmed.isEmpty ? "0" : String(trimmed)
     }
@@ -255,6 +256,9 @@ private final class WalletVaultStore {
 }
 
 final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
+    private static let protocolVersion = 1
+    private static let maximumPreparedIntents = 32
+    private static let maximumActivePolicies = 32
     private let queue = DispatchQueue(label: "io.sparktales.locus.wallet-signer")
     private let store = WalletVaultStore()
     private var pendingEntropy: Data?
@@ -264,6 +268,13 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
     private var activeSessionID: String?
     private var preparedIntents: [String: StoredEVMIntent] = [:]
     private var activePolicies: [String: SignerActivePolicy] = [:]
+
+    func invalidateConnection() {
+        queue.async {
+            self.lockInMemory()
+            self.clearPending()
+        }
+    }
 
     func status(reply: @escaping (Data) -> Void) {
         queue.async { reply(self.encoded(self.currentStatus())) }
@@ -362,12 +373,13 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
 
     func encodeEVMContract(_ request: Data, reply: @escaping (Data) -> Void) {
         queue.async {
-            guard self.unlockedEntropy != nil else {
-                return reply(self.error("Locus Vault is locked."))
-            }
             do {
-                let request = try JSONDecoder().decode(WalletContractEncodingRequest.self, from: request)
-                reply(self.encoded(try self.authoritativeContractEncoding(request)))
+                let authorized: WalletAuthorizedRequest<WalletContractEncodingRequest> =
+                    try self.authorized(request)
+                guard authorized.source == .agent else {
+                    throw self.signerError("Browser requests cannot register or encode contract calls.")
+                }
+                reply(self.encoded(try self.authoritativeContractEncoding(authorized.payload)))
             } catch {
                 reply(self.error("Contract encoding failed: \(error.localizedDescription)"))
             }
@@ -376,11 +388,20 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
 
     func prepareEVM(_ request: Data, reply: @escaping (Data) -> Void) {
         queue.async {
-            guard let entropy = self.unlockedEntropy else {
-                return reply(self.error("Locus Vault is locked."))
-            }
             do {
-                let packet = try JSONDecoder().decode(WalletEVMPreparationPacket.self, from: request)
+                let authorized: WalletAuthorizedRequest<WalletEVMPreparationPacket> =
+                    try self.authorized(request)
+                let packet = authorized.payload
+                guard packet.request.source == authorized.source else {
+                    throw self.signerError("The request source changed before signer preparation.")
+                }
+                guard let entropy = self.unlockedEntropy else {
+                    throw self.signerError("Locus Vault is locked.")
+                }
+                self.expireIntents()
+                guard self.preparedIntents.count < Self.maximumPreparedIntents else {
+                    throw self.signerError("Too many wallet intents are pending for this session.")
+                }
                 let intent: StoredEVMIntent
                 switch packet.request.action.type {
                 case .nativeTransfer:
@@ -399,8 +420,13 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
     func simulateEVM(_ request: Data, reply: @escaping (Data) -> Void) {
         queue.async {
             do {
-                let recheck = try JSONDecoder().decode(WalletEVMRecheckPacket.self, from: request)
+                let authorized: WalletAuthorizedRequest<WalletEVMRecheckPacket> =
+                    try self.authorized(request)
+                let recheck = authorized.payload
                 var intent = try self.validatedIntent(for: recheck)
+                guard intent.prepared.source == authorized.source else {
+                    throw self.signerError("The request source changed before transaction recheck.")
+                }
                 intent.prepared = self.rechecked(intent.prepared, using: recheck)
                 self.preparedIntents[recheck.intentID] = intent
                 reply(self.encoded(intent.prepared))
@@ -410,31 +436,48 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
         }
     }
 
-    func confirmEVM(_ intentID: String, reply: @escaping (Data) -> Void) {
+    func confirmEVM(_ request: Data, reply: @escaping (Data) -> Void) {
         queue.async {
-            guard var intent = self.preparedIntents[intentID],
-                  intent.prepared.expiresAt > Date() else {
-                return reply(self.error("The prepared transaction is missing or expired."))
+            do {
+                let authorized: WalletAuthorizedRequest<String> = try self.authorized(request)
+                guard var intent = self.preparedIntents[authorized.payload],
+                      intent.prepared.expiresAt > Date(),
+                      intent.prepared.source == authorized.source else {
+                    throw self.signerError("The prepared transaction is missing, expired, or belongs to another source.")
+                }
+                intent.explicitlyApproved = true
+                self.preparedIntents[authorized.payload] = intent
+                reply(self.encoded(intent.prepared))
+            } catch {
+                reply(self.error("Transaction confirmation failed: \(error.localizedDescription)"))
             }
-            intent.explicitlyApproved = true
-            self.preparedIntents[intentID] = intent
-            reply(self.encoded(intent.prepared))
         }
     }
 
     func executeEVM(_ request: Data, reply: @escaping (Data) -> Void) {
         queue.async {
-            guard let entropy = self.unlockedEntropy else {
-                return reply(self.error("Locus Vault is locked."))
-            }
             do {
-                let recheck = try JSONDecoder().decode(WalletEVMRecheckPacket.self, from: request)
+                let authorized: WalletAuthorizedRequest<WalletEVMRecheckPacket> =
+                    try self.authorized(request)
+                guard let entropy = self.unlockedEntropy else {
+                    throw self.signerError("Locus Vault is locked.")
+                }
+                let recheck = authorized.payload
                 let validated = try self.validatedIntent(for: recheck)
+                guard validated.prepared.source == authorized.source else {
+                    throw self.signerError("The transaction belongs to another request source.")
+                }
                 let automaticPolicyID: String?
                 if validated.explicitlyApproved {
                     automaticPolicyID = nil
                 } else {
-                    automaticPolicyID = try self.validAutomaticPolicyID(for: validated.prepared)
+                    let currentPolicyID = try self.validAutomaticPolicyID(for: validated.prepared)
+                    guard currentPolicyID == validated.prepared.policyID else {
+                        throw self.signerError(
+                            "The autonomous policy changed after transaction preparation."
+                        )
+                    }
+                    automaticPolicyID = currentPolicyID
                 }
                 // Consume before signing. If signing or broadcasting later
                 // fails, this exact intent can never be replayed.
@@ -463,12 +506,19 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
 
     func activatePolicy(_ request: Data, reply: @escaping (Data) -> Void) {
         queue.async {
-            guard self.unlockedEntropy != nil else {
-                return reply(self.error("Locus Vault is locked."))
-            }
             do {
-                let policy = try JSONDecoder().decode(WalletSessionPolicy.self, from: request)
+                let authorized: WalletAuthorizedRequest<WalletSessionPolicy> =
+                    try self.authorized(request)
+                guard authorized.source == .agent else {
+                    throw self.signerError("Browser origins cannot activate autonomous policies.")
+                }
+                let policy = authorized.payload
                 try self.validatePolicy(policy)
+                self.expirePolicies()
+                guard self.activePolicies[policy.id] != nil
+                        || self.activePolicies.count < Self.maximumActivePolicies else {
+                    throw self.signerError("Too many wallet policies are active for this session.")
+                }
                 self.activePolicies[policy.id] = SignerActivePolicy(
                     policy: policy, spentBaseUnits: "0"
                 )
@@ -479,17 +529,33 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
         }
     }
 
-    func listPolicies(reply: @escaping (Data) -> Void) {
+    func listPolicies(_ request: Data, reply: @escaping (Data) -> Void) {
         queue.async {
-            self.expirePolicies()
-            reply(self.encoded(self.policyStatuses()))
+            do {
+                let authorized = try self.authorizedSession(request)
+                guard authorized.source == .agent else {
+                    throw self.signerError("Browser origins cannot inspect autonomous policies.")
+                }
+                self.expirePolicies()
+                reply(self.encoded(self.policyStatuses()))
+            } catch {
+                reply(self.error("Policy listing failed: \(error.localizedDescription)"))
+            }
         }
     }
 
-    func clearPolicies(reply: @escaping (Data) -> Void) {
+    func clearPolicies(_ request: Data, reply: @escaping (Data) -> Void) {
         queue.async {
-            self.activePolicies.removeAll(keepingCapacity: false)
-            reply(self.encoded([WalletActivePolicyStatus]()))
+            do {
+                let authorized = try self.authorizedSession(request)
+                guard authorized.source == .agent else {
+                    throw self.signerError("Browser origins cannot clear autonomous policies.")
+                }
+                self.activePolicies.removeAll(keepingCapacity: false)
+                reply(self.encoded([WalletActivePolicyStatus]()))
+            } catch {
+                reply(self.error("Policy clearing failed: \(error.localizedDescription)"))
+            }
         }
     }
 
@@ -522,7 +588,7 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
         else if pendingEntropy != nil { state = .awaitingBackup }
         else { state = store.exists ? .locked : .missing }
         return WalletSignerStatus(
-            protocolVersion: 1,
+            protocolVersion: Self.protocolVersion,
             vaultState: state,
             sessionID: activeSessionID,
             accounts: (try? store.accounts()) ?? []
@@ -593,6 +659,7 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
             digest: rust.digest,
             networkID: packet.request.networkID,
             accountID: packet.request.accountID,
+            source: packet.request.source,
             action: packet.request.action,
             summary: "Send \(amount) wei on Sepolia to \(recipient)",
             effects: [WalletDecodedEffect(
@@ -607,7 +674,8 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
             createdAt: now, expiresAt: now.addingTimeInterval(120),
             policyDecision: "exact_confirmation_required", policyID: nil
         )
-        if let policyID = try? validAutomaticPolicyID(for: prepared) {
+        if packet.request.source.kind == .agent,
+           let policyID = try? validAutomaticPolicyID(for: prepared) {
             prepared.policyDecision = "allowed_by_session_policy"
             prepared.policyID = policyID
         }
@@ -677,9 +745,10 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
             function: packet.request.action.function ?? "", abiDigest: entry.abiDigest,
             runtimeCodeHash: entry.runtimeCodeHash
         )
-        let prepared = WalletPreparedTransaction(
+        var prepared = WalletPreparedTransaction(
             id: intentID, digest: rust.digest, networkID: packet.request.networkID,
-            accountID: packet.request.accountID, action: packet.request.action,
+            accountID: packet.request.accountID, source: packet.request.source,
+            action: packet.request.action,
             summary: "Call \(entry.label).\(packet.request.action.function ?? "unknown") on Sepolia",
             effects: decoded.effects, riskFlags: decoded.riskFlags, contract: identity,
             adapterID: decoded.adapterID, budgetAssetID: decoded.budgetAssetID,
@@ -690,8 +759,11 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
             createdAt: now, expiresAt: now.addingTimeInterval(120),
             policyDecision: "exact_confirmation_required", policyID: nil
         )
-        // Contract policies are intentionally unavailable until their effect
-        // adapter and budget semantics pass a separate security gate.
+        if packet.request.source.kind == .agent,
+           let policyID = try? validAutomaticPolicyID(for: prepared) {
+            prepared.policyDecision = "allowed_by_session_policy"
+            prepared.policyID = policyID
+        }
         return StoredEVMIntent(transaction: packet.transaction, prepared: prepared)
     }
 
@@ -755,6 +827,7 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
     ) -> (effects: [WalletDecodedEffect], riskFlags: [WalletRiskFlag],
           adapterID: String?, budgetAssetID: String, spendBaseUnits: String) {
         let tokenAsset = "eip155:11155111/erc20:\(entry.checksumAddress.lowercased())"
+        let reviewedAdapterID = WalletReviewedAdapters.validatedID(for: entry)
         var effects: [WalletDecodedEffect] = []
         var riskFlags: [WalletRiskFlag] = [.unknownEffect]
         var adapterID: String?
@@ -770,7 +843,8 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
                 spender: nil
             )]
             riskFlags = []
-            adapterID = entry.reviewedAdapterID == "erc20-v1" ? "erc20-v1" : nil
+            adapterID = reviewedAdapterID == WalletReviewedAdapters.erc20
+                ? WalletReviewedAdapters.erc20 : nil
             budgetAssetID = tokenAsset
             spendBaseUnits = amount
         } else if action.function == "approve(address,uint256)", action.arguments.count == 2,
@@ -783,9 +857,30 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
                 spender: action.arguments[0].value
             )]
             riskFlags = amount == Self.maximumUInt256Decimal ? [.unlimitedApproval] : []
-            adapterID = entry.reviewedAdapterID == "erc20-v1" ? "erc20-v1" : nil
+            adapterID = reviewedAdapterID == WalletReviewedAdapters.erc20
+                ? WalletReviewedAdapters.erc20 : nil
             budgetAssetID = tokenAsset
             spendBaseUnits = amount
+        } else if reviewedAdapterID == WalletReviewedAdapters.uniswapUniversalRouterV2ExactIn,
+                  let swap = WalletUniversalRouterV2Adapter.decode(
+                    action: action, accountAddress: account.address
+                  ) {
+            effects = [
+                WalletDecodedEffect(
+                    id: "\(intentID):uniswap-spend", kind: "token_swap_exact_in",
+                    assetID: swap.inputAssetID, amountBaseUnits: swap.amountIn,
+                    from: account.address, to: entry.checksumAddress, spender: nil
+                ),
+                WalletDecodedEffect(
+                    id: "\(intentID):uniswap-minimum-receive", kind: "minimum_receive",
+                    assetID: swap.outputAssetID, amountBaseUnits: swap.minimumAmountOut,
+                    from: entry.checksumAddress, to: swap.recipient, spender: nil
+                ),
+            ]
+            riskFlags = []
+            adapterID = WalletReviewedAdapters.uniswapUniversalRouterV2ExactIn
+            budgetAssetID = swap.inputAssetID
+            spendBaseUnits = swap.amountIn
         } else {
             effects = [WalletDecodedEffect(
                 id: "\(intentID):contract-call", kind: "contract_call",
@@ -799,6 +894,10 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
                 amountBaseUnits: nativeValue, from: account.address,
                 to: entry.checksumAddress, spender: nil
             ))
+            // Reviewed token and swap adapters cover no native-value side
+            // effect. Such calls remain available only by exact confirmation.
+            riskFlags.append(.unknownEffect)
+            adapterID = nil
         }
         return (effects, riskFlags, adapterID, budgetAssetID, spendBaseUnits)
     }
@@ -808,16 +907,17 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
 
     private func validatePolicy(_ policy: WalletSessionPolicy) throws {
         let accounts = try store.accounts()
-        guard !policy.id.isEmpty,
+        guard !policy.id.isEmpty, policy.id.count <= 128,
               policy.networkID == "eip155:11155111",
               accounts.contains(where: { $0.id == policy.accountID && $0.chain == .evm }),
               policy.expiresAt > Date(),
               policy.expiresAt <= Date().addingTimeInterval(8 * 60 * 60),
-              policy.allowedAssetIDs == ["slip44:60"],
-              policy.allowedAdapterIDs == ["native-eth-transfer-v1"],
-              policy.allowedContractIDs.isEmpty,
               !policy.allowedRecipients.isEmpty,
+              policy.allowedRecipients.count <= 32,
               policy.allowedRecipients.allSatisfy(Self.isEVMAddress),
+              policy.allowedAssetIDs.count == 1,
+              policy.allowedAdapterIDs.count == 1,
+              policy.allowedContractIDs.count <= 1,
               SignerUnsignedInteger.normalize(policy.maximumTransactionBaseUnits) != nil,
               SignerUnsignedInteger.normalize(policy.maximumSessionBaseUnits) != nil,
               SignerUnsignedInteger.normalize(policy.maximumFeeBaseUnits) != nil,
@@ -825,28 +925,50 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
                   policy.maximumTransactionBaseUnits, policy.maximumSessionBaseUnits
               ) else {
             throw signerError(
-                "Phase-one policies must be Sepolia native-ETH budgets for explicit recipient addresses and expire within eight hours."
+                "Wallet policies require one reviewed adapter and asset, explicit EVM counterparties, bounded base-unit budgets, and an expiry within eight hours."
             )
+        }
+        let adapterID = policy.allowedAdapterIDs.first!
+        let nativePolicy = adapterID == "native-eth-transfer-v1"
+            && policy.allowedAssetIDs == ["slip44:60"]
+            && policy.allowedContractIDs.isEmpty
+        let contractPolicy = [
+            WalletReviewedAdapters.erc20,
+            WalletReviewedAdapters.uniswapUniversalRouterV2ExactIn,
+        ].contains(adapterID)
+            && policy.allowedContractIDs.count == 1
+            && policy.allowedAssetIDs.allSatisfy(Self.isSepoliaERC20AssetID)
+        guard nativePolicy || contractPolicy else {
+            throw signerError("The policy does not match a supported reviewed adapter shape.")
         }
     }
 
     private func validAutomaticPolicyID(for transaction: WalletPreparedTransaction) throws -> String {
         expirePolicies()
-        guard transaction.adapterID == "native-eth-transfer-v1",
-              transaction.budgetAssetID == "slip44:60",
+        guard transaction.source.kind == .agent,
+              let adapterID = transaction.adapterID,
+              ["native-eth-transfer-v1", WalletReviewedAdapters.erc20,
+               WalletReviewedAdapters.uniswapUniversalRouterV2ExactIn].contains(adapterID),
               transaction.riskFlags.isEmpty,
-              let recipient = transaction.action.recipient else {
+              let counterparties = policyCounterparties(for: transaction),
+              !counterparties.isEmpty else {
             throw signerError("This transaction has no reviewed autonomous effect adapter.")
         }
         for active in activePolicies.values.sorted(by: { $0.policy.id < $1.policy.id }) {
             let policy = active.policy
+            let contractMatches = transaction.contract.map {
+                policy.allowedContractIDs.contains($0.registryID)
+            } ?? policy.allowedContractIDs.isEmpty
             guard policy.accountID == transaction.accountID,
                   policy.networkID == transaction.networkID,
                   policy.allowedAssetIDs.contains(transaction.budgetAssetID),
-                  policy.allowedAdapterIDs.contains("native-eth-transfer-v1"),
-                  policy.allowedRecipients.contains(where: {
-                      $0.caseInsensitiveCompare(recipient) == .orderedSame
+                  policy.allowedAdapterIDs.contains(adapterID),
+                  counterparties.allSatisfy({ counterparty in
+                      policy.allowedRecipients.contains(where: {
+                          $0.caseInsensitiveCompare(counterparty) == .orderedSame
+                      })
                   }),
+                  contractMatches,
                   SignerUnsignedInteger.lessThanOrEqual(
                       transaction.spendBaseUnits, policy.maximumTransactionBaseUnits
                   ),
@@ -864,6 +986,31 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
             return policy.id
         }
         throw signerError("No active signer policy covers this exact transaction.")
+    }
+
+    private func policyCounterparties(for transaction: WalletPreparedTransaction) -> [String]? {
+        switch transaction.adapterID {
+        case "native-eth-transfer-v1":
+            return transaction.action.recipient.map { [$0] }
+        case WalletReviewedAdapters.erc20:
+            let values = transaction.effects.compactMap { effect -> String? in
+                if effect.kind == "token_transfer" { return effect.to }
+                if effect.kind == "approval" || effect.kind == "approval_revoke" {
+                    return effect.spender
+                }
+                return nil
+            }
+            return values
+        case WalletReviewedAdapters.uniswapUniversalRouterV2ExactIn:
+            guard transaction.action.arguments.count == 3,
+                  let deadline = UInt64(transaction.action.arguments[2].value),
+                  deadline >= UInt64(max(0, Date().timeIntervalSince1970.rounded(.down))) else {
+                return nil
+            }
+            return transaction.effects.filter { $0.kind == "minimum_receive" }.compactMap(\.to)
+        default:
+            return nil
+        }
     }
 
     private func reserveBudget(for transaction: WalletPreparedTransaction, policyID: String) throws {
@@ -885,6 +1032,11 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
         activePolicies = activePolicies.filter { $0.value.policy.expiresAt > now }
     }
 
+    private func expireIntents() {
+        let now = Date()
+        preparedIntents = preparedIntents.filter { $0.value.prepared.expiresAt > now }
+    }
+
     private func policyStatuses() -> [WalletActivePolicyStatus] {
         activePolicies.values.map(\.status).sorted { $0.policy.expiresAt < $1.policy.expiresAt }
     }
@@ -893,7 +1045,14 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
         value.count == 42 && value.hasPrefix("0x") && value.dropFirst(2).allSatisfy(\.isHexDigit)
     }
 
+    private static func isSepoliaERC20AssetID(_ value: String) -> Bool {
+        let prefix = "eip155:11155111/erc20:"
+        guard value.hasPrefix(prefix) else { return false }
+        return isEVMAddress(String(value.dropFirst(prefix.count)))
+    }
+
     private func validatedIntent(for recheck: WalletEVMRecheckPacket) throws -> StoredEVMIntent {
+        expireIntents()
         guard let intent = preparedIntents[recheck.intentID] else {
             throw signerError("The prepared transaction is missing or already consumed.")
         }
@@ -925,7 +1084,8 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
     ) -> WalletPreparedTransaction {
         WalletPreparedTransaction(
             id: prepared.id, digest: prepared.digest, networkID: prepared.networkID,
-            accountID: prepared.accountID, action: prepared.action, summary: prepared.summary,
+            accountID: prepared.accountID, source: prepared.source,
+            action: prepared.action, summary: prepared.summary,
             effects: prepared.effects, riskFlags: prepared.riskFlags, contract: prepared.contract,
             adapterID: prepared.adapterID, budgetAssetID: prepared.budgetAssetID,
             spendBaseUnits: prepared.spendBaseUnits,
@@ -998,6 +1158,52 @@ final class WalletSignerService: NSObject, WalletSignerXPCProtocol {
     private func signerError(_ message: String) -> NSError {
         NSError(domain: "WalletSigner", code: 3,
                 userInfo: [NSLocalizedDescriptionKey: message])
+    }
+
+    private func authorized<Payload: Codable & Equatable & Sendable>(
+        _ request: Data
+    ) throws -> WalletAuthorizedRequest<Payload> {
+        let authorized = try JSONDecoder().decode(WalletAuthorizedRequest<Payload>.self, from: request)
+        guard authorized.protocolVersion == Self.protocolVersion,
+              let activeSessionID,
+              unlockedEntropy != nil,
+              authorized.sessionID == activeSessionID,
+              validSource(authorized.source) else {
+            throw signerError("The wallet session is missing, stale, or belongs to another client.")
+        }
+        return authorized
+    }
+
+    private func authorizedSession(_ request: Data) throws -> WalletSessionRequest {
+        let authorized = try JSONDecoder().decode(WalletSessionRequest.self, from: request)
+        guard authorized.protocolVersion == Self.protocolVersion,
+              let activeSessionID,
+              unlockedEntropy != nil,
+              authorized.sessionID == activeSessionID,
+              validSource(authorized.source) else {
+            throw signerError("The wallet session is missing, stale, or belongs to another client.")
+        }
+        return authorized
+    }
+
+    private func validSource(_ source: WalletRequestSource) -> Bool {
+        switch source.kind {
+        case .agent:
+            return source.origin == nil
+        case .browser:
+            guard let origin = source.origin,
+                  let components = URLComponents(string: origin),
+                  let scheme = components.scheme?.lowercased(),
+                  ["http", "https"].contains(scheme),
+                  let host = components.host?.lowercased(), !host.isEmpty,
+                  components.path.isEmpty, components.query == nil, components.fragment == nil else {
+                return false
+            }
+            let standardPort = (scheme == "https" && components.port == 443)
+                || (scheme == "http" && components.port == 80)
+            let port = components.port.map { standardPort ? "" : ":\($0)" } ?? ""
+            return origin == "\(scheme)://\(host)\(port)"
+        }
     }
 
     private func lockInMemory() {

--- a/WalletSignerService/main.swift
+++ b/WalletSignerService/main.swift
@@ -1,13 +1,45 @@
 import Foundation
+import Security
 
 private final class WalletSignerListenerDelegate: NSObject, NSXPCListenerDelegate {
-    private let service = WalletSignerService()
+    private static let hostBundleIdentifier = "io.sparktales.locus"
+    private static let hostTeamIdentifier = "4X4RJA7GMD"
 
     func listener(_ listener: NSXPCListener, shouldAcceptNewConnection connection: NSXPCConnection) -> Bool {
+        guard Self.isTrustedHost(connection) else { return false }
+        let service = WalletSignerService()
         connection.exportedInterface = NSXPCInterface(with: WalletSignerXPCProtocol.self)
         connection.exportedObject = service
+        connection.interruptionHandler = { service.invalidateConnection() }
+        connection.invalidationHandler = { service.invalidateConnection() }
         connection.resume()
         return true
+    }
+
+    private static func isTrustedHost(_ connection: NSXPCConnection) -> Bool {
+        let attributes = [
+            kSecGuestAttributePid as String: NSNumber(value: connection.processIdentifier),
+        ] as CFDictionary
+        var guest: SecCode?
+        guard SecCodeCopyGuestWithAttributes(nil, attributes, [], &guest) == errSecSuccess,
+              let guest else { return false }
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(guest, [], &staticCode) == errSecSuccess,
+              let staticCode else { return false }
+        var rawInformation: CFDictionary?
+        guard SecCodeCopySigningInformation(
+            staticCode, SecCSFlags(rawValue: kSecCSSigningInformation), &rawInformation
+        ) == errSecSuccess,
+              let information = rawInformation as? [String: Any],
+              information[kSecCodeInfoIdentifier as String] as? String == hostBundleIdentifier else {
+            return false
+        }
+        let team = information[kSecCodeInfoTeamIdentifier as String] as? String
+        #if DEBUG
+        return team == nil || team == hostTeamIdentifier
+        #else
+        return team == hostTeamIdentifier
+        #endif
     }
 }
 


### PR DESCRIPTION
## Summary

- harden the isolated wallet signer with caller validation, per-connection sessions, source binding, bounded state, and fail-closed RPC validation
- add durable public activity and receipt reconciliation, reviewed ERC-20 and Universal Router adapters, exact signer-owned policy limits, and gated external connector foundations
- expand wallet settings, focused tests, activation/security documentation, the formal threat model, and README coverage

## Safety boundary

- remains off by default and direct-download only
- native EVM remains Sepolia only
- native Solana/Sui signing and live MetaMask, Phantom, and Slush connections remain gated

## Local verification

- focused Swift wallet tests: 26 passed
- Rust signer tests: 9 passed; fmt and clippy passed
- Python wallet bridge tests: 4 passed
- Release and ReleaseMAS builds passed from fresh derived data
- binary export audit, secret scan, and SBOM generation passed
- RustSec audit reported no vulnerabilities and the two documented transitive maintenance warnings
