### PR TITLE
docs(notebook): record why the caption is not muted

### DIFF
--- a/Locus/NotebookSheet.swift
+++ b/Locus/NotebookSheet.swift
@@ -36,11 +36,11 @@ struct NotebookSheet: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Notebook")
                     .font(.locus(size: 15, weight: .bold))
-                // The smallest text on this surface, and the only line that
-                // explains what the Notebook is. `muted` leaves it close enough
-                // to the contrast floor that antialiasing at 1x can push it
-                // under; secondary copy is the right weight for a caption this
-                // long anyway.
+                // `muted` nominally clears the contrast floor here, but at nine
+                // points its antialiased strokes never reach that colour: the
+                // pixels this caption actually draws measure 4.4:1 against the
+                // panel, under the 4.5:1 minimum. Secondary copy measures about
+                // 11.8:1 and is the right weight for prose in any case.
                 Text("Every note Locus has kept — one per workspace, one per chat, and one shared by all of them. Edits here are the same document the Notes panel shows.")
                     .font(.locus(size: 9))
                     .foregroundStyle(LocusTheme.textSecondary)


### PR DESCRIPTION
Follow-up to #40, correcting a comment I got wrong there.

#40 changed the Notebook caption from `muted` to secondary copy while chasing a
contrast audit failure, and explained it as antialiasing at 1x pushing a
compliant colour under the floor. Measuring the pixels each colour actually
draws shows something simpler:

| caption colour | rendered contrast | verdict |
| --- | --- | --- |
| `muted` (original) | **4.4:1** | under the 4.5:1 minimum |
| `textSecondary` (current) | ~11.8:1 | comfortably compliant |

At nine points `muted`'s antialiased strokes never reach the nominal colour that
would have cleared the floor, so the audit was right about the original. The
colour is therefore correct and stays; only the reason was wrong, and this
replaces it with the measurement.

Separately, the audit also flags the replacement at 11.8:1, which is the false
positive #40's handler measures before failing a run.

Comment-only change to app code.