### PR TITLE
ci(design-system): make the audit run, and ratchet instead of blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - run: brew install xcodegen
+      # ripgrep is what the design-system audit greps with. Without it that
+      # step found nothing, reported success, and checked nothing at all.
+      - run: brew install xcodegen ripgrep
       - run: xcodegen generate
       - name: Generated project is current
         run: git diff --exit-code -- Locus.xcodeproj/project.pbxproj

--- a/Tools/AuditDesignSystem.sh
+++ b/Tools/AuditDesignSystem.sh
@@ -1,47 +1,121 @@
 #!/bin/zsh
 
+# Design-system source audit.
+#
+# Each rule greps for a pattern the design system forbids and compares the
+# number of hits against a checked-in baseline. Anything above the baseline
+# fails; anything at or below it passes. That makes the audit a ratchet: the
+# violations already in the tree are tolerated while new ones are blocked, so
+# the check can be honest today rather than after a burn-down.
+#
+# Run with --update-baseline after removing violations to lock in the lower
+# number. Lowering a baseline is the only way it changes; nothing raises it
+# automatically.
+
 set -eu
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
+update_baseline=0
+for arg in "$@"; do
+    case "$arg" in
+        --update-baseline) update_baseline=1 ;;
+        *)
+            print -u2 "usage: ${0:t} [--update-baseline]"
+            exit 2
+            ;;
+    esac
+done
+
+# A check whose pass condition is "found nothing" has to prove its finder ran.
+# Without this, every rule below returned no matches and the audit reported
+# success on any machine without ripgrep — which is what CI did from the day
+# this script was added until the day this guard arrived.
+if ! command -v rg > /dev/null 2>&1; then
+    print -u2 "error: ${0:t} requires ripgrep; install it with 'brew install ripgrep'"
+    exit 2
+fi
+
+baseline_file="$repo_root/Tools/design-system-baseline.txt"
+
+typeset -A baseline
+if [[ -f "$baseline_file" ]]; then
+    while IFS=' ' read -r key value; do
+        [[ -z "$key" || "$key" == \#* ]] && continue
+        baseline[$key]="$value"
+    done < "$baseline_file"
+fi
+
+typeset -A observed
+typeset -a rule_order
 failed=0
 
 report_matches() {
-    local title="$1"
-    local matches="$2"
+    local key="$1"
+    local title="$2"
+    local matches="$3"
+    local -i count=0
     if [[ -n "$matches" ]]; then
+        local -a lines=("${(@f)matches}")
+        count=${#lines}
+    fi
+    observed[$key]=$count
+    rule_order+=("$key")
+    (( update_baseline )) && return 0
+
+    local -i allowed=${baseline[$key]:-0}
+    if (( count > allowed )); then
         print -u2 "error: $title"
+        print -u2 -- "  baseline allows $allowed, found $count"
         print -u2 -- "$matches"
         failed=1
+    elif (( count < allowed )); then
+        print "$title"
+        print -- "  improved: $count, baseline $allowed — rerun with --update-baseline to lock it in"
     fi
+    return 0
 }
 
-report_matches \
+report_matches swiftui-point-fonts \
     "Use LocusType or Font.locus instead of direct point-sized SwiftUI fonts." \
     "$(rg -n '\.font\(\.system\(size:|Font\.system\(size:' Locus --glob '*.swift' --glob '!Theme.swift' || true)"
 
-report_matches \
+report_matches appkit-small-fonts \
     "AppKit prose fonts must be at least 11 points." \
     "$(rg -n -P 'NSFont\.(?:systemFont|monospacedSystemFont)\(ofSize: (?:[0-9](?:\.[0-9]+)?|10(?:\.0+)?)\b' Locus --glob '*.swift' || true)"
 
-report_matches \
+report_matches plain-button-styles \
     "Use a shared Locus button style instead of plain or borderless styling." \
     "$(rg -n '\.buttonStyle\(\.(?:plain|borderless)\)' Locus --glob '*.swift' || true)"
 
-report_matches \
+report_matches custom-animations \
     "Route custom animations through LocusMotion." \
     "$(rg -n -P '(?:withAnimation|\.animation)\((?![^\n]*LocusMotion)' Locus --glob '*.swift' --glob '!Theme.swift' || true)"
 
-report_matches \
+report_matches move-transitions \
     "Route spatial transitions through LocusMotion.transition." \
     "$(rg -n '\.transition\(\.move' Locus --glob '*.swift' || true)"
 
-report_matches \
+report_matches repeat-forever \
     "Repeating animation belongs only in the central motion policy." \
     "$(rg -n 'repeatForever' Locus --glob '*.swift' --glob '!Theme.swift' || true)"
 
+if (( update_baseline )); then
+    {
+        print -- "# Design-system audit baseline: the number of existing violations"
+        print -- "# each rule is allowed. New violations fail CI; removing them and"
+        print -- "# rerunning Tools/AuditDesignSystem.sh --update-baseline lowers these."
+        for key in $rule_order; do
+            print -- "$key ${observed[$key]}"
+        done
+    } > "$baseline_file"
+    print "Baseline written to ${baseline_file:t}."
+    exit 0
+fi
+
 if (( failed )); then
+    print -u2 "Design-system audit failed: a rule has more violations than its baseline allows."
     exit 1
 fi
 

--- a/Tools/design-system-baseline.txt
+++ b/Tools/design-system-baseline.txt
@@ -1,0 +1,9 @@
+# Design-system audit baseline: the number of existing violations
+# each rule is allowed. New violations fail CI; removing them and
+# rerunning Tools/AuditDesignSystem.sh --update-baseline lowers these.
+swiftui-point-fonts 6
+appkit-small-fonts 3
+plain-button-styles 19
+custom-animations 0
+move-transitions 0
+repeat-forever 0


### PR DESCRIPTION
## The problem

Every rule in `Tools/AuditDesignSystem.sh` is built like this:

```bash
report_matches "…" "$(rg -n '…' Locus --glob '*.swift' || true)"
```

`report_matches` fails only when its argument is non-empty. ripgrep was never
installed on the runner, so every substitution came back empty, `|| true` kept
`set -e` quiet, and the step reported success without reading a line of source.
The runner log has said so since the audit was added:

```
Tools/AuditDesignSystem.sh:20: command not found: rg
```

"The tool didn't run" and "the code is clean" were indistinguishable. All six
rules have been passing vacuously.

## The change

- The `swift` job installs ripgrep.
- The script refuses to run without it, so the next missing tool fails loudly
  instead of silently.
- Each rule compares against a checked-in baseline: at or below passes, above
  fails. `--update-baseline` lowers the counts once violations are removed;
  nothing raises them automatically.

Enforcing the rules outright would fail the build on 28 pre-existing
violations, so this ratchets instead — new violations blocked from today, the
existing ones left for a separate decision. It is the same advisory shape the
"Reviewability report (advisory)" and "Rust advisory audit" steps already use.

## Why this cannot change Locus

No application code is touched. The baseline is seeded at exactly what the tree
already contains, so the audit passes on the current source:

| rule | baseline |
| --- | --- |
| `swiftui-point-fonts` | 6 |
| `appkit-small-fonts` | 3 |
| `plain-button-styles` | 19 |
| `custom-animations` | 0 |
| `move-transitions` | 0 |
| `repeat-forever` | 0 |

## Verified locally

| path | result |
| --- | --- |
| clean tree | passes, exit 0 |
| ripgrep absent | `error: … requires ripgrep`, exit 2 |
| one new violation added | fails, exit 1, prints the offending line |
| one violation removed | passes, reports the improvement |

## Not in this PR

Several of the 28 look like rule bugs rather than code bugs, and I would rather
fix the rules than contort code to satisfy them:

- All three `appkit-small-fonts` hits are a document exporter (`attributedDocument`,
  9.5pt detail text in an exported PDF) and generated image artwork
  (`"IN PROGRESS".draw`). Neither is on-screen prose, which is what the ≥11pt
  rule is for.
- `plain-button-styles` flags `Theme.swift` — the design system building its own
  control. The font and animation rules already exclude that file; this one
  does not.
- Ten of the nineteen are `Button("Edit")` / `Button("Delete")` in settings rows,
  where `.borderless` is the native idiom.

There is a real finding underneath the button rule worth its own look: `.plain`
drops `LocusButtonStyle`'s focus ring, so keyboard users lose focus indication
on those controls, and the accessibility audits do not catch that.