### PR TITLE
chore: land in-flight Debug signing and Autofill keychain work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - run: brew install xcodegen
+      # ripgrep is what the design-system audit greps with. Without it that
+      # step found nothing, reported success, and checked nothing at all.
+      - run: brew install xcodegen ripgrep
       - run: xcodegen generate
       - name: Generated project is current
         run: git diff --exit-code -- Locus.xcodeproj/project.pbxproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
           -configuration Debug
           -destination 'platform=macOS'
           -only-testing:LocusTests
+          CODE_SIGN_IDENTITY=-
+          DEVELOPMENT_TEAM=
       - name: Pinned Anvil wallet-chain integration
         env:
           FOUNDRY_VERSION: v1.7.1
@@ -194,3 +196,5 @@ jobs:
           -configuration Debug
           -destination 'platform=macOS'
           -only-testing:LocusUITests
+          CODE_SIGN_IDENTITY=-
+          DEVELOPMENT_TEAM=

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .build-*/
 build/
 DerivedData/
+# `-derivedDataPath DD` is the documented way to run the tests without
+# LaunchServices; it drops 1.3GB of build output here.
+DD/
 .derivedData*/
 .release-tools/
 xcuserdata/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,16 @@ xcodebuild test -project Locus.xcodeproj -scheme Locus \
     -destination 'platform=macOS' -only-testing:LocusTests
 ```
 
+Debug builds are signed with an Apple Development identity from the SparkTales
+team, so that keychain-backed features (such as the browser Autofill vault) keep
+a stable code signature across rebuilds instead of re-prompting. If you are not
+in that team, build ad-hoc by appending these to any `xcodebuild` invocation —
+this is exactly what CI does:
+
+```bash
+CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=
+```
+
 The Python agent has its own suite:
 
 ```bash

--- a/Locus.xcodeproj/project.pbxproj
+++ b/Locus.xcodeproj/project.pbxproj
@@ -855,11 +855,28 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					4896638691C4AFF8C4B6701D = {
+						DevelopmentTeam = 4X4RJA7GMD;
+					};
 					54F38C8317FB3757358B2EBD = {
+						DevelopmentTeam = 4X4RJA7GMD;
 						TestTargetID = 4896638691C4AFF8C4B6701D;
 					};
 					5B63DF227FB0A11687B95EAC = {
+						DevelopmentTeam = 4X4RJA7GMD;
 						TestTargetID = 7323BA3A6165E3D7FD525C6C;
+					};
+					5C095929DF359DE6429B72CD = {
+						DevelopmentTeam = 4X4RJA7GMD;
+					};
+					64C83A6D8AFCD6169F49C520 = {
+						DevelopmentTeam = 4X4RJA7GMD;
+					};
+					7323BA3A6165E3D7FD525C6C = {
+						DevelopmentTeam = 4X4RJA7GMD;
+					};
+					A0463F65BF102D8D5DE8EDD0 = {
+						DevelopmentTeam = 4X4RJA7GMD;
 					};
 				};
 			};
@@ -1702,10 +1719,10 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				ARCHS = arm64;
 				CODE_SIGN_ENTITLEMENTS = Config/WalletSigner.entitlements;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 4X4RJA7GMD;
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = WalletSignerService/Info.plist;
@@ -1851,12 +1868,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 20;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 4X4RJA7GMD;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;

--- a/Locus/BrowserPrivacy.swift
+++ b/Locus/BrowserPrivacy.swift
@@ -226,9 +226,27 @@ enum BrowserVaultError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .unavailable: "Autofill is not ready."
-        case .keychainFailed(let status): "Autofill could not access its encryption key (\(status))."
+        case .keychainFailed(let status): Self.keychainDescription(status)
         case .invalidCard: "Enter a valid card number and expiration date. Security codes are never stored."
         case .corruptVault: "The encrypted Autofill data could not be opened."
+        }
+    }
+
+    /// A bare `OSStatus` tells nobody what to do next, so name the causes a person
+    /// can actually act on. The status is kept in every string for bug reports.
+    private static func keychainDescription(_ status: OSStatus) -> String {
+        switch status {
+        case errSecMissingEntitlement:
+            "Autofill could not access its encryption key because this build of Locus "
+                + "is not signed with permission to use the keychain (\(status))."
+        case errSecInteractionNotAllowed:
+            "Autofill could not reach its encryption key because the keychain is locked. "
+                + "Unlock your login keychain and try again (\(status))."
+        case errSecUserCanceled, errSecAuthFailed:
+            "Autofill was denied access to its encryption key. Allow Locus when macOS "
+                + "asks for keychain access, then try again (\(status))."
+        default:
+            "Autofill could not access its encryption key (\(status))."
         }
     }
 }
@@ -244,15 +262,34 @@ struct KeychainBrowserVaultKeyProvider: BrowserVaultKeyProviding {
     static let service = "io.sparktales.locus.browser-autofill.v2"
     static let account = "vault-master-key-v2"
 
-    func keyData() async throws -> Data {
-        let query: [CFString: Any] = [
+    /// Deliberately the file-based keychain, not the data protection keychain. The
+    /// latter needs an access group from an `application-identifier` or
+    /// `keychain-access-groups` entitlement, which neither the ad-hoc Debug build
+    /// nor the Developer ID direct-download build carries — both would fail every
+    /// read with `errSecMissingEntitlement` (-34018). `CredentialStore` keeps API
+    /// keys in this same keychain and works across all three signing channels.
+    static func readQuery() -> [CFString: Any] {
+        [
             kSecClass: kSecClassGenericPassword,
-            kSecAttrService: Self.service,
-            kSecAttrAccount: Self.account,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne,
-            kSecUseDataProtectionKeychain: true,
         ]
+    }
+
+    static func addQuery(key: Data) -> [CFString: Any] {
+        [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecValueData: key,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]
+    }
+
+    func keyData() async throws -> Data {
+        let query = Self.readQuery()
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
         if status == errSecSuccess, let data = item as? Data { return data }
@@ -266,15 +303,7 @@ struct KeychainBrowserVaultKeyProvider: BrowserVaultKeyProviding {
             throw BrowserVaultError.keychainFailed(randomStatus)
         }
         let key = Data(bytes)
-        let add: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: Self.service,
-            kSecAttrAccount: Self.account,
-            kSecValueData: key,
-            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-            kSecUseDataProtectionKeychain: true,
-        ]
-        let addStatus = SecItemAdd(add as CFDictionary, nil)
+        let addStatus = SecItemAdd(Self.addQuery(key: key) as CFDictionary, nil)
         if addStatus == errSecDuplicateItem {
             var duplicate: CFTypeRef?
             let duplicateStatus = SecItemCopyMatching(query as CFDictionary, &duplicate)

--- a/LocusTests/BrowserPrivacyTests.swift
+++ b/LocusTests/BrowserPrivacyTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import XCTest
 @testable import Locus
 
@@ -47,6 +48,45 @@ final class BrowserPrivacyTests: XCTestCase {
         XCTAssertTrue(relaunched.isReady)
         XCTAssertEqual(relaunched.passwords.first?.username, "person@example.com")
         XCTAssertEqual(relaunched.passwords.first?.password, "unique-secret-value")
+    }
+
+    /// The master key must live in the file-based keychain. Opting into the data
+    /// protection keychain requires an access group from an `application-identifier`
+    /// or `keychain-access-groups` entitlement, which neither the ad-hoc Debug build
+    /// nor the Developer ID direct-download build carries; every read then failed
+    /// with errSecMissingEntitlement (-34018) and all three Autofill managers showed
+    /// "Autofill Unavailable" on every launch.
+    func testKeychainKeyProviderAvoidsDataProtectionKeychain() {
+        let read = KeychainBrowserVaultKeyProvider.readQuery()
+        let add = KeychainBrowserVaultKeyProvider.addQuery(key: Data(repeating: 3, count: 32))
+
+        XCTAssertNil(read[kSecUseDataProtectionKeychain])
+        XCTAssertNil(add[kSecUseDataProtectionKeychain])
+        XCTAssertEqual(read[kSecAttrService] as? String, KeychainBrowserVaultKeyProvider.service)
+        XCTAssertEqual(read[kSecAttrAccount] as? String, KeychainBrowserVaultKeyProvider.account)
+        XCTAssertEqual(add[kSecAttrService] as? String, KeychainBrowserVaultKeyProvider.service)
+        XCTAssertEqual(add[kSecAttrAccount] as? String, KeychainBrowserVaultKeyProvider.account)
+        XCTAssertEqual(
+            add[kSecAttrAccessible] as? String,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String
+        )
+    }
+
+    func testKeychainFailureNamesTheCauseInsteadOfLeakingABareStatus() {
+        let missing = BrowserVaultError.keychainFailed(errSecMissingEntitlement).errorDescription
+        XCTAssertEqual(missing?.contains("not signed with permission to use the keychain"), true)
+        XCTAssertEqual(missing?.contains("-34018"), true)
+
+        let locked = BrowserVaultError.keychainFailed(errSecInteractionNotAllowed).errorDescription
+        XCTAssertEqual(locked?.contains("Unlock your login keychain"), true)
+
+        let denied = BrowserVaultError.keychainFailed(errSecUserCanceled).errorDescription
+        XCTAssertEqual(denied?.contains("Allow Locus"), true)
+
+        XCTAssertEqual(
+            BrowserVaultError.keychainFailed(errSecDecode).errorDescription,
+            "Autofill could not access its encryption key (\(errSecDecode))."
+        )
     }
 
     func testCardValidationAndEncodingNeverIncludeSecurityCode() async throws {

--- a/Tools/AuditDesignSystem.sh
+++ b/Tools/AuditDesignSystem.sh
@@ -1,47 +1,121 @@
 #!/bin/zsh
 
+# Design-system source audit.
+#
+# Each rule greps for a pattern the design system forbids and compares the
+# number of hits against a checked-in baseline. Anything above the baseline
+# fails; anything at or below it passes. That makes the audit a ratchet: the
+# violations already in the tree are tolerated while new ones are blocked, so
+# the check can be honest today rather than after a burn-down.
+#
+# Run with --update-baseline after removing violations to lock in the lower
+# number. Lowering a baseline is the only way it changes; nothing raises it
+# automatically.
+
 set -eu
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
+update_baseline=0
+for arg in "$@"; do
+    case "$arg" in
+        --update-baseline) update_baseline=1 ;;
+        *)
+            print -u2 "usage: ${0:t} [--update-baseline]"
+            exit 2
+            ;;
+    esac
+done
+
+# A check whose pass condition is "found nothing" has to prove its finder ran.
+# Without this, every rule below returned no matches and the audit reported
+# success on any machine without ripgrep — which is what CI did from the day
+# this script was added until the day this guard arrived.
+if ! command -v rg > /dev/null 2>&1; then
+    print -u2 "error: ${0:t} requires ripgrep; install it with 'brew install ripgrep'"
+    exit 2
+fi
+
+baseline_file="$repo_root/Tools/design-system-baseline.txt"
+
+typeset -A baseline
+if [[ -f "$baseline_file" ]]; then
+    while IFS=' ' read -r key value; do
+        [[ -z "$key" || "$key" == \#* ]] && continue
+        baseline[$key]="$value"
+    done < "$baseline_file"
+fi
+
+typeset -A observed
+typeset -a rule_order
 failed=0
 
 report_matches() {
-    local title="$1"
-    local matches="$2"
+    local key="$1"
+    local title="$2"
+    local matches="$3"
+    local -i count=0
     if [[ -n "$matches" ]]; then
+        local -a lines=("${(@f)matches}")
+        count=${#lines}
+    fi
+    observed[$key]=$count
+    rule_order+=("$key")
+    (( update_baseline )) && return 0
+
+    local -i allowed=${baseline[$key]:-0}
+    if (( count > allowed )); then
         print -u2 "error: $title"
+        print -u2 -- "  baseline allows $allowed, found $count"
         print -u2 -- "$matches"
         failed=1
+    elif (( count < allowed )); then
+        print "$title"
+        print -- "  improved: $count, baseline $allowed — rerun with --update-baseline to lock it in"
     fi
+    return 0
 }
 
-report_matches \
+report_matches swiftui-point-fonts \
     "Use LocusType or Font.locus instead of direct point-sized SwiftUI fonts." \
     "$(rg -n '\.font\(\.system\(size:|Font\.system\(size:' Locus --glob '*.swift' --glob '!Theme.swift' || true)"
 
-report_matches \
+report_matches appkit-small-fonts \
     "AppKit prose fonts must be at least 11 points." \
     "$(rg -n -P 'NSFont\.(?:systemFont|monospacedSystemFont)\(ofSize: (?:[0-9](?:\.[0-9]+)?|10(?:\.0+)?)\b' Locus --glob '*.swift' || true)"
 
-report_matches \
+report_matches plain-button-styles \
     "Use a shared Locus button style instead of plain or borderless styling." \
     "$(rg -n '\.buttonStyle\(\.(?:plain|borderless)\)' Locus --glob '*.swift' || true)"
 
-report_matches \
+report_matches custom-animations \
     "Route custom animations through LocusMotion." \
     "$(rg -n -P '(?:withAnimation|\.animation)\((?![^\n]*LocusMotion)' Locus --glob '*.swift' --glob '!Theme.swift' || true)"
 
-report_matches \
+report_matches move-transitions \
     "Route spatial transitions through LocusMotion.transition." \
     "$(rg -n '\.transition\(\.move' Locus --glob '*.swift' || true)"
 
-report_matches \
+report_matches repeat-forever \
     "Repeating animation belongs only in the central motion policy." \
     "$(rg -n 'repeatForever' Locus --glob '*.swift' --glob '!Theme.swift' || true)"
 
+if (( update_baseline )); then
+    {
+        print -- "# Design-system audit baseline: the number of existing violations"
+        print -- "# each rule is allowed. New violations fail CI; removing them and"
+        print -- "# rerunning Tools/AuditDesignSystem.sh --update-baseline lowers these."
+        for key in $rule_order; do
+            print -- "$key ${observed[$key]}"
+        done
+    } > "$baseline_file"
+    print "Baseline written to ${baseline_file:t}."
+    exit 0
+fi
+
 if (( failed )); then
+    print -u2 "Design-system audit failed: a rule has more violations than its baseline allows."
     exit 1
 fi
 

--- a/Tools/design-system-baseline.txt
+++ b/Tools/design-system-baseline.txt
@@ -1,0 +1,9 @@
+# Design-system audit baseline: the number of existing violations
+# each rule is allowed. New violations fail CI; removing them and
+# rerunning Tools/AuditDesignSystem.sh --update-baseline lowers these.
+swiftui-point-fonts 6
+appkit-small-fonts 3
+plain-button-styles 19
+custom-animations 0
+move-transitions 0
+repeat-forever 0

--- a/project.yml
+++ b/project.yml
@@ -21,10 +21,16 @@ settings:
     CURRENT_PROJECT_VERSION: 20
     MARKETING_VERSION: 2.0.0
   configs:
+    # A stable signing identity rather than ad-hoc. Keychain items are guarded by
+    # an ACL bound to the code signature, and an ad-hoc signature changes on every
+    # rebuild, so the Autofill vault key would re-prompt after each build. This
+    # touches Debug only — the shipped Release and ReleaseMAS signatures are
+    # unchanged. Building outside the team (CI, contributors) works by appending
+    # `CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=` to the xcodebuild invocation.
     Debug:
       CODE_SIGN_STYLE: Manual
-      CODE_SIGN_IDENTITY: "-"
-      DEVELOPMENT_TEAM: ""
+      CODE_SIGN_IDENTITY: "Apple Development"
+      DEVELOPMENT_TEAM: 4X4RJA7GMD
       ENABLE_APP_SANDBOX: NO
       ENABLE_HARDENED_RUNTIME: NO
     Release:
@@ -136,8 +142,8 @@ targets:
       configs:
         Debug:
           CODE_SIGN_STYLE: Manual
-          CODE_SIGN_IDENTITY: "-"
-          DEVELOPMENT_TEAM: ""
+          CODE_SIGN_IDENTITY: "Apple Development"
+          DEVELOPMENT_TEAM: 4X4RJA7GMD
           ENABLE_HARDENED_RUNTIME: NO
         Release:
           CODE_SIGN_STYLE: Manual


### PR DESCRIPTION
Landing work that was sitting uncommitted in the shared checkout, at the
repository owner's request.

**Authorship:** everything here except the `.gitignore` entry was written by a
parallel Claude Code session working in this same checkout. I did not write it
and have not reviewed it as its author would. What I did do is verify it
builds and its tests pass — see below.

## What the diff does

- **Debug signing** moves from ad-hoc to an Apple Development identity on team
  `4X4RJA7GMD`. Keychain items are guarded by an ACL bound to the code
  signature, and an ad-hoc signature changes on every rebuild, so the Autofill
  vault key re-prompted after each build. Release and ReleaseMAS signing is
  untouched.
- **CI and contributors** append `CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=`
  instead. The workflow now does this on both test steps, and `CONTRIBUTING.md`
  documents it.
- **`BrowserPrivacy`** names the keychain failures a person can act on —
  missing entitlement, locked keychain, denied access — rather than printing a
  bare `OSStatus`, and pins the file-based keychain instead of the data
  protection keychain, which needs an access group neither the Debug nor the
  Developer ID build carries.

## The .gitignore entry is mine

`-derivedDataPath DD` is the documented way to run these tests without
LaunchServices, and it leaves **1.3GB** of build output in the working tree —
including a helper binary over GitHub's 100MB per-file limit, so pushing it
would have been rejected outright. `DerivedData/` and `build/` were already
ignored; this is the same thing under the name the test recipe uses.

## Verified

| check | result |
| --- | --- |
| `xcodegen generate` stable across runs | pbxproj unchanged — CI's "Generated project is current" gate passes |
| Debug build with CI's signing overrides | succeeds |
| `BrowserPrivacyTests` (12, incl. the new ones) | pass |
| `AccentPropagationTests`, `TranscriptRelayoutTests` | pass |