### PR TITLE
Close every turn with a written answer

### DIFF
--- a/Locus/MarkdownRenderer.swift
+++ b/Locus/MarkdownRenderer.swift
@@ -894,24 +894,27 @@ private struct MarkdownBlocksView: View {
     private func blockView(_ block: MarkdownRenderBlock, path: [Int]) -> some View {
         switch block {
         case .paragraph(let runs):
-            if let artifact = standaloneArtifact(in: runs) {
-                if artifact.kind == .image, let image = NSImage(contentsOf: artifact.url) {
-                    WorkspaceImageArtifactView(
-                        reference: artifact,
-                        image: image,
-                        caption: runs.map(\.text).joined(),
-                        selectionStore: selectionStore,
-                        selectionSpan: selectionSpan(at: path),
-                        onOpen: { open(artifact) }
-                    )
-                } else {
-                    WorkspaceArtifactCard(
-                        reference: artifact,
-                        selectionStore: selectionStore,
-                        selectionSpan: selectionSpan(at: path),
-                        onOpen: { open(artifact) }
-                    )
-                }
+            let artifact = standaloneArtifact(in: runs)
+            let artifactImage = artifact.flatMap { reference in
+                reference.kind == .image ? NSImage(contentsOf: reference.url) : nil
+            }
+            if let artifact, let artifactImage {
+                WorkspaceImageArtifactView(
+                    reference: artifact,
+                    image: artifactImage,
+                    caption: runs.map(\.text).joined(),
+                    selectionStore: selectionStore,
+                    selectionSpan: selectionSpan(at: path),
+                    onOpen: { open(artifact) }
+                )
+            } else if let artifact,
+                      MarkdownArtifactPromotion.allowsCard(nestingDepth: nestingDepth) {
+                WorkspaceArtifactCard(
+                    reference: artifact,
+                    selectionStore: selectionStore,
+                    selectionSpan: selectionSpan(at: path),
+                    onOpen: { open(artifact) }
+                )
             } else {
                 prose(runs, path: path)
             }
@@ -1191,6 +1194,17 @@ private struct MarkdownBlocksView: View {
 struct WorkspaceSourceLocation: Hashable, Sendable {
     let line: Int
     let column: Int?
+}
+
+/// Whether a standalone workspace reference earns its own block-level card.
+///
+/// A file card is 58pt of chrome with three buttons. One sitting in a paragraph
+/// is a useful artifact; one per bullet turns a seven-file listing into a wall
+/// of cards, so inside a list the reference stays an inline link instead.
+/// Images are content rather than chrome and are promoted at any depth by the
+/// caller before this is consulted.
+enum MarkdownArtifactPromotion {
+    static func allowsCard(nestingDepth: Int) -> Bool { nestingDepth == 0 }
 }
 
 enum WorkspaceArtifactKind: String, Hashable, Sendable {

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -1084,6 +1084,19 @@ final class FeatureLogicTests: XCTestCase {
         )
     }
 
+    func testFileCardsAreReservedForTopLevelReferences() {
+        // A reply that lists a directory writes one bullet per file. Promoting
+        // each of those to a 58pt card with three buttons turned a seven-file
+        // answer into a wall of chrome, which is what made the reply read as a
+        // raw dump rather than an answer.
+        XCTAssertTrue(MarkdownArtifactPromotion.allowsCard(nestingDepth: 0))
+        XCTAssertFalse(
+            MarkdownArtifactPromotion.allowsCard(nestingDepth: 1),
+            "inside a list the reference stays an inline, still-clickable link"
+        )
+        XCTAssertFalse(MarkdownArtifactPromotion.allowsCard(nestingDepth: 2))
+    }
+
     @MainActor
     func testWorkspacePreviewPublishesAndClearsSourceLocation() {
         let model = WorkspaceFileModel()

--- a/agent/ollama_code/agent_config.py
+++ b/agent/ollama_code/agent_config.py
@@ -9,10 +9,24 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-VALID_MODES = {"ask", "work", "plan", "build"}
+#: "build" is the retired GSD mode, kept so stored agent configs still parse.
+VALID_MODES = {"ask", "work", "plan", "grill", "build"}
 VALID_TONES = {"balanced", "direct", "warm", "analytical"}
 VALID_VERBOSITY = {"concise", "balanced", "detailed"}
 VALID_MEMORY_SCOPES = {"personal", "workspace", "agent"}
+
+#: How a turn is presented once the work is done. Locked, and deliberately
+#: static: the ChatGPT-native path fingerprints the developer layer it goes
+#: into, so anything per-turn in here would restart that thread every turn.
+ANSWER_CONTRACT = """Every turn ends with a written answer, for a reader who did not watch the tools run.
+
+- Lead with the direct answer in one or two sentences. Never open by restating the request.
+- Scale length to the work. A single lookup is one to three sentences. A turn that ran several tools gets a short write-up: what you did, what you found, what changed, and anything the user now has to decide.
+- Add structure only when the work has structure. Prose beats a list when there are fewer than three points.
+- A bare list of names, paths, or values is not an answer. Every bullet says what the item is or why it matters: `AppModel.swift` on its own is noise, while "`AppModel.swift` - the composition root, and the largest file here" answers something.
+- Cite what you actually observed: a path as `dir/file.swift:42`, the command you ran, the number you read. Never present an assumption as an observation, and say plainly when something was not verified.
+- Summarize tool output; never paste it back. No raw directory dumps, no reprinted file contents.
+- Close with concrete next steps only when real ones exist. Do not invent follow-up work to fill a section."""
 
 
 def _text(value: Any, default: str, limit: int) -> str:
@@ -233,6 +247,10 @@ def compose_system_prompt(
     sections: list[tuple[str, str]] = [("Locked runtime rules", locked_runtime)]
     if role_contract.strip():
         sections.append(("Locked role and access contract", role_contract.strip()))
+    if mode != "ask":
+        # Just Chat has no tools, so the presentation rules for tool work would
+        # only confuse it.
+        sections.append(("Locked answer contract", ANSWER_CONTRACT))
     sections.append(("Editable agent behavior", "\n\n".join(editable_parts)))
     if memory_context.strip():
         sections.append(("Approved memory", memory_context.strip()))

--- a/agent/ollama_code/core.py
+++ b/agent/ollama_code/core.py
@@ -40,7 +40,11 @@ from pathlib import Path
 from typing import Any
 
 from . import proxy
-from .agent_config import AgentConfiguration, compose_system_prompt
+from .agent_config import (
+    ANSWER_CONTRACT,
+    AgentConfiguration,
+    compose_system_prompt,
+)
 from .config import (
     DEFAULTS,
     MINIMUM_CONTEXT_WINDOW,
@@ -231,7 +235,7 @@ Rules:
 3. Use todo_write to plan and track tasks that need multiple steps.
 4. Paths are relative to the working directory unless they start with /.
 5. Keep going: after a tool result comes back, continue with the next step until the task is fully done, then stop calling tools and give your final answer.
-6. Be concise. Final answers: 1-3 short sentences saying what you did and which files changed.
+6. Finish every turn with a written final answer that follows the locked answer contract below.
 7. When the user states an explicit durable preference, repeats a lasting constraint, or confirms a decision or outcome, call propose_memory once so it appears in the review-only Memory Inbox. Never propose guesses, secrets, or transient task details.
 
 Environment:
@@ -250,6 +254,20 @@ Answer the user's question conversationally using only the conversation shown to
 
 "Locus" names this app, not the model. Your underlying model: {model_identity}. When asked which model or LLM you are, answer with that.
 """
+
+#: What the runtime says when a turn did the work and then said nothing. The
+#: instruction is request-only — see AgentCore._run_final_answer_pass.
+FINAL_ANSWER_NUDGE = (
+    "This turn ended without a written answer. Using only what it has already "
+    "established, write the final answer now, following the locked answer "
+    "contract. Do not call any tools and do not start new work."
+)
+
+#: A reply shorter than this, after a turn that ran at least
+#: FINAL_ANSWER_TOOL_FLOOR tools, is a fragment rather than an answer. One tool
+#: call and a short sentence is a legitimately terse turn and is left alone.
+FINAL_ANSWER_MIN_CHARS = 40
+FINAL_ANSWER_TOOL_FLOOR = 3
 
 INIT_PROMPT = (
     "Analyze this project and create an OLLAMA.md file that will help future AI "
@@ -1384,6 +1402,7 @@ class AgentCore:
                 "submit_plan tool exactly once with your final implementation "
                 "plan. Do not modify any files in this mode."
             )
+        sections.append("## Locus answer contract\n" + ANSWER_CONTRACT)
         return "\n\n".join(sections)
 
     def start_new_session(
@@ -2075,16 +2094,20 @@ class AgentCore:
                     event_handler=handle_event,
                     should_interrupt=self._interrupt.is_set,
                 )
-                # A disconnect can omit the terminal notification after valid
-                # deltas. Finalize those partial items in first-seen order so
-                # the transcript never keeps a dangling streaming row.
-                for state in assistant_items.values():
-                    if state["ended"]:
-                        continue
-                    if state["kind"] == "message":
-                        finish_message(state)
-                    else:
-                        finish_reasoning(state)
+                def finalize_items() -> None:
+                    # A disconnect can omit the terminal notification after
+                    # valid deltas. Finalize those partial items in first-seen
+                    # order so the transcript never keeps a dangling streaming
+                    # row.
+                    for state in list(assistant_items.values()):
+                        if state["ended"]:
+                            continue
+                        if state["kind"] == "message":
+                            finish_message(state)
+                        else:
+                            finish_reasoning(state)
+
+                finalize_items()
                 if not any(
                     state["kind"] == "message" for state in assistant_items.values()
                 ):
@@ -2096,6 +2119,30 @@ class AgentCore:
                         "content": "",
                         "_phase": "final_answer",
                     })
+                if self._needs_final_answer_pass(
+                    reason=reason, tool_calls=dynamic_call_count
+                ):
+                    # The helper thread already holds this whole turn, so the
+                    # write-up is one more turn on it with no tools attached —
+                    # not a rebuilt request. Its own failure must not lose the
+                    # work that already succeeded, so it is caught here rather
+                    # than by the turn's handler, which would clear the thread.
+                    try:
+                        manager.run_turn(
+                            thread_id=self._chatgpt_thread_id,
+                            text=FINAL_ANSWER_NUDGE,
+                            model=self.model,
+                            effort=effort,
+                            tool_handler=None,
+                            event_handler=handle_event,
+                            should_interrupt=self._interrupt.is_set,
+                        )
+                        finalize_items()
+                    except (CodexAppServerError, RuntimeError, ValueError):
+                        self._emit({
+                            "type": "note",
+                            "text": "Locus could not write a closing summary for this turn.",
+                        })
                 last = usage.get("last") if isinstance(usage.get("last"), dict) else {}
                 prompt = int(last.get("inputTokens") or 0)
                 completion = int(last.get("outputTokens") or 0)
@@ -2467,6 +2514,70 @@ class AgentCore:
     #: Shorter alias used by the WebSocket handler.
     retry_last = retry_last_response
 
+    def _last_final_answer_text(self) -> str:
+        """This turn's visible answer, or "" when it never wrote one.
+
+        Walks back only as far as the current turn: a user message ends the
+        search, and so does a tool result, which in the classic loop is what
+        sits after an assistant message that only asked for tools.
+        """
+        for message in reversed(self.messages):
+            role = str(message.get("role") or "")
+            if role in {"user", "tool"}:
+                break
+            if role != "assistant":
+                continue
+            if message.get("_display_only"):
+                continue
+            if str(message.get("_phase") or "final_answer") != "final_answer":
+                # Codex commentary is narration between tool calls, not the
+                # answer; keep looking back through this turn.
+                continue
+            if message.get("tool_calls"):
+                break
+            return str(message.get("content") or "").strip()
+        return ""
+
+    def _needs_final_answer_pass(self, *, reason: str, tool_calls: int) -> bool:
+        """Whether this turn worked and then failed to say anything about it."""
+        if reason != "complete" or tool_calls <= 0:
+            return False
+        if self._interrupt.is_set() or not self._turn_allows_tools:
+            return False
+        if self.agent_role_contract or self._suppress_turn_done:
+            # Team workers and background runs are collected programmatically.
+            # Nobody is reading a write-up, and an extra call would be spent on
+            # text that is thrown away.
+            return False
+        text = self._last_final_answer_text()
+        if not text:
+            return True
+        return (
+            tool_calls >= FINAL_ANSWER_TOOL_FLOOR
+            and len(text) < FINAL_ANSWER_MIN_CHARS
+        )
+
+    def _run_final_answer_pass(self) -> bool:
+        """One tool-free call that writes the answer the turn owed the user."""
+        resp = self._stream_response(
+            extra_messages=[{"role": "user", "content": FINAL_ANSWER_NUDGE}],
+            disable_tools=True,
+        )
+        if resp is None:
+            # An error or a partial reply already reached the conversation.
+            return False
+        text = strip_think(resp.content).strip()
+        if not text:
+            return False
+        self._add_message({
+            "role": "assistant",
+            "content": text,
+            "_phase": "final_answer",
+        })
+        self.total_prompt_tokens += resp.prompt_eval_count
+        self.total_completion_tokens += resp.eval_count
+        return True
+
     def _run_response_loop(
         self,
         decider: PermissionDecider | None = None,
@@ -2479,6 +2590,7 @@ class AgentCore:
         completion_tokens_before = self.total_completion_tokens
         reason = "complete"
         iteration = 0
+        tool_calls_run = 0
         iteration_limit = self.max_iterations
         hard_call_limit = max(int(model_call_limit), 0) if model_call_limit is not None else None
         while iteration < iteration_limit and (hard_call_limit is None or iteration < hard_call_limit):
@@ -2605,6 +2717,7 @@ class AgentCore:
                     steered = True
                     break
                 self._in_tool_call = True
+                tool_calls_run += 1
                 try:
                     result = self._run_tool_call(tc, decider)
                 finally:
@@ -2655,6 +2768,9 @@ class AgentCore:
         # accepted before this point is either applied above or caused another
         # loop iteration; anything later belongs in Queue or Stop & Send.
         self.end_steerable_turn()
+        if self._needs_final_answer_pass(reason=reason, tool_calls=tool_calls_run):
+            if self._run_final_answer_pass():
+                iteration += 1
         terminal = {
             "type": "turn_done",
             "reason": reason,
@@ -2740,7 +2856,18 @@ class AgentCore:
         self,
         allow_overflow_retry: bool = True,
         allow_image_retry: bool = True,
+        *,
+        extra_messages: list[dict[str, Any]] | None = None,
+        disable_tools: bool = False,
     ) -> ChatResponse | None:
+        """Stream one model call.
+
+        ``extra_messages`` are appended to the request only: they never enter
+        ``self.messages``, so a one-off instruction cannot leak into the
+        conversation the next turn replays. ``disable_tools`` withholds the
+        schemas without touching ``_turn_allows_tools``, which would swap the
+        Just Chat system prompt in underneath.
+        """
         self._emit({"type": "message_start"})
         think_filter = ThinkFilter()
         inline_thinking: list[str] = []
@@ -2785,8 +2912,12 @@ class AgentCore:
             try:
                 resp = self.client.chat_stream(
                     model=self.model,
-                    messages=self._request_messages(),
-                    tools=self.tool_registry.schemas() if self._turn_allows_tools else [],
+                    messages=self._request_messages() + list(extra_messages or []),
+                    tools=(
+                        []
+                        if disable_tools or not self._turn_allows_tools
+                        else self.tool_registry.schemas()
+                    ),
                     on_token=on_token,
                     should_stop=self._should_stop_stream,
                     on_thinking=on_thinking,
@@ -2840,6 +2971,8 @@ class AgentCore:
                 return self._stream_response(
                     allow_overflow_retry=allow_overflow_retry,
                     allow_image_retry=False,
+                    extra_messages=extra_messages,
+                    disable_tools=disable_tools,
                 )
             if (
                 allow_overflow_retry
@@ -2865,6 +2998,8 @@ class AgentCore:
                 return self._stream_response(
                     allow_overflow_retry=False,
                     allow_image_retry=allow_image_retry,
+                    extra_messages=extra_messages,
+                    disable_tools=disable_tools,
                 )
             if partial:
                 visible_text.append(partial)

--- a/agent/tests/test_agent_config.py
+++ b/agent/tests/test_agent_config.py
@@ -1,6 +1,10 @@
 from ollama_code import server as server_mod
 from ollama_code import tool_registry
-from ollama_code.agent_config import AgentConfiguration, compose_system_prompt
+from ollama_code.agent_config import (
+    ANSWER_CONTRACT,
+    AgentConfiguration,
+    compose_system_prompt,
+)
 from ollama_code.core import AgentCore
 from ollama_code.orchestration import AgentProfile
 
@@ -53,14 +57,44 @@ def test_composer_keeps_locked_identity_and_safety_in_separate_first_layer():
     assert [layer["name"] for layer in layers] == [
         "Locked runtime rules",
         "Locked role and access contract",
+        "Locked answer contract",
         "Editable agent behavior",
         "Approved memory",
         "Workspace instructions from AGENTS.md",
     ]
-    assert [layer["editable"] for layer in layers] == [False, False, True, False, False]
+    assert [layer["editable"] for layer in layers] == [
+        False, False, False, True, False, False,
+    ]
     assert prompt.index("ActualModel") < prompt.index("FakeModel")
     assert "Never exceed granted permissions" in layers[0]["content"]
-    assert "Prefer small, verified patches" in layers[2]["content"]
+    assert "Prefer small, verified patches" in layers[3]["content"]
+
+
+def test_answer_contract_is_locked_for_tool_modes_and_absent_from_just_chat():
+    """Just Chat has no tools, so rules about presenting tool work confuse it."""
+    config = AgentConfiguration.parse({
+        "custom_instructions": "Answer with a single word and nothing else.",
+    })
+
+    for mode in ("work", "plan", "build"):
+        prompt, layers = compose_system_prompt("Locked.", config, mode=mode)
+        contract = next(
+            layer for layer in layers if layer["name"] == "Locked answer contract"
+        )
+        assert contract["editable"] is False
+        assert contract["content"] == ANSWER_CONTRACT
+        assert "A bare list of names, paths, or values is not an answer" in prompt
+        # The editable layer cannot quietly cancel it: the contract is composed
+        # into the locked half, which the runtime declares outranks user text.
+        assert prompt.index("Locked answer contract") < prompt.index(
+            "Answer with a single word"
+        )
+
+    chat_prompt, chat_layers = compose_system_prompt("Locked.", config, mode="ask")
+    assert not [
+        layer for layer in chat_layers if layer["name"] == "Locked answer contract"
+    ]
+    assert "A bare list of names" not in chat_prompt
 
 
 def test_agent_configuration_round_trips_as_versioned_additive_payload():

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -2742,7 +2742,9 @@ def test_reading_outside_the_workspace_requires_permission(tmp_path):
             tool_calls=[ToolCall("glob", {"pattern": str(secret.parent / "*")})],
             done=True,
         ),
-        ChatResponse(content_parts=["done"], done=True),
+        ChatResponse(content_parts=[
+            "Read `inside.txt`. Both paths outside the workspace were denied."
+        ], done=True),
     ])
     events = []
     core.on_event(events.append)
@@ -4448,6 +4450,95 @@ def test_system_prompt_names_the_underlying_model(tmp_path):
     assert "Underlying model: test-model via local Ollama" in message
     assert "names this agent, not the model" in message
     assert "call propose_memory once" in message
+
+
+def test_answer_contract_reaches_both_prompt_paths_but_not_just_chat(tmp_path):
+    """The screenshot case: ChatGPT-native sends no Locus system prompt at all."""
+    core = _core(tmp_path, [])
+
+    work = core.system_message()["content"]
+    assert "A bare list of names, paths, or values is not an answer" in work
+    assert "follows the locked answer contract" in work
+
+    assert "A bare list of names" not in core.system_message(mode="ask")["content"]
+
+    # The native-prompt route drops the system message entirely, so the
+    # contract has to ride in the developer layer or it never arrives.
+    assert "A bare list of names" in core._parity_developer_instructions()
+
+
+def test_a_turn_that_works_and_says_nothing_gets_one_written_answer(tmp_path):
+    from ollama_code.core import FINAL_ANSWER_NUDGE
+    from ollama_code.ollama import ToolCall
+
+    (tmp_path / "notes.md").write_text("hi")
+    listing = ChatResponse(tool_calls=[ToolCall("list_dir", {"path": "."})], done=True)
+    core = _core(tmp_path, [
+        listing,
+        ChatResponse(tool_calls=[ToolCall("list_dir", {"path": "."})], done=True),
+        ChatResponse(tool_calls=[ToolCall("list_dir", {"path": "."})], done=True),
+        ChatResponse(content_parts=[], done=True),
+        ChatResponse(content_parts=["The workspace holds one file, notes.md."], done=True),
+    ])
+    events = []
+    core.on_event(events.append)
+
+    core.run_turn("what is in here")
+
+    assert core.client.calls == 5
+    assert core.messages[-1]["content"] == "The workspace holds one file, notes.md."
+    assert core.messages[-1]["_phase"] == "final_answer"
+    # Tool-free, so the write-up cannot start new work.
+    assert core.client.seen_tools[-1] == []
+    assert core.client.seen_messages[-1][-1] == {
+        "role": "user", "content": FINAL_ANSWER_NUDGE,
+    }
+    # …and the instruction is request-only: replaying this conversation next
+    # turn must not show the user asking for a summary they never asked for.
+    assert not [m for m in core.messages if m.get("content") == FINAL_ANSWER_NUDGE]
+    done = next(e for e in events if e["type"] == "turn_done")
+    assert done["reason"] == "complete"
+    assert done["model_calls"] == 5
+
+
+def test_the_written_answer_pass_stays_out_of_turns_that_already_answered(tmp_path):
+    from ollama_code.ollama import ToolCall
+
+    (tmp_path / "notes.md").write_text("hi")
+
+    def listing():
+        return ChatResponse(tool_calls=[ToolCall("list_dir", {"path": "."})], done=True)
+
+    answered = _core(tmp_path, [
+        listing(), listing(), listing(),
+        ChatResponse(content_parts=[
+            "One file: `notes.md`, two bytes, unchanged since you asked."
+        ], done=True),
+    ])
+    answered.run_turn("what is in here")
+    assert answered.client.calls == 4
+
+    # One tool call and a short sentence is a legitimately terse turn.
+    terse = _core(tmp_path, [
+        listing(),
+        ChatResponse(content_parts=["Just notes.md."], done=True),
+    ])
+    terse.run_turn("what is in here")
+    assert terse.client.calls == 2
+
+    # No tools ran, so there is no work to write up.
+    chatted = _core(tmp_path, [ChatResponse(content_parts=["Hi."], done=True)])
+    chatted.run_turn("hi")
+    assert chatted.client.calls == 1
+
+    # A team worker's output is collected programmatically, not read.
+    worker = _core(tmp_path, [
+        listing(), listing(), listing(),
+        ChatResponse(content_parts=[], done=True),
+    ])
+    worker.agent_role_contract = "Read-only research worker."
+    worker.run_turn("what is in here")
+    assert worker.client.calls == 4
 
 
 def test_model_switch_refreshes_the_identity_mid_conversation(tmp_path):
@@ -6687,7 +6778,9 @@ def test_mid_turn_eviction_keeps_tool_pairing_and_the_newest_result(tmp_path, mo
             ToolCall("read_file", {"path": "b"}),
             ToolCall("read_file", {"path": "c"}),
         ], done=True),
-        ChatResponse(content_parts=["done"], done=True),
+        ChatResponse(content_parts=[
+            "Read all three files; the oldest results no longer fit the window."
+        ], done=True),
     ])
     core.client.loaded_window = 8_192
     # A model whose ceiling *is* 8k, so the pin cannot raise the window and the


### PR DESCRIPTION
Asking Locus *"what's in the directory and what's the model"* came back as a bare file listing and a `Model:` line — no write-up. Claude Code and Codex both close a turn with a synthesized answer; Locus did not.

## Why it happened

**The locked prompt forbade it.** `BASE_SYSTEM_PROMPT` rule 6 asked for "1-3 short sentences". That sits in the locked layer, which `compose_system_prompt` declares outranks editable behavior — so the "Detail level" control in Agent Teams settings could never widen it. A setting that reads as user-configurable was dead on arrival.

**The ChatGPT-native route never saw a Locus prompt at all.** Under parity the system message is dropped in favour of Codex's own, and only `_parity_developer_instructions` reaches the model. It carried AGENTS.md and the mode notes, and nothing about how to present work.

**The renderer amplified it.** A paragraph whose entire content is one workspace file reference is promoted to a 58pt `WorkspaceArtifactCard`. Once per bullet, a seven-file listing became ~450pt of chrome with the filenames buried inside it.

## What changed

- One `ANSWER_CONTRACT`, composed into both routes — a locked, non-editable layer everywhere except Just Chat, which has no tools and would only be confused by rules for presenting them. Deliberately static: the native route fingerprints the developer layer.
- A tool-free fallback call, fired only when a turn ran tools and then wrote nothing, or wrote under 40 characters after 3+ tools. The instruction rides in `extra_messages` and never enters `self.messages`. Team workers and background runs are excluded.
- File cards reserved for `nestingDepth == 0`. Inside a list the reference falls through to `prose`, where it stays a clickable `locus-workspace://` link and loses only the chrome. Images still promote at any depth.

## Verification

`pytest` 649 passed (645 on main + 4 new). `ruff` and `Tools/AuditDesignSystem.sh` clean. The new Swift test passes via the XCTest-injection route.

End to end against a local Ollama model, same prompt as the report:

> The directory has five items: `AGENTS.md` (workspace instructions), `data.csv`, `stock.py` and `test_stock.py` (likely a small Python module with its tests), and `report.pdf`.
>
> I'm running as the ollama-code agent using the underlying model davidau-qwen3.6-27b-fable:Q4_K_M via local Ollama.

Lead sentence, annotated items, both halves answered, no card wall. The fallback correctly stayed out of that turn.

## Note for reviewers

Managed ChatGPT accounts will rebuild their Codex thread once on the first turn after this, because the developer layer is fingerprinted. The canonical Locus transcript already handles that path.

The ChatGPT-native route is verified by unit test, not by a live managed session.