### PR TITLE
Runs panel: report what a run actually did

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@
 
 ### Changed
 
+- **New ChatGPT plans now answer with Locus's tools.** Adding a ChatGPT account
+  starts it under the Locus contract — Locus's own prompt and tool registry,
+  with approved memories, cross-chat context, and the skill index — instead of
+  Codex-native parity. ChatGPT accounts you already added are untouched and
+  keep answering exactly as they did; flipping that switch restarts a
+  conversation's server-side context, so it stays your call. "Codex-native
+  mode" is still one toggle away in the account editor, for either direction.
+
 - **Reasoning and tool activity now stay in transcript order.** Collapsed mode
   uses quiet inline summary disclosures at each real activity boundary, while
   Expanded reasoning and Verbose tools retain their detailed cards. Each turn

--- a/Locus/AccountEditorView.swift
+++ b/Locus/AccountEditorView.swift
@@ -21,7 +21,10 @@ struct AccountEditorView: View {
     @State private var testResult: String?
     @State private var testFailed = false
     @State private var contextWindow = ""
-    @State private var nativeMode = true
+    // Overwritten from the account on appear; the initial value only decides
+    // what a new ChatGPT account paints for one frame, so it matches the
+    // initialiser's default rather than contradicting it.
+    @State private var nativeMode = false
     @State private var webSearch = false
     @State private var reasoningEffort = ""
     @State private var focusedField: FocusedField?
@@ -273,7 +276,7 @@ struct AccountEditorView: View {
 
             Toggle("Codex-native mode", isOn: $nativeMode)
                 .accessibilityIdentifier("accountEditor.chatGPT.nativeMode")
-            Text("Answers match OpenAI's Codex: native prompt and tools, no Locus memory or skills on this account's chats. Changing this restarts conversation context.")
+            Text("Off by default: this account's chats use Locus's prompt, tools, memory, and skills. Turn it on to match OpenAI's Codex instead — native prompt and tools, and no Locus memory or skills here. Changing this restarts conversation context.")
                 .font(.locus(size: 9))
                 .foregroundStyle(LocusTheme.muted)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Locus/AgentTeams.swift
+++ b/Locus/AgentTeams.swift
@@ -1423,6 +1423,73 @@ struct OrchestrationEvent: Identifiable, Codable, Hashable {
     func text(_ key: String) -> String? { values[key]?.string }
 }
 
+/// What a run actually did, folded out of its own durable event log.
+///
+/// The Runs panel used to answer "which files did this touch?" from live git
+/// status, which meant a run that had already finished showed nothing at all.
+/// Every fact here is already persisted per run — `tool_result` carries the tool
+/// name, its outcome, and `file_effects` — so history reads the same as a run
+/// that is still going.
+struct RunWork: Equatable {
+    struct FileChange: Identifiable, Equatable {
+        let path: String
+        /// Reader-facing wording, not the wire value: `created` or `edited`.
+        let effect: String
+        var id: String { path }
+    }
+
+    struct Command: Identifiable, Equatable {
+        let id: String
+        let summary: String
+        let ok: Bool
+    }
+
+    var files: [FileChange] = []
+    var commands: [Command] = []
+    /// Tools the run ran. The count a reader recognises as "how much happened",
+    /// and the fallback for runs recorded before the agent reported it.
+    var toolSteps = 0
+    /// Set when delegation could not be armed at all, which reads nothing like
+    /// an agent that simply saw no reason to split the work.
+    var delegationUnavailable = false
+    var isEmpty: Bool { files.isEmpty && commands.isEmpty }
+
+    init() {}
+
+    init(events: [OrchestrationEvent]) {
+        var effects: [String: String] = [:]
+        var order: [String] = []
+        for event in events where !event.isTransientStream {
+            if event.type == "note",
+               event.values["solo_swarm_unavailable"]?.boolean == true {
+                delegationUnavailable = true
+            }
+            guard event.type == "tool_result" else { continue }
+            toolSteps += 1
+            let ok = event.values["ok"]?.boolean ?? true
+            if event.text("tool") == "bash", let summary = event.text("summary") {
+                commands.append(Command(id: event.id, summary: summary, ok: ok))
+            }
+            guard ok, case .array(let raw)? = event.values["file_effects"] else { continue }
+            for item in raw {
+                guard case .object(let object) = item,
+                      let path = object["path"]?.string, !path.isEmpty else { continue }
+                if effects[path] == nil { order.append(path) }
+                // A file created and then edited in the same run is still new to
+                // the reader, so "create" is the fact worth keeping.
+                if effects[path] != "create" {
+                    effects[path] = object["effect"]?.string ?? "edit"
+                }
+            }
+        }
+        files = order.compactMap { path in
+            // A file the run deleted is not something to list and offer to open.
+            guard let effect = effects[path], effect != "delete" else { return nil }
+            return FileChange(path: path, effect: effect == "create" ? "created" : "edited")
+        }
+    }
+}
+
 struct AgentJobAttempt: Identifiable, Codable, Hashable {
     let runID: String
     let jobID: String

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -1280,6 +1280,87 @@ final class AppModel: ObservableObject {
         )
     }
 
+    // MARK: - Reasoning effort
+
+    /// The efforts the current route accepts, weakest first, or empty when it
+    /// has no effort control. Empty is what hides the header picker.
+    ///
+    /// A ChatGPT plan answers for itself: its catalog is fetched from the
+    /// account's own model list and already withholds efforts the helper
+    /// cannot serve. Every other account falls back to the published table.
+    /// Local Ollama has no account and no effort control.
+    var reasoningEffortOptions: [String] {
+        guard let account = activeAccount else { return [] }
+        let model = routedModel(for: account)
+        if account.kind == .chatGPT {
+            var efforts = accountModelCatalogs[account.id]?
+                .first(where: { $0.id == model })?
+                .supportedReasoningEfforts?
+                .map(\.effort) ?? []
+            // Keep a stored choice selectable even when the catalog drops it,
+            // so the picker never silently disagrees with what is being sent.
+            let current = resolvedReasoningEffort
+            if !current.isEmpty, !efforts.contains(current) { efforts.append(current) }
+            return efforts
+        }
+        return account.kind.publishedReasoningEfforts(for: model)
+    }
+
+    /// The effort this route will actually request: the workspace's own choice,
+    /// then the account's default, then "" for the model's default.
+    ///
+    /// nil and "" are different answers here. nil is a workspace that has never
+    /// chosen, which defers to the account; "" is a workspace that chose Auto,
+    /// which has to beat an account default or picking Auto would do nothing on
+    /// the one kind of account that has one.
+    var resolvedReasoningEffort: String {
+        if let workspace = currentWorkspaceReasoningEffort { return workspace }
+        return activeAccount?.codexReasoningEffortValue ?? ""
+    }
+
+    /// The override stored against the workspace currently open, if any.
+    private var currentWorkspaceReasoningEffort: String? {
+        let path = workspacePath
+        return workspaceProfiles.first {
+            SessionSummary.canonicalWorkspacePath($0.path) == path
+        }?.reasoningEffort
+    }
+
+    /// Records the effort for this workspace and re-sends the route so the next
+    /// turn uses it. Effort is applied per turn on every provider, so this never
+    /// restarts a conversation — only the prompt cache pays, by re-reading the
+    /// prefix once.
+    func setReasoningEffort(_ effort: String) {
+        guard effort != resolvedReasoningEffort else { return }
+        let path = workspacePath
+        if let index = workspaceProfiles.firstIndex(where: {
+            SessionSummary.canonicalWorkspacePath($0.path) == path
+        }) {
+            workspaceProfiles[index].reasoningEffort = effort
+            persistWorkspaceProfiles()
+        } else {
+            // No profile yet — the workspace has not been recorded. Writing the
+            // whole profile is what creates it, and it carries the effort along.
+            pendingReasoningEffort = effort
+            persistCurrentWorkspaceProfile()
+        }
+        pendingReasoningEffort = nil
+        Task { _ = await applyProvider(announce: false) }
+    }
+
+    /// Carries an effort into `persistCurrentWorkspaceProfile` for a workspace
+    /// that has no stored profile yet.
+    private var pendingReasoningEffort: String?
+
+    /// Test seam: the effort picker reads a catalog fetched from the account's
+    /// own model list, and unit tests have no backend to fetch one from.
+    func applyAccountModelCatalogForTesting(
+        _ models: [ChatGPTModelsResponse.Model],
+        for account: UUID
+    ) {
+        accountModelCatalogs[account] = models
+    }
+
     func isLocalModelHidden(_ name: String) -> Bool {
         settings.hiddenLocalModels.contains {
             $0.caseInsensitiveCompare(name) == .orderedSame
@@ -9678,7 +9759,9 @@ final class AppModel: ObservableObject {
                 // missing field, so omitting one would freeze a stale choice.
                 "native_mode": account.codexNativeModeEnabled,
                 "web_search": account.codexWebSearchEnabled,
-                "reasoning_effort": account.codexReasoningEffortValue,
+                // The workspace's own choice when it has one, else the
+                // account's default — the header picker overrides the editor.
+                "reasoning_effort": effortToSend(for: account),
             ]
         }
         return [
@@ -9704,8 +9787,39 @@ final class AppModel: ObservableObject {
             "context_window": account.contextWindow ?? 0,
             "published_context_window":
                 account.kind.publishedContextWindow(for: account.preferredModel) ?? 0,
+            // Always sent, like the ChatGPT route's copy: "" is a real choice
+            // meaning the model's default, and omitting the key would leave a
+            // cleared effort reading as "keep whatever was set before".
+            "reasoning_effort": effortToSend(for: account),
             "verify": verify,
         ]
+    }
+
+    /// The effort to actually request, or "" when this model will not take the
+    /// one that is stored.
+    ///
+    /// The stored choice belongs to the workspace, not to the account, so it
+    /// outlives a switch between them: "max" set on a Claude model is still
+    /// there when the same workspace routes to a ChatGPT plan, which tops out
+    /// at "xhigh". An effort a model does not accept fails the turn rather than
+    /// being ignored, so it is filtered here rather than sent hopefully.
+    private func effortToSend(for account: ProviderAccount) -> String {
+        let effort = resolvedReasoningEffort
+        guard !effort.isEmpty else { return "" }
+        let model = routedModel(for: account)
+        guard account.kind == .chatGPT else {
+            return account.kind.publishedReasoningEfforts(for: model)
+                .contains(effort) ? effort : ""
+        }
+        // The catalog arrives asynchronously, and a backend older than
+        // effort reporting sends no efforts at all. With nothing to check
+        // against, the helper is the authority — pass the choice through
+        // rather than silently dropping what the user asked for.
+        guard let supported = accountModelCatalogs[account.id]?
+            .first(where: { $0.id == model })?
+            .supportedReasoningEfforts
+        else { return effort }
+        return supported.contains { $0.effort == effort } ? effort : ""
     }
 
     /// Pushes the chosen provider to the local agent. The key travels from the
@@ -13663,6 +13777,9 @@ final class AppModel: ObservableObject {
             previewURL: settings.previewURL,
             contextFiles: contextFiles,
             draft: draftText,
+            reasoningEffort: pendingReasoningEffort ?? workspaceProfiles.first(where: {
+                SessionSummary.canonicalWorkspacePath($0.path) == path
+            })?.reasoningEffort,
             soloSwarmEnabled: soloSwarmEnabled,
             landingCheckCommands: workspaceProfiles.first(where: {
                 SessionSummary.canonicalWorkspacePath($0.path) == path
@@ -14454,17 +14571,68 @@ final class AppModel: ObservableObject {
         }
     }
 
+    /// The tool trail of a Solo turn that wrote code and ran it: two files, two
+    /// commands, one of which failed. Everything the Overview's file list and
+    /// the Activity timeline read comes from events shaped exactly like these.
+    private func soloWorkFixtureEvents(runID: String, start: Double) -> [[String: Any]] {
+        [
+            [
+                "event_id": "seed-work-1", "run_id": runID, "seq": 3,
+                "occurred_at": start + 12,
+                "type": "tool_result", "id": "call-1", "tool": "write_file",
+                "summary": "write stock_checker.py (77 lines)",
+                "result": "Wrote /tmp/stock_checker.py (2210 chars, 78 lines).",
+                "ok": true, "denied": false,
+                "file_effects": [["path": "stock_checker.py", "effect": "create"]],
+            ],
+            [
+                "event_id": "seed-work-2", "run_id": runID, "seq": 4,
+                "occurred_at": start + 31,
+                "type": "tool_result", "id": "call-2", "tool": "bash",
+                "summary": "$ python3 -m unittest test_stock_checker.py",
+                "result": "[stderr]\nImportError: no module named stock_checker\n\n[exit code 1]",
+                "ok": false, "denied": false,
+            ],
+            [
+                "event_id": "seed-work-3", "run_id": runID, "seq": 5,
+                "occurred_at": start + 48,
+                "type": "tool_result", "id": "call-3", "tool": "multi_edit",
+                "summary": "edit stock_checker.py (5 changes)",
+                "result": "Edited /tmp/stock_checker.py: applied 5 edit(s).",
+                "ok": true, "denied": false,
+                "file_effects": [
+                    ["path": "stock_checker.py", "effect": "edit"],
+                    ["path": "test_stock_checker.py", "effect": "create"],
+                ],
+            ],
+            [
+                "event_id": "seed-work-4", "run_id": runID, "seq": 6,
+                "occurred_at": start + 96,
+                "type": "tool_result", "id": "call-4", "tool": "bash",
+                "summary": "$ python3 -m unittest test_stock_checker.py",
+                "result": "Ran 4 tests in 0.01s\n\nOK",
+                "ok": true, "denied": false,
+            ],
+        ]
+    }
+
     private func seedUITestRunFixtureIfNeeded() {
         guard let fixture = ProcessInfo.processInfo.environment["LOCUS_UI_TESTING_RUN_FIXTURE"],
               [
                 "completed", "recoverable", "dispatcher-repair", "dispatch-plan",
                 "activity", "swarm-live", "swarm-recoverable",
                 "solo-swarm-live", "solo-swarm-completed", "solo-swarm-empty",
+                "solo-swarm-work",
               ].contains(fixture)
         else { return }
         let isSoloSwarmFixture = fixture.hasPrefix("solo-swarm-")
+        // A Solo turn that did real work by itself: no workers, but files
+        // written and commands run. The panel's most common case, and the one
+        // that used to render as an empty Activity list and a single model call.
+        let soloWithoutWorkers = ["solo-swarm-empty", "solo-swarm-work"].contains(fixture)
         let state: TeamRunState = switch fixture {
-        case "completed", "solo-swarm-completed", "solo-swarm-empty": .completed
+        case "completed", "solo-swarm-completed", "solo-swarm-empty", "solo-swarm-work":
+            .completed
         case "recoverable", "swarm-recoverable": .interrupted
         case "dispatch-plan": .waitingDispatchApproval
         case "activity": .failed
@@ -14472,7 +14640,7 @@ final class AppModel: ObservableObject {
         default: .dispatching
         }
         let lastSequence = ["dispatcher-repair", "dispatch-plan"].contains(fixture) ? 1 : 1_200
-        let swarmAttempts: [AgentJobAttempt]? = if isSoloSwarmFixture && fixture != "solo-swarm-empty" {
+        let swarmAttempts: [AgentJobAttempt]? = if isSoloSwarmFixture && !soloWithoutWorkers {
             [
                 AgentJobAttempt(
                     runID: "seed-run",
@@ -14584,9 +14752,11 @@ final class AppModel: ObservableObject {
                 "model_calls": .number(3),
                 "root_prompt_tokens": .number(260),
                 "root_completion_tokens": .number(90),
-                "worker_prompt_tokens": .number(fixture == "solo-swarm-empty" ? 0 : 180),
-                "worker_completion_tokens": .number(fixture == "solo-swarm-empty" ? 0 : 60),
-                "worker_model_calls": .number(fixture == "solo-swarm-empty" ? 0 : 2),
+                "worker_prompt_tokens": .number(soloWithoutWorkers ? 0 : 180),
+                "worker_completion_tokens": .number(soloWithoutWorkers ? 0 : 60),
+                "worker_model_calls": .number(soloWithoutWorkers ? 0 : 2),
+                "metered_tokens": .number(22_901),
+                "tool_steps": .number(fixture == "solo-swarm-work" ? 4 : 0),
             ] : ["model_calls": .number(12)],
             manifest: isSoloSwarmFixture ? ["solo_swarm": .bool(true)] : nil,
             jobCount: isSoloSwarmFixture ? (swarmAttempts?.count ?? 0) : 4,
@@ -14615,7 +14785,7 @@ final class AppModel: ObservableObject {
         if fixture == "activity" {
             return
         }
-        let rawEvents: [[String: Any]]
+        var rawEvents: [[String: Any]]
         if isSoloSwarmFixture {
             rawEvents = [
                 [
@@ -14630,14 +14800,21 @@ final class AppModel: ObservableObject {
                     "event_id": "seed-event-2",
                     "run_id": run.id,
                     "seq": 2,
-                    "type": fixture == "solo-swarm-empty" ? "turn_done" : "agent_spawned",
+                    "type": soloWithoutWorkers ? "turn_done" : "agent_spawned",
                     "node_id": "/root/inventory-api",
                     "parent_node_id": "/root",
                     "depth": 1,
-                    "agent_name": "Inventory API reader",
-                    "goal": "Verify the inventory API contract",
+                    // Worker identity belongs only to a run that spawned one;
+                    // carrying it on a turn_done made the terminal row describe
+                    // a worker that never existed.
+                    "agent_name": soloWithoutWorkers ? "" : "Inventory API reader",
+                    "goal": soloWithoutWorkers ? "" : "Verify the inventory API contract",
+                    "reason": soloWithoutWorkers ? "complete" : "",
                 ],
             ]
+            if fixture == "solo-swarm-work" {
+                rawEvents += soloWorkFixtureEvents(runID: run.id, start: run.createdAt)
+            }
         } else if fixture.hasPrefix("swarm-") {
             rawEvents = [[
                 "event_id": "seed-event-1",
@@ -15189,7 +15366,11 @@ final class AppModel: ObservableObject {
             .nilIfEmpty ?? "locus-session"
     }
 
-    nonisolated private static func displayUserText(_ content: String) -> String {
+    /// The user's own words, with the composer's `[Locus mode: …]` wrapper and
+    /// context sections removed. The transcript has always shown this; the Runs
+    /// panel showed the raw decorated prompt, so the request itself was the part
+    /// that got truncated away.
+    nonisolated static func displayUserText(_ content: String) -> String {
         guard let range = content.range(of: "User request:\n", options: .backwards) else {
             return content
         }

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -1415,6 +1415,7 @@ struct InspectorRunsTab: View {
     @State private var filter = ""
     @State private var draftPlan: DispatchPlan?
     @State private var showTechnicalLog = false
+    @State private var requestExpanded = false
     @State private var telemetryContentRunID: String?
 
     var body: some View {
@@ -1487,6 +1488,9 @@ struct InspectorRunsTab: View {
             HStack(spacing: 8) {
                 Image(systemName: "point.3.connected.trianglepath.dotted")
                     .foregroundStyle(LocusTheme.signalDeep)
+                    // Decoration beside the panel's own title: unhidden, it is
+                    // exposed with its raw SF Symbol name as its label.
+                    .accessibilityHidden(true)
                 Text("RUNS")
                     .font(.locus(size: 8, weight: .bold))
                     .tracking(0.7)
@@ -2072,59 +2076,17 @@ struct InspectorRunsTab: View {
     }
 
     private func soloSwarmOverview(_ run: OrchestrationRun) -> some View {
-        ScrollView {
+        let work = runWork(run)
+        return ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                overviewCard("REQUEST", symbol: "text.bubble") {
-                    Text(run.request.isEmpty ? "No request was recorded." : run.request)
-                        .font(.locus(size: 9))
-                        .foregroundStyle(LocusTheme.inkSoft)
-                        .lineLimit(8)
-                }
-
-                overviewCard("SWARM STATUS", symbol: "circle.hexagongrid.fill") {
-                    VStack(alignment: .leading, spacing: 6) {
-                        metricRow("State", run.state.replacingOccurrences(of: "_", with: " ").capitalized)
-                        metricRow("Workers", "\(swarmCompletedCount(run)) of \(swarmWorkerCount(run)) completed")
-                        metricRow("Duration", runDuration(run))
-                        if let calls = swarmModelCalls(run) {
-                            metricRow("Model calls", calls.formatted())
-                        }
-                        if let tokens = swarmTotalTokens(run) {
-                            metricRow("Total tokens", tokens.formatted())
-                        }
-                    }
-                }
-
-                overviewCard("WORKERS", symbol: "person.fill") {
-                    if usesLiveSwarmWorkers(run) {
-                        VStack(alignment: .leading, spacing: 8) {
-                            ForEach(model.agentActivities.filter { $0.depth == 1 }) { activity in
-                                liveSwarmWorkerRow(activity)
-                            }
-                        }
-                    } else if !agentTreeAttempts(run).isEmpty {
-                        VStack(alignment: .leading, spacing: 8) {
-                            ForEach(agentTreeAttempts(run)) { attempt in
-                                swarmAttemptRow(attempt)
-                            }
-                        }
-                    } else {
-                        VStack(alignment: .leading, spacing: 5) {
-                            Text(run.state == "running"
-                                ? "No workers delegated yet"
-                                : "This run did not delegate any workers")
-                                .font(.locus(size: 9, weight: .semibold))
-                            Text("The primary agent can finish a Solo request itself when parallel investigation would not help.")
-                                .font(.locus(size: 8))
-                                .foregroundStyle(LocusTheme.muted)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        .accessibilityIdentifier("runs.soloSwarm.noWorkers")
-                    }
-                }
-
+                runSummaryStrip(run, work: work)
+                requestCard(run)
+                whatHappenedCard(run, work: work)
+                workersCard(run, work: work)
                 if swarmHasUsageBreakdown(run) {
-                    overviewCard("USAGE", symbol: "gauge") {
+                    // A breakdown of numbers the strip already reports, so it
+                    // opens on demand rather than competing with them.
+                    DisclosureGroup("Token breakdown") {
                         VStack(alignment: .leading, spacing: 6) {
                             metricRow(
                                 "Primary agent",
@@ -2134,13 +2096,17 @@ struct InspectorRunsTab: View {
                                 "Solo workers",
                                 "\(swarmWorkerTokens(run).formatted()) tokens"
                             )
+                            if let calls = swarmModelCalls(run) {
+                                metricRow("Model calls", calls.formatted())
+                            }
                             if let calls = run.usage?["worker_model_calls"]?.integer {
                                 metricRow("Worker model calls", calls.formatted())
                             }
                         }
+                        .padding(.top, 6)
                     }
+                    .font(.locus(size: 8, weight: .semibold))
                 }
-
                 technicalDetails(run)
             }
             .padding(12)
@@ -2150,27 +2116,12 @@ struct InspectorRunsTab: View {
     }
 
     private func soloOverview(_ run: OrchestrationRun) -> some View {
-        ScrollView {
+        let work = runWork(run)
+        return ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                overviewCard("REQUEST", symbol: "text.bubble") {
-                    Text(run.request.isEmpty ? "No request was recorded." : run.request)
-                        .font(.locus(size: 9))
-                        .foregroundStyle(LocusTheme.inkSoft)
-                        .lineLimit(8)
-                }
-                overviewCard("RESULT", symbol: "checkmark.seal") {
-                    VStack(alignment: .leading, spacing: 6) {
-                        metricRow("State", run.state.replacingOccurrences(of: "_", with: " ").capitalized)
-                        metricRow("Duration", runDuration(run))
-                        if let calls = run.usage?["model_calls"]?.integer {
-                            metricRow("Model calls", calls.formatted())
-                        }
-                        if let prompt = run.usage?["prompt_tokens"]?.integer,
-                           let completion = run.usage?["completion_tokens"]?.integer {
-                            metricRow("Tokens", (prompt + completion).formatted())
-                        }
-                    }
-                }
+                runSummaryStrip(run, work: work)
+                requestCard(run)
+                whatHappenedCard(run, work: work)
                 technicalDetails(run)
             }
             .padding(12)
@@ -2179,20 +2130,286 @@ struct InspectorRunsTab: View {
         .accessibilityIdentifier("runs.solo.overview")
     }
 
+    /// The four numbers that answer "what happened here?" before any card does.
+    ///
+    /// Sized through `Font.locus`, which maps everything below 11 point onto one
+    /// semantic style: the previous rows asked for 7, 8 and 9 point and all three
+    /// rendered identically, so a duration and a token count carried exactly the
+    /// same weight. Crossing the 11-point boundary buys a real step in the ramp
+    /// without opting out of Dynamic Type.
+    private func runSummaryStrip(_ run: OrchestrationRun, work: RunWork) -> some View {
+        let files = work.files.count
+        let tokens = swarmTotalTokens(run)
+        return ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: 10) {
+                summaryStat(runDuration(run), "Duration")
+                summaryStat(runStepCount(run, work: work).formatted(), "Steps")
+                summaryStat(files.formatted(), files == 1 ? "File" : "Files")
+                summaryStat(
+                    tokens?.formatted(.number.notation(.compactName)) ?? "—", "Tokens"
+                )
+            }
+            Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 10) {
+                GridRow {
+                    summaryStat(runDuration(run), "Duration")
+                    summaryStat(runStepCount(run, work: work).formatted(), "Steps")
+                }
+                GridRow {
+                    summaryStat(files.formatted(), files == 1 ? "File" : "Files")
+                    summaryStat(
+                        tokens?.formatted(.number.notation(.compactName)) ?? "—", "Tokens"
+                    )
+                }
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .summaryCardChrome()
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("runs.summaryStrip")
+    }
+
+    private func summaryStat(_ value: String, _ label: String) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(value)
+                .font(.locus(size: 15, weight: .semibold))
+                .foregroundStyle(LocusTheme.textPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+            Text(label.uppercased())
+                .font(.locus(size: 7, weight: .bold))
+                .tracking(0.5)
+                .foregroundStyle(LocusTheme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        // One element, one phrase: read as "Steps, 4" rather than as two
+        // unrelated fragments. A collapsed element does not carry a separate
+        // accessibility value, so the number belongs in the label.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(label), \(value)")
+        .accessibilityIdentifier("runs.summaryStat.\(label.lowercased())")
+    }
+
+    /// The request as the person typed it. `run.request` is the composer's
+    /// decorated prompt, which opens with a mode header and several paragraphs
+    /// of standing instruction — clamping that showed the boilerplate and cut
+    /// off the only part anyone came to read. The transcript already strips it.
+    private func requestCard(_ run: OrchestrationRun) -> some View {
+        let text = AppModel.displayUserText(run.request)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let clamped = text.count > 220 || text.contains("\n")
+        return overviewCard("REQUEST", symbol: "text.bubble") {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(text.isEmpty ? "No request was recorded." : text)
+                    .font(.locus(size: 9))
+                    .foregroundStyle(LocusTheme.textSecondary)
+                    .lineLimit(requestExpanded ? nil : 3)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+                if clamped, !text.isEmpty {
+                    Button(requestExpanded ? "Show less" : "Show more") {
+                        withAnimation(LocusMotion.content) { requestExpanded.toggle() }
+                    }
+                    .buttonStyle(.locus())
+                    .font(.locus(size: 8, weight: .semibold))
+                    .accessibilityIdentifier("runs.request.expand")
+                }
+            }
+        }
+    }
+
+    /// Files written and commands run, rebuilt from the run's own events. The
+    /// panel used to answer this from live git status, so it went blank the
+    /// moment you opened a run that had already finished.
+    @ViewBuilder
+    private func whatHappenedCard(_ run: OrchestrationRun, work: RunWork) -> some View {
+        overviewCard("WHAT HAPPENED", symbol: "hammer") {
+            if work.isEmpty {
+                Text(run.state == "running"
+                    ? "Nothing recorded yet."
+                    : "This run wrote no files and ran no commands.")
+                    .font(.locus(size: 8))
+                    .foregroundStyle(LocusTheme.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("runs.work.empty")
+            } else {
+                VStack(alignment: .leading, spacing: 10) {
+                    if !work.files.isEmpty {
+                        workSubhead("Files", work.files.count)
+                        SummaryList(
+                            work.files,
+                            identifierPrefix: "runs.work.file",
+                            noun: "file"
+                        ) { _, change in
+                            SummaryRow(
+                                icon: .forPath(change.path),
+                                label: change.path,
+                                meta: change.effect,
+                                identifier: "runs.work.file.\(change.path)",
+                                help: change.path,
+                                action: fileOpener(run, path: change.path)
+                            )
+                        }
+                    }
+                    if !work.commands.isEmpty {
+                        workSubhead("Commands", work.commands.count)
+                        SummaryList(
+                            work.commands,
+                            identifierPrefix: "runs.work.command",
+                            noun: "command"
+                        ) { _, command in
+                            SummaryRow(
+                                icon: .process,
+                                label: command.summary,
+                                meta: command.ok ? nil : "failed",
+                                metaColor: LocusTheme.dangerForeground,
+                                identifier: "runs.work.command.\(command.id)",
+                                help: command.summary,
+                                // A command reads from the left; keeping its
+                                // tail made two different `python3 -m unittest`
+                                // invocations render as the same row.
+                                truncation: .tail
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func workSubhead(_ title: String, _ count: Int) -> some View {
+        HStack(spacing: 5) {
+            Text(title.uppercased())
+                .font(.locus(size: 7, weight: .bold))
+                .tracking(0.5)
+            Text(count.formatted())
+                .font(.locus(size: 7, design: .monospaced))
+        }
+        .foregroundStyle(LocusTheme.textSecondary)
+    }
+
+    /// Only offered where activating it is safe and meaningful: the run has to
+    /// belong to the workspace that is open, or the path resolves somewhere else
+    /// entirely.
+    private func fileOpener(_ run: OrchestrationRun, path: String) -> (() -> Void)? {
+        guard let root = run.workspaceRoot, root == model.workspacePath else { return nil }
+        return { model.openSessionFile(path) }
+    }
+
+    /// Workers earn a card when there were any. When there were none, the fact
+    /// belongs in one line — and it has to say *which* kind of none it was: the
+    /// agent seeing no reason to split the work reads nothing like delegation
+    /// having been unavailable, and the two used to be indistinguishable.
+    @ViewBuilder
+    private func workersCard(_ run: OrchestrationRun, work: RunWork) -> some View {
+        if usesLiveSwarmWorkers(run) {
+            overviewCard("WORKERS", symbol: "person.fill") {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(model.agentActivities.filter { $0.depth == 1 }) { activity in
+                        liveSwarmWorkerRow(activity)
+                    }
+                }
+            }
+        } else if !agentTreeAttempts(run).isEmpty {
+            overviewCard(
+                "WORKERS · \(swarmCompletedCount(run)) OF \(swarmWorkerCount(run))",
+                symbol: "person.fill"
+            ) {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(agentTreeAttempts(run)) { attempt in
+                        swarmAttemptRow(attempt)
+                    }
+                }
+            }
+        } else {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: work.delegationUnavailable
+                    ? "exclamationmark.triangle" : "person.slash")
+                    .font(.locus(size: 8))
+                    .foregroundStyle(work.delegationUnavailable
+                        ? LocusTheme.warningForeground : LocusTheme.textTertiary)
+                Text(workersEmptyText(run, work: work))
+                    .font(.locus(size: 8))
+                    .foregroundStyle(LocusTheme.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("runs.soloSwarm.noWorkers")
+        }
+    }
+
+    private func workersEmptyText(_ run: OrchestrationRun, work: RunWork) -> String {
+        if work.delegationUnavailable {
+            return "Delegation was unavailable for this run, so the agent worked alone."
+        }
+        if run.state == "running" { return "No workers delegated yet." }
+        return "This run did not delegate any workers — the primary agent can finish "
+            + "a Solo request itself when parallel investigation would not help."
+    }
+
+    /// Tool steps: what the run did, rather than how many times a provider was
+    /// asked. `usage.tool_steps` is authoritative when the agent reported it;
+    /// runs recorded before that field existed are counted from their own
+    /// persisted tool results, so history reads correctly too.
+    private func runStepCount(_ run: OrchestrationRun, work: RunWork) -> Int {
+        if let steps = run.usage?["tool_steps"]?.integer, steps > 0 { return steps }
+        return work.toolSteps
+    }
+
+    private func runWork(_ run: OrchestrationRun) -> RunWork {
+        RunWork(events: model.orchestrationEvents)
+    }
+
     private func technicalDetails(_ run: OrchestrationRun) -> some View {
         DisclosureGroup("Technical details") {
             VStack(alignment: .leading, spacing: 5) {
                 Text("Run ID · \(run.id)")
                 Text("Saved events · \(run.lastSequence)")
+                Text("Started · \(runTimestamp(run.createdAt))")
+                if let ended = run.completedAt {
+                    Text("Ended · \(runTimestamp(ended))")
+                }
+                if let model = runModelLabel(run) {
+                    Text("Model · \(model)")
+                }
+                if let root = run.workspaceRoot, !root.isEmpty {
+                    Text("Workspace · \(root)")
+                }
+                if let environment = run.executionEnvironment, !environment.isEmpty {
+                    Text("Environment · \(environment)")
+                }
+                if let trace = run.traceID, !trace.isEmpty {
+                    Text("Trace · \(trace)")
+                }
                 if let checkpoint = run.checkpoint {
                     Text("Checkpoint · \(checkpoint.kind.replacingOccurrences(of: "_", with: " "))")
                 }
             }
             .font(.locus(size: 7, design: .monospaced))
-            .foregroundStyle(LocusTheme.muted)
+            .foregroundStyle(LocusTheme.textTertiary)
+            .textSelection(.enabled)
             .padding(.top, 6)
         }
         .font(.locus(size: 8, weight: .semibold))
+        .accessibilityIdentifier("runs.technicalDetails")
+    }
+
+    private func runTimestamp(_ value: Double) -> String {
+        Date(timeIntervalSince1970: value)
+            .formatted(date: .abbreviated, time: .standard)
+    }
+
+    /// Provider and model are reported on the turn's terminal event, which the
+    /// run row itself does not carry.
+    private func runModelLabel(_ run: OrchestrationRun) -> String? {
+        guard let terminal = model.orchestrationEvents.last(where: {
+            $0.type == "turn_done" || $0.type == "orchestration_completed"
+        }) else { return nil }
+        let name = terminal.text("model") ?? ""
+        let provider = terminal.text("provider") ?? ""
+        let label = [provider, name].filter { !$0.isEmpty }.joined(separator: " · ")
+        return label.isEmpty ? nil : label
     }
 
     private func usesLiveSwarmWorkers(_ run: OrchestrationRun) -> Bool {
@@ -2351,7 +2568,10 @@ struct InspectorRunsTab: View {
                 TextField("Filter run activity", text: $filter)
                     .textFieldStyle(.roundedBorder)
                     .accessibilityIdentifier("runs.filter")
-                Toggle("Technical log", isOn: $showTechnicalLog)
+                // Renamed from "Technical log": with the list above now
+                // showing the run's actual work, this is the raw firehose you
+                // reach for to debug, not the only way to see anything at all.
+                Toggle("Raw events", isOn: $showTechnicalLog)
                     .toggleStyle(.checkbox)
                     .font(.locus(size: 8, weight: .semibold))
                     .accessibilityIdentifier("runs.technicalLog")
@@ -2371,7 +2591,7 @@ struct InspectorRunsTab: View {
                                 .font(.locus(size: 9, weight: .semibold))
                             Text(filter.isEmpty
                                 ? "Events will appear here as this run progresses."
-                                : "Try a different search term or open the technical log.")
+                                : "Try a different search term, or switch on Raw events.")
                                 .font(.locus(size: 8))
                                 .foregroundStyle(LocusTheme.muted)
                                 .multilineTextAlignment(.center)
@@ -2384,27 +2604,42 @@ struct InspectorRunsTab: View {
                                 Text(group.title.uppercased())
                                     .font(.locus(size: 7, weight: .bold))
                                     .tracking(0.6)
-                                    .foregroundStyle(LocusTheme.muted)
+                                    .foregroundStyle(LocusTheme.textSecondary)
                                     .padding(.horizontal, 12)
                                     .padding(.top, 10)
                                     .padding(.bottom, 4)
                                 ForEach(group.events) { event in
                                     HStack(alignment: .top, spacing: 8) {
                                         Image(systemName: friendlyEventSymbol(event))
-                                            .foregroundStyle(color(for: event.type))
+                                            .foregroundStyle(eventColor(event))
                                             .frame(width: 14)
                                         VStack(alignment: .leading, spacing: 2) {
                                             Text(friendlyEventTitle(event))
                                                 .font(.locus(size: 9, weight: .semibold))
                                             Text(friendlyEventDetail(event))
                                                 .font(.locus(size: 8))
-                                                .foregroundStyle(LocusTheme.inkSoft)
-                                                .lineLimit(6)
+                                                .foregroundStyle(LocusTheme.textSecondary)
+                                                .lineLimit(4)
                                         }
-                                        Spacer(minLength: 0)
+                                        Spacer(minLength: 6)
+                                        // Offsets, not clock times: what a
+                                        // reader wants from a run's timeline is
+                                        // how long it took to get here.
+                                        if let offset = eventOffset(event, in: run) {
+                                            Text(offset)
+                                                .font(.locus(size: 7, design: .monospaced))
+                                                .foregroundStyle(LocusTheme.textTertiary)
+                                                .accessibilityLabel("at \(offset)")
+                                        }
                                     }
                                     .padding(.horizontal, 12)
                                     .padding(.vertical, 8)
+                                    // Spelled out rather than combined: a
+                                    // combined row reports an empty label here,
+                                    // which reads as an undescribed element.
+                                    .accessibilityElement(children: .ignore)
+                                    .accessibilityLabel(activityRowLabel(event, in: run))
+                                    .accessibilityIdentifier("runs.activity.event.\(event.id)")
                                     Divider().padding(.leading, 34)
                                 }
                             }
@@ -2426,14 +2661,14 @@ struct InspectorRunsTab: View {
             Label(title, systemImage: symbol)
                 .font(.locus(size: 8, weight: .bold))
                 .tracking(0.5)
-                .foregroundStyle(LocusTheme.muted)
+                .foregroundStyle(LocusTheme.textSecondary)
             content()
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(LocusTheme.white.opacity(0.58))
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay { RoundedRectangle(cornerRadius: 8).stroke(LocusTheme.line) }
+        // The same chrome as the Overview tab's summary cards, so the two
+        // surfaces read as siblings instead of as two nearly-identical recipes.
+        .summaryCardChrome()
     }
 
     private func metricRow(_ title: String, _ value: String) -> some View {
@@ -2943,13 +3178,23 @@ struct InspectorRunsTab: View {
     }
 
     private var activityGroups: [ActivityGroup] {
-        let visible = filteredEvents.filter(isUserFacingEvent)
+        let visible = withoutRedundantWork(filteredEvents.filter(isUserFacingEvent))
+        // Phase headings describe a team's shape. A solo turn that delegated
+        // nothing has one phase, and filing its whole timeline under a "Solo
+        // workers" heading described workers that never existed.
+        if isSoloRun, agentTreeAttempts(model.selectedOrchestrationRun).isEmpty {
+            return visible.isEmpty ? [] : [ActivityGroup(title: "Timeline", events: visible)]
+        }
         let order = ["Solo workers", "Planning", "Approval", "Specialists", "Coding jobs", "Review", "Complete"]
         let grouped = Dictionary(grouping: visible, by: activityPhase)
         return order.compactMap { title in
             guard let events = grouped[title], !events.isEmpty else { return nil }
             return ActivityGroup(title: title, events: events)
         }
+    }
+
+    private func agentTreeAttempts(_ run: OrchestrationRun?) -> [AgentJobAttempt] {
+        run.map(agentTreeAttempts) ?? []
     }
 
     private func runPhases(_ run: OrchestrationRun) -> [RunPhase] {
@@ -2991,6 +3236,24 @@ struct InspectorRunsTab: View {
         return "\(state) · \(run.completedJobCount ?? 0) of \(total) \(unit)"
     }
 
+    private func activityRowLabel(_ event: OrchestrationEvent, in run: OrchestrationRun) -> String {
+        [
+            friendlyEventTitle(event),
+            friendlyEventDetail(event),
+            eventOffset(event, in: run).map { "at \($0)" },
+        ]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+    }
+
+    private func eventOffset(_ event: OrchestrationEvent, in run: OrchestrationRun) -> String? {
+        guard let occurred = event.occurredAt else { return nil }
+        let seconds = Int(occurred.timeIntervalSince1970 - run.createdAt)
+        guard seconds >= 0 else { return nil }
+        return String(format: "+%d:%02d", seconds / 60, seconds % 60)
+    }
+
     private func runDuration(_ run: OrchestrationRun) -> String {
         let end = run.completedAt ?? run.updatedAt
         let seconds = max(Int(end - run.createdAt), 0)
@@ -3005,8 +3268,13 @@ struct InspectorRunsTab: View {
         }
     }
 
+    /// A solo run is a team run's opposite: it emits no `agent_*` and no
+    /// `orchestration_*` events, so the team-shaped allow-list below could only
+    /// ever match its two lifecycle rows. The turn's tools *are* its activity,
+    /// which is why the useful list used to live behind the raw-events switch.
     private func isUserFacingEvent(_ event: OrchestrationEvent) -> Bool {
-        event.type == "error"
+        if isSoloRun, soloWorkEventTypes.contains(event.type) { return true }
+        return event.type == "error"
             || ["run_started", "agent_spawned", "agent_branch_stopped",
                 "swarm_telemetry", "turn_done", "note"].contains(event.type)
             || event.type == "permission_request"
@@ -3015,6 +3283,35 @@ struct InspectorRunsTab: View {
             || event.type == "task_changes"
             || event.type.hasPrefix("agent_job_")
             || event.type.hasPrefix("orchestration_")
+    }
+
+    private var isSoloRun: Bool {
+        model.selectedOrchestrationRun?.runKind == "solo"
+    }
+
+    private var soloWorkEventTypes: Set<String> {
+        ["tool_result", "tool_call_proposed", "workspace_changed"]
+    }
+
+    /// `tool_call_proposed` and `tool_result` are a pair; showing both doubles
+    /// the list without adding a fact. The proposal survives only when no result
+    /// followed it — a call that was denied, or one the turn was stopped during,
+    /// which is exactly the case worth seeing. `workspace_changed` is dropped
+    /// outright: the Overview's file list says the same thing with the paths.
+    private func withoutRedundantWork(
+        _ events: [OrchestrationEvent]
+    ) -> [OrchestrationEvent] {
+        guard isSoloRun else { return events }
+        let resolved = Set(
+            events.filter { $0.type == "tool_result" }.compactMap { $0.text("id") }
+        )
+        return events.filter { event in
+            switch event.type {
+            case "workspace_changed": false
+            case "tool_call_proposed": !resolved.contains(event.text("id") ?? "")
+            default: true
+            }
+        }
     }
 
     private func activityPhase(_ event: OrchestrationEvent) -> String {
@@ -3076,11 +3373,20 @@ struct InspectorRunsTab: View {
             ? "Team run completed" : "Team run stopped"
         case "task_changes": "Workspace changes are ready"
         case "error": "Run error"
+        case "tool_result", "tool_call_proposed":
+            event.text("summary")?.nilIfEmpty ?? event.text("tool") ?? "Tool call"
         default: event.title
         }
     }
 
     private func friendlyEventDetail(_ event: OrchestrationEvent) -> String {
+        if event.type == "tool_result" {
+            if event.values["denied"]?.boolean == true { return "Denied" }
+            return event.text("result")?.nilIfEmpty ?? "Completed"
+        }
+        if event.type == "tool_call_proposed" {
+            return event.text("detail")?.nilIfEmpty ?? "Never ran"
+        }
         let agent = event.text("agent_name")
         let model = event.text("model")
         let route = [agent, model].compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " · ")
@@ -3094,12 +3400,31 @@ struct InspectorRunsTab: View {
     }
 
     private func friendlyEventSymbol(_ event: OrchestrationEvent) -> String {
+        if event.type == "tool_call_proposed" { return "circle.dotted" }
+        if event.type == "tool_result" {
+            if event.values["denied"]?.boolean == true { return "hand.raised.circle.fill" }
+            return event.values["ok"]?.boolean == false
+                ? "exclamationmark.circle.fill" : "checkmark.circle.fill"
+        }
         if event.type.contains("completed") { return "checkmark.circle.fill" }
         if event.type.contains("incomplete") || event.type.contains("paused") { return "pause.circle.fill" }
         if event.type.contains("error") || event.type.contains("rejected") { return "exclamationmark.circle.fill" }
         if event.type.contains("permission") { return "lock.circle.fill" }
         if event.type.contains("plan") { return "list.bullet.clipboard.fill" }
         return "circle.inset.filled"
+    }
+
+    /// `tool_result` carries its outcome in a flag, not in its type name, so
+    /// the type-based palette painted a failed command the same green as a
+    /// successful one.
+    private func eventColor(_ event: OrchestrationEvent) -> Color {
+        if event.type == "tool_result" {
+            if event.values["denied"]?.boolean == true { return LocusTheme.warning }
+            return event.values["ok"]?.boolean == false
+                ? LocusTheme.coral : LocusTheme.success
+        }
+        if event.type == "tool_call_proposed" { return LocusTheme.muted }
+        return color(for: event.type)
     }
 
     private func color(for type: String) -> Color {

--- a/Locus/Models/SessionModels.swift
+++ b/Locus/Models/SessionModels.swift
@@ -359,6 +359,11 @@ struct WorkspaceProfile: Identifiable, Codable, Hashable {
     var previewURL: String
     var contextFiles: [ContextFile]
     var draft: String
+    /// The reasoning effort this workspace was last used with, overriding the
+    /// account's own default. Optional, so profiles saved before it decode
+    /// unchanged; nil and "" both fall back to the account, then to the
+    /// model's default.
+    var reasoningEffort: String? = nil
     /// Deprecated compatibility field. Solo now delegates adaptively without
     /// a per-workspace switch.
     var soloSwarmEnabled: Bool? = nil

--- a/Locus/PinnedSummaryView.swift
+++ b/Locus/PinnedSummaryView.swift
@@ -619,6 +619,10 @@ struct SummaryRow: View {
     let identifier: String
     var accessibilityLabel: String? = nil
     var help: String? = nil
+    /// Middle by default, because most rows are paths and the tail — the file
+    /// name — is what identifies them. A row whose label reads left to right,
+    /// like a shell command, needs the head kept instead.
+    var truncation: Text.TruncationMode = .middle
     var action: (() -> Void)? = nil
 
     init(
@@ -630,6 +634,7 @@ struct SummaryRow: View {
         identifier: String,
         accessibilityLabel: String? = nil,
         help: String? = nil,
+        truncation: Text.TruncationMode = .middle,
         action: (() -> Void)? = nil
     ) {
         self.icon = icon
@@ -640,6 +645,7 @@ struct SummaryRow: View {
         self.identifier = identifier
         self.accessibilityLabel = accessibilityLabel
         self.help = help
+        self.truncation = truncation
         self.action = action
     }
 
@@ -672,7 +678,7 @@ struct SummaryRow: View {
                 .font(.locus(size: 10, weight: .semibold))
                 .foregroundStyle(LocusTheme.ink)
                 .lineLimit(1)
-                .truncationMode(.middle)
+                .truncationMode(truncation)
             Spacer(minLength: 6)
             if let meta {
                 Text(meta)

--- a/Locus/ProviderAccounts.swift
+++ b/Locus/ProviderAccounts.swift
@@ -177,6 +177,51 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
         }
     }
 
+    /// The reasoning efforts one of this provider's models accepts, weakest
+    /// first, or empty when the model has no effort control at all.
+    ///
+    /// Empty is a real answer, not a gap: most models take no effort parameter,
+    /// and sending one to them is an error rather than a no-op. The picker is
+    /// hidden entirely for those, which is why this must not guess — an
+    /// unlisted model gets an empty list and no control.
+    ///
+    /// `.chatGPT` is deliberately absent. A ChatGPT plan reports its own
+    /// efforts through the account's model catalog, which is authoritative and
+    /// already withholds the ones the helper cannot serve; a second static copy
+    /// here could only go stale against it.
+    ///
+    /// Verify against vendor documentation when adding a model.
+    func publishedReasoningEfforts(for model: String) -> [String] {
+        let name = model.lowercased()
+        switch self {
+        case .claude:
+            // Effort is generally available on the Claude 5 family and takes
+            // the place of the retired token budget. Haiku 4.5 rejects the
+            // parameter outright, so it gets no control rather than a default.
+            if name.hasPrefix("claude-opus-5")
+                || name.hasPrefix("claude-sonnet-5")
+                || name.hasPrefix("claude-fable-5") {
+                return ["low", "medium", "high", "xhigh", "max"]
+            }
+            return []
+        case .codex:
+            // OpenAI's reasoning models take `reasoning_effort`; the 4.1 line
+            // and other non-reasoning models do not.
+            if name.hasPrefix("gpt-5") || name.hasPrefix("o3") || name.hasPrefix("o4") {
+                return ["minimal", "low", "medium", "high"]
+            }
+            return []
+        case .chatGPT:
+            return []
+        case .kimi, .kimiCode:
+            return []
+        case .custom:
+            // Someone else's deployment; only they know what it accepts, and a
+            // rejected parameter would fail the turn rather than degrade.
+            return []
+        }
+    }
+
     /// A model this provider will accept for a one-token connection probe.
     var probeModel: String { curatedModels.first ?? "" }
 
@@ -322,6 +367,7 @@ struct ProviderAccount: Identifiable, Codable, Hashable {
     /// Codex-native parity for this ChatGPT account: the agent uses Codex's
     /// own prompt and tools, with no Locus memory or skills. Optional so
     /// accounts stored before this existed decode unchanged; nil reads as on.
+    /// Accounts created since then start at `false` — see the initialiser.
     var codexNativeMode: Bool?
     /// Whether the model may call OpenAI's web search on this account.
     /// Optional for the same migration reason; nil reads as off.
@@ -364,6 +410,15 @@ struct ProviderAccount: Identifiable, Codable, Hashable {
         } else {
             self.codexHomeID = codexHomeID
         }
+        // Same reasoning for the contract the account answers under. A ChatGPT
+        // account built in code is a new one, and a new one runs Locus's own
+        // prompt, tools, memory, and skills. Decoding bypasses this initialiser,
+        // so an account stored before this keeps its nil — and nil still reads
+        // as Codex-native, which is what leaves every account already signed in
+        // answering exactly as it did rather than silently changing contract.
+        if kind == .chatGPT {
+            self.codexNativeMode = false
+        }
     }
 
     /// An unknown kind resolves to `.custom`, which keeps the account usable:
@@ -396,8 +451,11 @@ struct ProviderAccount: Identifiable, Codable, Hashable {
     /// is the pre-multi-account home, which is exactly what nil should mean.
     var codexHomeIdentifier: String { codexHomeID ?? "" }
 
-    /// Parity mode defaults to on: a ChatGPT account answers like Codex until
-    /// the user turns Locus's own prompt and tools back on.
+    /// Whether this account answers like Codex rather than under the Locus
+    /// contract. New accounts are created with parity off, so they arrive with
+    /// Locus's prompt, tools, memory, and skills. nil is the pre-existing
+    /// account that never made the choice, and it keeps reading as on: that is
+    /// what stops an upgrade from re-routing a conversation already in flight.
     var codexNativeModeEnabled: Bool { codexNativeMode ?? true }
 
     /// Web search stays off until the user opts in to sending queries out.

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -7,6 +7,7 @@ struct WorkspaceView: View {
     @EnvironmentObject private var model: AppModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var modelPickerPresented = false
+    @State private var effortPickerPresented = false
     @State private var teamProgressPresented = false
     let sidebarVisible: Bool
     let showSidebar: () -> Void
@@ -180,6 +181,10 @@ struct WorkspaceView: View {
                     .accessibilityIdentifier("workspace.reviewAndLand")
             }
 
+            if !model.reasoningEffortOptions.isEmpty {
+                effortPicker
+            }
+
             Button {
                 modelPickerPresented.toggle()
             } label: {
@@ -233,6 +238,104 @@ struct WorkspaceView: View {
         .overlay(alignment: .bottom) {
             Rectangle().fill(LocusTheme.line).frame(height: 1)
         }
+    }
+
+    /// How hard the current model should think, beside the model it applies to.
+    ///
+    /// Only rendered when the route advertises efforts at all — most models
+    /// take no effort parameter, and a disabled control for them would be
+    /// permanent dead chrome for anyone on a local model.
+    private var effortPicker: some View {
+        Button {
+            effortPickerPresented.toggle()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "gauge.with.dots.needle.33percent")
+                    .font(.locus(size: 9, weight: .semibold))
+                    .foregroundStyle(LocusTheme.muted)
+                Text(effortLabel)
+                    .font(.locus(size: 9, weight: .semibold))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.locus(size: 8, weight: .semibold))
+                    .foregroundStyle(LocusTheme.muted)
+            }
+            .padding(.horizontal, 9)
+            .frame(height: 28)
+            .background(LocusTheme.white.opacity(0.78))
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .stroke(LocusTheme.line, lineWidth: 1)
+            }
+        }
+        .buttonStyle(.locus())
+        .help("Reasoning effort · \(effortLabel)")
+        .accessibilityLabel("Reasoning effort, \(effortLabel)")
+        .accessibilityIdentifier("workspace.effortPicker")
+        .frame(height: 28)
+        .popover(isPresented: $effortPickerPresented, arrowEdge: .top) {
+            effortPopover
+        }
+    }
+
+    /// "Auto" rather than "Default": the closed chip has no room to say what
+    /// the default is, and Auto reads as a choice the model makes.
+    private var effortLabel: String {
+        let effort = model.resolvedReasoningEffort
+        return effort.isEmpty ? "Auto" : effort.capitalized
+    }
+
+    private var effortPopover: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Reasoning effort")
+                .font(.locus(size: 10, weight: .bold))
+
+            effortRow(effort: "", title: "Auto")
+            ForEach(model.reasoningEffortOptions, id: \.self) { effort in
+                effortRow(effort: effort, title: effort.capitalized)
+            }
+
+            Divider().overlay(LocusTheme.line)
+
+            Text(
+                "Applies to this workspace and takes effect on the next message. "
+                + "Higher efforts think longer and cost more."
+            )
+            .font(.locus(size: 8))
+            .foregroundStyle(LocusTheme.muted)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(10)
+        .frame(width: 240)
+        .background(LocusTheme.white)
+        .accessibilityIdentifier("workspace.effortPicker.popover")
+    }
+
+    private func effortRow(effort: String, title: String) -> some View {
+        let selected = model.resolvedReasoningEffort == effort
+        return Button {
+            model.setReasoningEffort(effort)
+            effortPickerPresented = false
+        } label: {
+            HStack(spacing: 8) {
+                Text(title)
+                Spacer(minLength: 12)
+                if selected {
+                    Image(systemName: "checkmark")
+                        .font(.locus(size: 8, weight: .bold))
+                }
+            }
+            .font(.locus(size: 9, weight: .semibold))
+            .foregroundStyle(LocusTheme.inkSoft)
+            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+            .background(selected ? LocusTheme.paperDeep : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.locus())
+        .accessibilityIdentifier("workspace.effortPicker.\(effort.isEmpty ? "auto" : effort)")
     }
 
     private var shouldShowWorkStatus: Bool {

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -1608,6 +1608,21 @@ final class AppModelTests: XCTestCase {
         return model.providerAccounts.first { $0.id == account.id } ?? account
     }
 
+    /// A minimal profile for the workspace under test. Seeded explicitly because
+    /// profiles are read from the real defaults even with persistence off.
+    private func seededProfile(path: String) -> WorkspaceProfile {
+        WorkspaceProfile(
+            path: path,
+            lastOpened: Date(),
+            model: "",
+            accountID: nil,
+            mode: .build,
+            previewURL: "",
+            contextFiles: [],
+            draft: ""
+        )
+    }
+
     @MainActor
     private func providerHandoffService(
         host: String = "provider-handoff.test"
@@ -1883,8 +1898,9 @@ final class AppModelTests: XCTestCase {
         XCTAssertEqual(body["account_id"] as? String, account.id.uuidString)
         XCTAssertEqual(body["codex_home_id"] as? String, account.codexHomeIdentifier)
         // All three always travel: the backend keeps its current value for a
-        // missing field, so omitting one would freeze a stale choice.
-        XCTAssertEqual(body["native_mode"] as? Bool, true)
+        // missing field, so omitting one would freeze a stale choice. A newly
+        // created account routes under the Locus contract, so parity is off.
+        XCTAssertEqual(body["native_mode"] as? Bool, false)
         XCTAssertEqual(body["web_search"] as? Bool, false)
         XCTAssertEqual(body["reasoning_effort"] as? String, "")
     }
@@ -1903,6 +1919,114 @@ final class AppModelTests: XCTestCase {
         XCTAssertEqual(body["native_mode"] as? Bool, false)
         XCTAssertEqual(body["web_search"] as? Bool, true)
         XCTAssertEqual(body["reasoning_effort"] as? String, "xhigh")
+    }
+
+    @MainActor
+    func testRemoteRouteSendsAnEffortOnlyForModelsThatAcceptOne() {
+        // Sending an effort to a model without an effort control fails the turn
+        // rather than being ignored, so the value is filtered against the same
+        // published table the picker is drawn from.
+        let model = AppModel(startImmediately: false)
+        let account = seedAccount(
+            model,
+            kind: .claude,
+            name: "Work",
+            preferredModel: "claude-opus-5"
+        )
+        model.settings.activeAccountID = account.id.uuidString
+        // Seeded explicitly: profiles are read from the real defaults even with
+        // persistence off, so leaving this to the machine's own state would make
+        // the test pass or fail depending on which workspaces it has open.
+        model.workspaceProfiles = [seededProfile(path: model.workspacePath)]
+
+        XCTAssertEqual(
+            model.providerRequestBody()["reasoning_effort"] as? String, "",
+            "no choice yet means the model's own default"
+        )
+
+        model.setReasoningEffort("xhigh")
+        XCTAssertEqual(model.providerRequestBody()["reasoning_effort"] as? String, "xhigh")
+
+        // The same stored choice against a model that takes no effort sends
+        // nothing at all, instead of a value that endpoint would reject.
+        var haiku = account
+        haiku.preferredModel = "claude-haiku-4-5"
+        model.saveProviderAccount(haiku, apiKey: nil)
+
+        XCTAssertEqual(model.providerRequestBody()["reasoning_effort"] as? String, "")
+        XCTAssertTrue(
+            model.reasoningEffortOptions.isEmpty,
+            "and the header picker is hidden for it"
+        )
+    }
+
+    @MainActor
+    func testChoosingAutoOverridesTheAccountsOwnDefaultEffort() {
+        // The regression test for nil-versus-empty. A workspace that has never
+        // chosen defers to the account; one that chose Auto has to beat it, or
+        // picking Auto on a ChatGPT account with a stored effort does nothing.
+        let model = AppModel(startImmediately: false)
+        var account = ProviderAccount(kind: .chatGPT, name: "Work")
+        account.preferredModel = "gpt-5.3-codex"
+        account.codexReasoningEffort = "high"
+        model.saveProviderAccount(account, apiKey: nil)
+        model.settings.activeAccountID = account.id.uuidString
+        model.workspaceProfiles = [seededProfile(path: model.workspacePath)]
+
+        XCTAssertEqual(
+            model.resolvedReasoningEffort, "high",
+            "no workspace choice defers to the account"
+        )
+
+        model.setReasoningEffort("")
+
+        XCTAssertEqual(model.resolvedReasoningEffort, "")
+        XCTAssertEqual(
+            model.providerRequestBody()["reasoning_effort"] as? String, "",
+            "and the model's own default is what gets sent"
+        )
+    }
+
+    @MainActor
+    func testAnEffortTheChatGPTCatalogDoesNotListIsNotSent() {
+        // The choice belongs to the workspace, so it outlives a switch between
+        // accounts: "max" set on a Claude model is still stored when the same
+        // workspace routes to a ChatGPT plan, which tops out at "xhigh".
+        let model = AppModel(startImmediately: false)
+        var account = ProviderAccount(kind: .chatGPT, name: "Work")
+        account.preferredModel = "gpt-5.3-codex"
+        model.saveProviderAccount(account, apiKey: nil)
+        model.settings.activeAccountID = account.id.uuidString
+        var profile = seededProfile(path: model.workspacePath)
+        profile.reasoningEffort = "max"
+        model.workspaceProfiles = [profile]
+
+        // With no catalog yet there is nothing to check against, and the helper
+        // is the authority — the choice travels rather than being dropped.
+        XCTAssertEqual(model.providerRequestBody()["reasoning_effort"] as? String, "max")
+
+        model.applyAccountModelCatalogForTesting(
+            [
+                ChatGPTModelsResponse.Model(
+                    id: "gpt-5.3-codex",
+                    displayName: "GPT-5.3 Codex",
+                    description: "",
+                    isDefault: true,
+                    supportedReasoningEfforts: [
+                        .init(effort: "low", description: nil),
+                        .init(effort: "high", description: nil),
+                        .init(effort: "xhigh", description: nil),
+                    ],
+                    defaultReasoningEffort: "high"
+                )
+            ],
+            for: account.id
+        )
+
+        XCTAssertEqual(
+            model.providerRequestBody()["reasoning_effort"] as? String, "",
+            "an effort this model rejects would fail the turn, so send none"
+        )
     }
 
     @MainActor

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -3223,6 +3223,25 @@ final class FeatureLogicTests: XCTestCase {
         XCTAssertEqual(account.codexReasoningEffortValue, "", "empty means the model default")
     }
 
+    func testNewChatGPTAccountStartsOnTheLocusContract() {
+        // A ChatGPT account created now answers with Locus's prompt, tools,
+        // memory, and skills. The value is stamped by the initialiser rather
+        // than by the accessor's fallback, which is what lets the test above
+        // keep its nil — an account added before this keeps answering as it did.
+        let account = ProviderAccount(kind: .chatGPT, name: "New")
+
+        XCTAssertEqual(account.codexNativeMode, false)
+        XCTAssertFalse(account.codexNativeModeEnabled, "new accounts use Locus tools")
+    }
+
+    func testNonChatGPTAccountsCarryNoParityChoice() {
+        // Parity is a ChatGPT-only contract; nothing should be stamped on the
+        // other kinds, where the field has no meaning.
+        let account = ProviderAccount(kind: .claude, name: "Work")
+
+        XCTAssertNil(account.codexNativeMode)
+    }
+
     func testCodexNativeParityFieldsRoundTrip() throws {
         var account = ProviderAccount(kind: .chatGPT, name: "Personal")
         account.codexNativeMode = false
@@ -3800,6 +3819,66 @@ final class FeatureLogicTests: XCTestCase {
             from: JSONEncoder().encode(updated)
         )
         XCTAssertTrue(roundTrip.resolvedSoloSwarmEnabled)
+    }
+
+    func testWorkspaceProfilesFromBeforeReasoningEffortStillDecode() throws {
+        let legacy = """
+        [{"path":"/tmp/ws","lastOpened":0,"model":"claude-opus-5","mode":"build",
+          "previewURL":"","contextFiles":[],"draft":""}]
+        """
+        let restored = try JSONDecoder().decode(
+            [WorkspaceProfile].self,
+            from: Data(legacy.utf8)
+        )
+        XCTAssertNil(restored[0].reasoningEffort, "no choice means the account's default")
+
+        var updated = restored[0]
+        updated.reasoningEffort = "xhigh"
+        let roundTrip = try JSONDecoder().decode(
+            WorkspaceProfile.self,
+            from: JSONEncoder().encode(updated)
+        )
+        XCTAssertEqual(roundTrip.reasoningEffort, "xhigh")
+    }
+
+    func testPublishedReasoningEffortsCoverOnlyModelsThatAcceptThem() {
+        // Effort is generally available across the Claude 5 family.
+        XCTAssertEqual(
+            ProviderKind.claude.publishedReasoningEfforts(for: "claude-opus-5"),
+            ["low", "medium", "high", "xhigh", "max"]
+        )
+        XCTAssertEqual(
+            ProviderKind.claude.publishedReasoningEfforts(for: "claude-sonnet-5"),
+            ["low", "medium", "high", "xhigh", "max"]
+        )
+        // Haiku rejects the parameter outright, so it gets no control at all
+        // rather than a control that fails the turn.
+        XCTAssertTrue(
+            ProviderKind.claude.publishedReasoningEfforts(for: "claude-haiku-4-5").isEmpty
+        )
+
+        // OpenAI's reasoning models take an effort; the 4.1 line does not.
+        XCTAssertEqual(
+            ProviderKind.codex.publishedReasoningEfforts(for: "gpt-5.6"),
+            ["minimal", "low", "medium", "high"]
+        )
+        XCTAssertEqual(
+            ProviderKind.codex.publishedReasoningEfforts(for: "o3"),
+            ["minimal", "low", "medium", "high"]
+        )
+        XCTAssertTrue(ProviderKind.codex.publishedReasoningEfforts(for: "gpt-4.1").isEmpty)
+
+        // A ChatGPT plan reports its own efforts through the account catalog;
+        // a static copy here could only go stale against it.
+        XCTAssertTrue(
+            ProviderKind.chatGPT.publishedReasoningEfforts(for: "gpt-5.3-codex").isEmpty
+        )
+        // Someone else's deployment, and an unknown model, get nothing.
+        XCTAssertTrue(ProviderKind.custom.publishedReasoningEfforts(for: "anything").isEmpty)
+        XCTAssertTrue(ProviderKind.kimi.publishedReasoningEfforts(for: "kimi-k3").isEmpty)
+        XCTAssertTrue(
+            ProviderKind.claude.publishedReasoningEfforts(for: "not-a-model").isEmpty
+        )
     }
 
     func testSettingsCarryTheActiveAccountAndOldOnesDecodeWithout() throws {
@@ -5578,5 +5657,116 @@ final class FeatureLogicTests: XCTestCase {
     func testSplitWorkspaceAlwaysResolvesToSideBySidePresentation() {
         XCTAssertEqual(ChatWorkspacePresentation.resolve(isSplit: false), .single)
         XCTAssertEqual(ChatWorkspacePresentation.resolve(isSplit: true), .sideBySide)
+    }
+
+    // MARK: - RunWork
+
+    /// Events arrive over the wire, so build them the way the app does rather
+    /// than reaching past the decoder.
+    private func runEvents(_ raw: [[String: Any]]) throws -> [OrchestrationEvent] {
+        let data = try JSONSerialization.data(withJSONObject: raw)
+        return try JSONDecoder().decode([OrchestrationEvent].self, from: data)
+    }
+
+    func testRunWorkReadsFilesAndCommandsFromToolResults() throws {
+        let events = try runEvents([
+            ["seq": 1, "type": "run_started"],
+            [
+                "seq": 2, "type": "tool_result", "tool": "write_file", "ok": true,
+                "event_id": "a", "summary": "write app.py (20 lines)",
+                "file_effects": [["path": "app.py", "effect": "create"]],
+            ],
+            [
+                "seq": 3, "type": "tool_result", "tool": "bash", "ok": true,
+                "event_id": "b", "summary": "$ pytest",
+            ],
+            [
+                "seq": 4, "type": "tool_result", "tool": "multi_edit", "ok": true,
+                "event_id": "c", "summary": "edit app.py",
+                "file_effects": [
+                    ["path": "app.py", "effect": "edit"],
+                    ["path": "util.py", "effect": "edit"],
+                ],
+            ],
+            ["seq": 5, "type": "turn_done"],
+        ])
+
+        let work = RunWork(events: events)
+
+        XCTAssertEqual(work.toolSteps, 3)
+        // A file created and later edited in the same run still reads as new.
+        XCTAssertEqual(
+            work.files,
+            [
+                RunWork.FileChange(path: "app.py", effect: "created"),
+                RunWork.FileChange(path: "util.py", effect: "edited"),
+            ]
+        )
+        XCTAssertEqual(work.commands.map(\.summary), ["$ pytest"])
+        XCTAssertFalse(work.isEmpty)
+        XCTAssertFalse(work.delegationUnavailable)
+    }
+
+    func testRunWorkIgnoresFailedEffectsAndDeletions() throws {
+        let events = try runEvents([
+            [
+                "seq": 1, "type": "tool_result", "tool": "write_file", "ok": false,
+                "event_id": "a", "summary": "write blocked.py",
+                "file_effects": [["path": "blocked.py", "effect": "create"]],
+            ],
+            [
+                "seq": 2, "type": "tool_result", "tool": "bash", "ok": false,
+                "event_id": "b", "summary": "$ false",
+            ],
+            [
+                "seq": 3, "type": "tool_result", "tool": "delete_file", "ok": true,
+                "event_id": "c", "summary": "delete old.py",
+                "file_effects": [["path": "old.py", "effect": "delete"]],
+            ],
+        ])
+
+        let work = RunWork(events: events)
+
+        // A call that did not succeed wrote nothing, and a deleted file is not
+        // something to list and offer to open.
+        XCTAssertTrue(work.files.isEmpty)
+        XCTAssertEqual(work.toolSteps, 3)
+        XCTAssertEqual(work.commands.map(\.ok), [false])
+    }
+
+    func testRunWorkSeparatesUnavailableDelegationFromAnAgentDecliningIt() throws {
+        let quiet = RunWork(events: try runEvents([
+            ["seq": 1, "type": "note", "text": "Nothing to split here."],
+        ]))
+        XCTAssertFalse(quiet.delegationUnavailable)
+
+        let broken = RunWork(events: try runEvents([[
+            "seq": 1, "type": "note",
+            "text": "The selected provider does not support Solo delegation.",
+            "solo_swarm_unavailable": true,
+        ]]))
+        XCTAssertTrue(broken.delegationUnavailable)
+    }
+
+    func testRunWorkOfATurnThatOnlyTalkedIsEmpty() throws {
+        let work = RunWork(events: try runEvents([
+            ["seq": 1, "type": "run_started"],
+            ["seq": 2, "type": "turn_done"],
+        ]))
+        XCTAssertTrue(work.isEmpty)
+        XCTAssertEqual(work.toolSteps, 0)
+    }
+
+    func testDisplayUserTextDropsTheComposerDecoration() {
+        let decorated = """
+        [Locus mode: Build]
+
+        Implement the request completely using the Get Shit Done method.
+
+        User request:
+        make a stock checker
+        """
+        XCTAssertEqual(AppModel.displayUserText(decorated), "make a stock checker")
+        XCTAssertEqual(AppModel.displayUserText("plain ask"), "plain ask")
     }
 }

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -3434,8 +3434,63 @@ final class LocusUITests: XCTestCase {
         relaunchWithRunFixture("solo-swarm-empty")
 
         XCTAssertTrue(anyElement("runs.soloSwarm.overview").waitForExistence(timeout: 3))
-        XCTAssertTrue(anyElement("runs.soloSwarm.noWorkers").exists)
-        XCTAssertTrue(app.staticTexts["This run did not delegate any workers"].exists)
+        let empty = anyElement("runs.soloSwarm.noWorkers")
+        XCTAssertTrue(empty.exists)
+        // Not a whole card any more: no workers is one line, and it has to say
+        // the agent chose this rather than that delegation was unavailable.
+        XCTAssertTrue(
+            (empty.label + " " + ((empty.value as? String) ?? ""))
+                .localizedCaseInsensitiveContains("did not delegate any workers")
+        )
+    }
+
+    func testSoloRunReportsTheWorkItActuallyDid() throws {
+        // The panel stacks a lot of chrome above its content, so a short test
+        // window can leave the timeline's later rows unrendered by the lazy
+        // stack rather than merely scrolled out of view.
+        app.launchEnvironment["LOCUS_UI_TESTING_WINDOW_HEIGHT"] = "1000"
+        relaunchWithRunFixture("solo-swarm-work")
+
+        XCTAssertTrue(anyElement("runs.soloSwarm.overview").waitForExistence(timeout: 3))
+
+        // The strip answers "what happened" before any card does. Four tool
+        // results, two surviving files: the numbers the panel used to report as
+        // "Model calls 1" for a run exactly like this one.
+        let strip = anyElement("runs.summaryStrip")
+        XCTAssertTrue(strip.exists)
+        XCTAssertEqual(anyElement("runs.summaryStat.steps").label, "Steps, 4")
+        XCTAssertEqual(anyElement("runs.summaryStat.files").label, "Files, 2")
+
+        XCTAssertTrue(anyElement("runs.work.file.stock_checker.py").exists)
+        XCTAssertTrue(anyElement("runs.work.file.test_stock_checker.py").exists)
+        XCTAssertFalse(anyElement("runs.work.empty").exists)
+
+        // And the timeline is populated without reaching for the raw log.
+        anyElement("runs.view.activity").click()
+        XCTAssertTrue(anyElement("runs.activity").waitForExistence(timeout: 3))
+        // The switch is off by default and now reads as what it is — the raw
+        // firehose, not the only route to a non-empty list.
+        XCTAssertTrue(anyElement("runs.technicalLog").exists)
+        XCTAssertTrue(app.checkBoxes["Raw events"].exists)
+        XCTAssertTrue(app.staticTexts["TIMELINE"].exists)
+        // The tools the run ran are rows in the default list, not something you
+        // have to switch the raw log on to find.
+        let write = anyElement("runs.activity.event.seed-work-1")
+        XCTAssertTrue(write.waitForExistence(timeout: 3))
+        XCTAssertTrue(write.label.localizedCaseInsensitiveContains("write stock_checker.py"))
+        XCTAssertTrue(
+            anyElement("runs.activity.event.seed-work-4").waitForExistence(timeout: 3)
+        )
+    }
+
+    func testRunsPanelPassesAnAccessibilityAudit() throws {
+        relaunchWithRunFixture("solo-swarm-work")
+
+        XCTAssertTrue(anyElement("runs.soloSwarm.overview").waitForExistence(timeout: 3))
+        try auditCurrentSurface()
+        anyElement("runs.view.activity").click()
+        XCTAssertTrue(anyElement("runs.activity").waitForExistence(timeout: 3))
+        try auditCurrentSurface()
     }
 
     func testPermissionPanelRepliesWithTheKeyboard() {

--- a/agent/PROTOCOL.md
+++ b/agent/PROTOCOL.md
@@ -276,12 +276,14 @@ The `chatgpt` variant requires `account_id`, with optional `account_label` and
 primary service's bundled Codex App Server and never falls back to `remote`.
 It also accepts three optional settings with "missing means keep" semantics,
 so an older client re-selecting the account never resets them: `native_mode`
-(bool, default true), `web_search` (bool, default false), and
+(bool, default true when the field is absent — note that Locus itself always
+sends the field, and sends `false` for newly created accounts),
+`web_search` (bool, default false), and
 `reasoning_effort` (string, `""` = the model's default, applied per turn —
 changing it never restarts the helper thread). `GET` echoes them back as
 `chatgpt_native_mode`, `chatgpt_web_search`, and `chatgpt_reasoning_effort`.
 
-With `native_mode` on (Codex-native parity, the default), interactive solo
+With `native_mode` on (Codex-native parity, the wire default), interactive solo
 Work/Plan/Build turns run under the model's own Codex base prompt instead of
 the Locus system prompt: `thread/start` omits `baseInstructions` and
 `personality`, AGENTS.md rides in `developerInstructions`, the environment
@@ -1069,7 +1071,15 @@ The terminal also carries this turn's spend and provenance — `prompt_tokens`
 and `completion_tokens` (deltas for the turn, not conversation totals),
 `provider`, `model`, `account_label` (empty for local Ollama),
 `workspace_root`, and `session_id`. The fields are additive; old clients
-ignore them. The server persists solo turns with nonzero tokens into the run
+ignore them.
+`tool_steps` counts the tools this turn actually ran, which is the number a
+reader recognises as "how much work happened". It exists because `model_calls`
+does not mean the same thing on both routes: the local loop makes one provider
+request per iteration, while a ChatGPT App Server turn is a single thread call
+that may run twenty tools inside it. On that route `model_calls` is derived from
+the helper's per-call `thread/tokenUsage/updated` reports, and token deltas are
+summed across them rather than read from the final snapshot — reading only the
+last one billed a whole turn at one request's cost. The server persists solo turns with nonzero tokens into the run
 store's `turn_usage` table for `GET /api/usage/summary`; orchestrated runs
 account usage in their own run records instead.
 A `session_info` event follows immediately.

--- a/agent/ollama_code/api/providers.py
+++ b/agent/ollama_code/api/providers.py
@@ -320,6 +320,7 @@ def _apply_provider(service: ChatService, body: dict[str, Any]) -> dict[str, Any
     raw_style = body.get("auth_style")
     raw_label = body.get("account_label")
     raw_lists = body.get("lists_models")
+    raw_effort = body.get("reasoning_effort")
     try:
         service.core.use_remote(
             base_url=base_url,
@@ -330,6 +331,7 @@ def _apply_provider(service: ChatService, body: dict[str, Any]) -> dict[str, Any
             lists_models=None if raw_lists is None else bool(raw_lists),
             context_window_tokens=body.get("context_window"),
             published_context_window=body.get("published_context_window"),
+            reasoning_effort=None if raw_effort is None else str(raw_effort),
         )
     except ValueError as error:
         raise HTTPException(422, str(error)) from error

--- a/agent/ollama_code/api/schedules.py
+++ b/agent/ollama_code/api/schedules.py
@@ -94,8 +94,9 @@ def _dispatch_companion_chat(
     if len(prompt) > 240_000:
         raise HTTPException(413, "prompt is too large")
     mode = str(body.get("mode") or "work").strip().lower()
-    if mode not in {"ask", "work", "plan", "build"}:
-        raise HTTPException(422, "mode must be ask, work, plan, or build")
+    # "build" is the retired GSD mode, kept so existing schedule rows still load.
+    if mode not in {"ask", "work", "plan", "grill", "build"}:
+        raise HTTPException(422, "mode must be ask, work, plan, or grill")
 
     requested_session_id = str(body.get("session_id") or "").strip()
     task: TaskCheckout | None = None

--- a/agent/ollama_code/chat_service.py
+++ b/agent/ollama_code/chat_service.py
@@ -248,6 +248,9 @@ class ChatService:
                 "completion_tokens": event["completion_tokens"],
                 "metered_tokens": event["prompt_tokens"] + event["completion_tokens"],
                 "model_calls": event["model_calls"],
+                # Tool steps are the root's own work; workers report their
+                # spend as model calls, not as steps in this turn.
+                "tool_steps": max(int(event.get("tool_steps") or 0), 0),
                 "root_prompt_tokens": root_prompt,
                 "root_completion_tokens": root_completion,
                 "worker_prompt_tokens": worker_usage["prompt_tokens"],

--- a/agent/ollama_code/config.py
+++ b/agent/ollama_code/config.py
@@ -27,6 +27,11 @@ DEFAULTS: dict[str, Any] = {
     # display label only: two accounts can share a host, and without it the
     # app cannot tell which one this process is actually holding a key for.
     "remote_account_label": "",
+    # "" means send no effort at all, which is what a model without an effort
+    # control requires — the endpoint rejects the turn rather than ignoring an
+    # unknown field. The app only sends a value for models it knows accept one.
+    # Applied per request, so changing it never restarts anything.
+    "remote_reasoning_effort": "",
     # False for a provider that serves chat completions and no model
     # listing (Kimi Code), so the health probe does not read its auth
     # error on /models as a rejected key.
@@ -222,8 +227,9 @@ def load_config() -> dict[str, Any]:
     if cfg.get("provider") not in PROVIDERS:
         cfg["provider"] = "ollama"
     for key in (
-        "remote_auth_style", "remote_account_label", "chatgpt_account_id",
-        "chatgpt_account_label", "chatgpt_model", "chatgpt_reasoning_effort",
+        "remote_auth_style", "remote_account_label", "remote_reasoning_effort",
+        "chatgpt_account_id", "chatgpt_account_label", "chatgpt_model",
+        "chatgpt_reasoning_effort",
     ):
         if not isinstance(cfg.get(key), str):
             cfg[key] = ""

--- a/agent/ollama_code/core.py
+++ b/agent/ollama_code/core.py
@@ -550,7 +550,10 @@ class AgentCore:
             fallback_instructions=fallback_instructions,
         )
         self.agent_id = str(agent_id or "primary")[:128]
-        self.agent_mode = mode if mode in {"ask", "work", "plan", "build"} else "work"
+        # Keep "grill" listed: `sessions.py` drops the mode-instruction section
+        # for ask/work only, so an unlisted mode would coerce to "work" here and
+        # silently strip the $grilling activation on the parity path.
+        self.agent_mode = mode if mode in {"ask", "work", "plan", "grill", "build"} else "work"
         self.agent_role_contract = str(role_contract or "")[:8_000]
         self.memory_context = str(memory_context or "")[:24_000]
         self.continuity_context = (
@@ -956,18 +959,33 @@ class AgentCore:
         explicit user output limit uses `max_completion_tokens` for OpenAI-style
         endpoints. With no explicit limit, the existing provider defaults stay
         untouched. Ollama receives the equivalent `num_predict` only when set.
+
+        Reasoning effort rides along here too, in the shape each surface takes:
+        Anthropic carries it inside `output_config`, OpenAI-style endpoints take
+        a top-level `reasoning_effort`. An empty setting sends nothing, because
+        a model without an effort control rejects the field rather than
+        ignoring it. Ollama's graded thinking is not wired up: its `think` flag
+        is a bool, which is a different control, not a coarser one.
         """
         output_cap = self.agent_configuration.runtime_policy.max_output_tokens
         if self.provider == "remote":
+            anthropic = getattr(self.client, "auth_style", "") == AUTH_ANTHROPIC
             room = self._reply_room()
             if output_cap is not None:
                 room = min(room, output_cap) if room > 0 else output_cap
-            if getattr(self.client, "auth_style", "") == AUTH_ANTHROPIC and room > 0:
-                return {"max_tokens": room}
-            if output_cap is not None:
-                return {"max_completion_tokens": output_cap}
-            return None
-        options: dict[str, Any] = {}
+            options: dict[str, Any] = {}
+            if anthropic and room > 0:
+                options["max_tokens"] = room
+            elif output_cap is not None:
+                options["max_completion_tokens"] = output_cap
+            effort = str(self.config.get("remote_reasoning_effort") or "")
+            if effort:
+                if anthropic:
+                    options["output_config"] = {"effort": effort}
+                else:
+                    options["reasoning_effort"] = effort
+            return options or None
+        options = {}
         if self._context_requested > 0:
             options["num_ctx"] = self._context_requested
         if output_cap is not None:
@@ -1047,6 +1065,7 @@ class AgentCore:
         lists_models: bool | None = None,
         context_window_tokens: Any = None,
         published_context_window: Any = None,
+        reasoning_effort: str | None = None,
     ) -> None:
         """Point the agent at an OpenAI-compatible endpoint.
 
@@ -1059,6 +1078,10 @@ class AgentCore:
         They arrive separately because they are not equally trustworthy: the
         first clamps and is reported as configured, the second is a labelled
         fallback used only when the endpoint says nothing about itself.
+
+        ``reasoning_effort`` follows the ``None`` rule too. "" is a meaningful
+        value, not an absent one: it means send no effort field at all, which
+        is what a model without an effort control requires.
         """
         normalized_url = normalize_base_url(base_url)
         effective_key = (
@@ -1097,6 +1120,13 @@ class AgentCore:
             self.config["remote_account_label"] = account_label.strip()
         if lists_models is not None:
             self.config["remote_lists_models"] = bool(lists_models)
+        if reasoning_effort is not None:
+            self.config["remote_reasoning_effort"] = reasoning_effort.strip()
+        elif _different_host(previous_url, self.config["remote_base_url"]):
+            # An effort belongs to the model that advertised it. Carrying one
+            # across endpoints is how "xhigh" reaches a model that rejects the
+            # field and fails the turn outright.
+            self.config["remote_reasoning_effort"] = ""
         self._build_remote_client()
         # _build_remote_client only adopts a non-empty model, so clearing the
         # config above is not enough on its own: self.model would keep the
@@ -1203,6 +1233,9 @@ class AgentCore:
             "remote_model": str(self.config.get("remote_model") or ""),
             "has_api_key": bool(self.config.get("remote_api_key")),
             "account_label": self.account_label,
+            "remote_reasoning_effort": str(
+                self.config.get("remote_reasoning_effort") or ""
+            ),
             "chatgpt_native_mode": bool(self.config.get("chatgpt_native_mode", True)),
             "chatgpt_web_search": bool(self.config.get("chatgpt_web_search", False)),
             "chatgpt_reasoning_effort": str(
@@ -1636,6 +1669,15 @@ class AgentCore:
         prompt_before = self.total_prompt_tokens
         completion_before = self.total_completion_tokens
         reason = "complete"
+        # App Server bills one thread call per turn, so the classic loop
+        # counter never advances here and a twenty-step build reported a
+        # single model call. Count what actually happened instead: one model
+        # call per token-usage update, and every tool step Locus ran. Declared
+        # out here because a missing helper skips the block below entirely.
+        native_model_calls = 0
+        native_tool_steps = 0
+        native_prompt_tokens = 0
+        native_completion_tokens = 0
         self._turn_allows_tools = allow_tools
         self._last_turn_allowed_tools = allow_tools
         self._interrupt.clear()
@@ -1811,7 +1853,6 @@ class AgentCore:
                 assistant_items: dict[str, dict[str, Any]] = {}
                 synthetic_message_id = "managed-message"
                 synthetic_reasoning_id = "managed-reasoning"
-                dynamic_call_count = 0
                 dynamic_call_limit = min(
                     self.max_iterations,
                     max(int(model_call_limit), 1)
@@ -1951,7 +1992,8 @@ class AgentCore:
                         })
 
                 def handle_event(event: dict[str, Any]) -> None:
-                    nonlocal usage
+                    nonlocal usage, native_model_calls
+                    nonlocal native_prompt_tokens, native_completion_tokens
                     method = str(event.get("method") or "")
                     params = event.get("params")
                     if not isinstance(params, dict):
@@ -2043,17 +2085,29 @@ class AgentCore:
                         candidate = params.get("tokenUsage")
                         if isinstance(candidate, dict):
                             usage = candidate
+                            # ``last`` is one model call's spend. The helper
+                            # sends one update per call, so summing them is the
+                            # turn's true cost; keeping only the final snapshot
+                            # reported the last call as the whole turn.
+                            last = candidate.get("last")
+                            if isinstance(last, dict):
+                                prompt = max(int(last.get("inputTokens") or 0), 0)
+                                completion = max(int(last.get("outputTokens") or 0), 0)
+                                if prompt or completion:
+                                    native_model_calls += 1
+                                    native_prompt_tokens += prompt
+                                    native_completion_tokens += completion
                     elif method in {"item/commandExecution/requestApproval", "item/fileChange/requestApproval"}:
                         raise RuntimeError("ChatGPT helper requested a disabled native approval")
 
                 def handle_tool(name: str, arguments: dict[str, Any], call_id: str) -> str:
-                    nonlocal dynamic_call_count
+                    nonlocal native_tool_steps
                     if not allow_tools:
                         return "Not run: Just Chat has no tool or workspace access."
-                    if dynamic_call_count >= dynamic_call_limit:
+                    if native_tool_steps >= dynamic_call_limit:
                         self._interrupt.set()
                         return "Error: Locus stopped this turn at its configured tool-step budget."
-                    dynamic_call_count += 1
+                    native_tool_steps += 1
                     if parity:
                         # Parity names exist only on the wire. Everything
                         # downstream — deny lists, accept-edits, previews,
@@ -2120,7 +2174,7 @@ class AgentCore:
                         "_phase": "final_answer",
                     })
                 if self._needs_final_answer_pass(
-                    reason=reason, tool_calls=dynamic_call_count
+                    reason=reason, tool_calls=native_tool_steps
                 ):
                     # The helper thread already holds this whole turn, so the
                     # write-up is one more turn on it with no tools attached —
@@ -2143,11 +2197,15 @@ class AgentCore:
                             "type": "note",
                             "text": "Locus could not write a closing summary for this turn.",
                         })
-                last = usage.get("last") if isinstance(usage.get("last"), dict) else {}
-                prompt = int(last.get("inputTokens") or 0)
-                completion = int(last.get("outputTokens") or 0)
-                self.total_prompt_tokens += max(prompt, 0)
-                self.total_completion_tokens += max(completion, 0)
+                # A helper that reports a running ``total`` is authoritative;
+                # otherwise the per-call sum built above is the honest figure.
+                total = usage.get("total") if isinstance(usage.get("total"), dict) else {}
+                prompt = max(int(total.get("inputTokens") or 0), 0) or native_prompt_tokens
+                completion = (
+                    max(int(total.get("outputTokens") or 0), 0) or native_completion_tokens
+                )
+                self.total_prompt_tokens += prompt
+                self.total_completion_tokens += completion
                 if self._interrupt.is_set():
                     reason = "interrupted"
             except (CodexAppServerError, RuntimeError, ValueError) as error:
@@ -2163,7 +2221,8 @@ class AgentCore:
             "type": "turn_done",
             "reason": reason,
             "duration_ms": max(int((time.monotonic() - started_at) * 1000), 0),
-            "model_calls": 1,
+            "model_calls": max(native_model_calls, 1),
+            "tool_steps": native_tool_steps,
             "iteration_limit": self.max_iterations,
             "model_call_limit": model_call_limit,
             "prompt_tokens": max(self.total_prompt_tokens - prompt_before, 0),
@@ -2776,6 +2835,8 @@ class AgentCore:
             "reason": reason,
             "duration_ms": max(int((time.monotonic() - started_at) * 1000), 0),
             "model_calls": iteration,
+            # The step count both routes agree on: one per tool Locus ran.
+            "tool_steps": tool_calls_run,
             "iteration_limit": iteration_limit,
             "model_call_limit": hard_call_limit,
             # This turn's token spend and provenance, additive so old clients

--- a/agent/ollama_code/schedules.py
+++ b/agent/ollama_code/schedules.py
@@ -9,7 +9,8 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 MIN_INTERVAL_SECONDS = 15 * 60
 MAX_INTERVAL_SECONDS = 365 * 24 * 60 * 60
-SCHEDULE_MODES = {"ask", "work", "plan", "build"}
+#: "build" is the retired GSD mode, kept so existing schedule rows still load.
+SCHEDULE_MODES = {"ask", "work", "plan", "grill", "build"}
 SCHEDULE_RUNNERS = {"solo", "solo_swarm", "team"}
 SCHEDULE_ENVIRONMENTS = {"local", "worktree"}
 SCHEDULE_PROVIDERS = {"ollama", "remote", "chatgpt"}
@@ -78,7 +79,7 @@ def normalize_schedule(value: Any, *, now: float) -> dict[str, Any]:
         raise ScheduleValidationError("workspace_root is required")
     mode = str(value.get("mode") or "work").strip().lower()
     if mode not in SCHEDULE_MODES:
-        raise ScheduleValidationError("mode must be ask, work, plan, or build")
+        raise ScheduleValidationError("mode must be ask, work, plan, or grill")
     environment = str(value.get("execution_environment") or "local").strip().lower()
     if environment not in SCHEDULE_ENVIRONMENTS:
         raise ScheduleValidationError("execution_environment must be local or worktree")

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -507,7 +507,14 @@ def _run_user_turn(
                 virtual_tools=svc.core.solo_worker_virtual_tools,
             )
         except SoloSwarmError as exc:
-            svc.emit({"type": "note", "text": str(exc)})
+            # Durable, so the Runs panel can tell "the agent saw no reason to
+            # delegate" apart from "delegation was never available here". The
+            # two used to look identical once the note scrolled away.
+            svc.emit({
+                "type": "note",
+                "text": str(exc),
+                "solo_swarm_unavailable": True,
+            })
     svc.active_solo_swarm = swarm
     svc.core.tool_ctx.delegate_read_only = swarm.execute if swarm is not None else None
     svc.core.tool_registry.set_solo_swarm_enabled(swarm is not None)
@@ -1890,7 +1897,10 @@ async def _handle_client_message(svc: ChatService, msg: dict[str, Any]) -> None:
             _command_error(svc, str(mtype), "Message is too large to process safely.")
             return
         mode = str(msg.get("mode") or "").strip().lower()
-        if mode not in {"", "ask", "work", "plan", "build"}:
+        # "build" is the retired GSD raw value. It stays accepted so an older
+        # desktop build, a legacy schedule row, or a replayed transcript is not
+        # rejected mid-flight; `AgentCore.configure_agent` maps it to work.
+        if mode not in {"", "ask", "work", "plan", "grill", "build"}:
             _command_error(svc, str(mtype), "Unknown conversation mode.")
             return
         just_chat = mode == "ask"

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -1518,6 +1518,28 @@ def test_provider_endpoint_carries_the_account_identity(client):
     assert client.post("/api/provider", json={"provider": "ollama"}).json()["account_label"] == ""
 
 
+def test_provider_endpoint_carries_the_reasoning_effort(client):
+    body = client.post("/api/provider", json={
+        "provider": "remote",
+        "base_url": "https://api.anthropic.com/v1",
+        "api_key": "sk-ant-secret",
+        "model": "claude-opus-5",
+        "auth_style": "anthropic",
+        "reasoning_effort": "high",
+    }).json()
+    assert body["remote_reasoning_effort"] == "high"
+
+    # "" is a real choice — the model's own default — and has to clear the
+    # previous one rather than read as an absent field.
+    cleared = client.post("/api/provider", json={
+        "provider": "remote",
+        "base_url": "https://api.anthropic.com/v1",
+        "model": "claude-opus-5",
+        "reasoning_effort": "",
+    }).json()
+    assert cleared["remote_reasoning_effort"] == ""
+
+
 # ------------------------------------------------------------------------ git
 
 
@@ -4684,6 +4706,7 @@ def test_solo_swarm_turn_combines_root_and_worker_usage_without_changing_context
             "type": "turn_done",
             "reason": "complete",
             "model_calls": 1,
+            "tool_steps": 6,
             "prompt_tokens": 200,
             "completion_tokens": 80,
             "provider": "ollama",
@@ -4702,6 +4725,8 @@ def test_solo_swarm_turn_combines_root_and_worker_usage_without_changing_context
         "completion_tokens": 110,
         "metered_tokens": 430,
         "model_calls": 4,
+        # The root's own steps; workers report model calls, not steps.
+        "tool_steps": 6,
         "root_prompt_tokens": 200,
         "root_completion_tokens": 80,
         "worker_prompt_tokens": 120,
@@ -6273,6 +6298,65 @@ def test_anthropic_output_cap_matches_the_room_reserved_for_it(tmp_path):
     assert options == {"max_tokens": core._reply_room()}
     assert options["max_tokens"] == 8_192, "the cap Anthropic is given, not 4096"
     assert "num_ctx" not in options, "meaningless in an OpenAI-style body"
+
+
+def test_anthropic_reasoning_effort_rides_inside_output_config(tmp_path):
+    """Anthropic carries effort in `output_config`, not at the top level, and
+    the token budget still has to travel with it."""
+    core = _remote_core(tmp_path, base_url="https://api.anthropic.com/v1")
+    core.config["published_context_window"] = 200_000
+    core.refresh_context_limit()
+    core.config["remote_reasoning_effort"] = "xhigh"
+
+    options = core.chat_options()
+
+    assert options == {
+        "max_tokens": core._reply_room(),
+        "output_config": {"effort": "xhigh"},
+    }
+    assert "reasoning_effort" not in options, "that is the OpenAI spelling"
+
+
+def test_openai_style_reasoning_effort_is_sent_top_level(tmp_path):
+    core = _remote_core(tmp_path)
+    core.config["remote_reasoning_effort"] = "low"
+
+    options = core.chat_options()
+
+    assert options == {"reasoning_effort": "low"}
+    assert "output_config" not in options, "that is the Anthropic spelling"
+
+
+def test_no_reasoning_effort_sends_no_effort_field(tmp_path):
+    """A model without an effort control rejects the field rather than ignoring
+    it, so an empty setting has to mean "send nothing" — not "send empty"."""
+    core = _remote_core(tmp_path)
+    core.config["remote_reasoning_effort"] = ""
+
+    assert core.chat_options() is None
+
+
+def test_switching_endpoints_drops_the_previous_effort(tmp_path):
+    """An effort belongs to the model that advertised it. Carrying "xhigh" to a
+    host that rejects the field would fail the turn outright."""
+    core = _remote_core(tmp_path)
+    core.config["remote_reasoning_effort"] = "high"
+
+    core.use_remote(base_url="https://api.anthropic.com/v1", api_key="k")
+
+    assert core.config["remote_reasoning_effort"] == ""
+
+
+def test_reselecting_the_same_endpoint_keeps_the_effort(tmp_path):
+    """"Missing means keep" — re-applying the same route must not silently
+    reset a choice the user made."""
+    core = _remote_core(tmp_path)
+    base = str(core.config["remote_base_url"])
+    core.config["remote_reasoning_effort"] = "high"
+
+    core.use_remote(base_url=base, api_key="k")
+
+    assert core.config["remote_reasoning_effort"] == "high"
 
 
 def test_a_pinned_window_that_spills_to_the_cpu_is_backed_off(tmp_path):

--- a/agent/tests/test_chatgpt_app_server.py
+++ b/agent/tests/test_chatgpt_app_server.py
@@ -773,3 +773,80 @@ def test_parity_schemas_add_submit_plan_only_in_plan_mode(tmp_path):
     assert "delegate_read_only" in {
         item["function"]["name"] for item in start["tools"]
     }
+
+
+class MeteredManagedRuntime(FakeManagedRuntime):
+    """A helper that bills each model call separately, as the real one does."""
+
+    def __init__(self, *, total=None, calls=2, tools=()):
+        super().__init__()
+        self.total = total
+        self.calls = calls
+        self.tools = list(tools)
+
+    def run_turn(self, *, text, event_handler, tool_handler=None, **_kwargs):
+        self.turn_texts.append(text)
+        if tool_handler is not None:
+            for name, arguments in self.tools:
+                tool_handler(name, arguments, f"call-{name}")
+        for index in range(self.calls):
+            usage = {"last": {"inputTokens": 100, "outputTokens": 10 + index}}
+            if self.total is not None:
+                usage["total"] = self.total
+            event_handler({
+                "method": "thread/tokenUsage/updated",
+                "params": {"tokenUsage": usage},
+            })
+        event_handler({
+            "method": "item/agentMessage/delta",
+            "params": {"delta": "done"},
+        })
+        return {"status": "completed"}
+
+
+def _turn_done(core, runtime, text="do the work", **kwargs):
+    events = []
+    core.on_event(events.append)
+    core.run_turn(text, **kwargs)
+    return next(event for event in events if event["type"] == "turn_done")
+
+
+def test_managed_turn_counts_every_model_call_and_tool_step(tmp_path):
+    """A managed turn used to report one model call however much it did."""
+    # Two tools keeps this under FINAL_ANSWER_TOOL_FLOOR, so the turn is
+    # exactly one thread call's worth of work and the arithmetic stays legible.
+    runtime = MeteredManagedRuntime(
+        calls=3, tools=[("list_dir", {}), ("glob", {"pattern": "*"})]
+    )
+    core = _managed_core(tmp_path, runtime)
+
+    terminal = _turn_done(core, runtime)
+
+    assert terminal["model_calls"] == 3
+    assert terminal["tool_steps"] == 2
+    assert terminal["prompt_tokens"] == 300
+    assert terminal["completion_tokens"] == 10 + 11 + 12
+
+
+def test_managed_turn_prefers_a_server_reported_total(tmp_path):
+    runtime = MeteredManagedRuntime(
+        calls=2, total={"inputTokens": 900, "outputTokens": 90}
+    )
+    core = _managed_core(tmp_path, runtime)
+
+    terminal = _turn_done(core, runtime, allow_tools=False)
+
+    assert terminal["prompt_tokens"] == 900
+    assert terminal["completion_tokens"] == 90
+    assert terminal["model_calls"] == 2
+    assert terminal["tool_steps"] == 0
+
+
+def test_managed_turn_without_usage_updates_still_reports_one_call(tmp_path):
+    runtime = MeteredManagedRuntime(calls=0)
+    core = _managed_core(tmp_path, runtime)
+
+    terminal = _turn_done(core, runtime, allow_tools=False)
+
+    assert terminal["model_calls"] == 1
+    assert terminal["tool_steps"] == 0


### PR DESCRIPTION
## Why

The Runs panel described a Solo run that wrote two files, ran tests twice and verified them live as **"Model calls 1 / Total tokens 22,901"**, with an Activity list of two rows. Both numbers were artifacts and the empty list was structural — so a working run read as a no-op, which is what made worker delegation look broken when it was not.

Delegation is fine: `delegate_read_only` was registered for that run (`solo_swarm: true` on both `run_started` and `turn_done`), it requires 2–4 *independent* tasks, and the run was a sequential TDD chain. A later run delegated two workers successfully seven minutes after the commit that was suspected of breaking it.

## Agent

- `_run_chatgpt_turn` hardcoded `model_calls: 1` and read token totals from the **final** `thread/tokenUsage/updated` snapshot. App Server bills a whole turn as one thread call, so the loop counter never advanced and one request's cost was reported as the turn's. Model calls are now derived from the helper's per-call usage reports, and tokens summed across them.
- Both routes now report `tool_steps` — the count a reader recognises as how much work happened. Documented in `agent/PROTOCOL.md`.
- A delegation route that fails to arm says so durably, so "did not delegate" no longer means either a choice or a breakage.
- The counter #44's final-answer pass reads is renamed: App Server turns track `native_tool_steps` in the turn's own scope, so a missing helper cannot leave it unbound.

## Panel

- **Summary strip** — duration, steps, files, tokens — answers "what happened" before any card.
- **Request** is shown as typed, not as the composer's decorated prompt whose boilerplate was long enough that clamping hid the request itself.
- **What happened** lists files written and commands run, rebuilt from `file_effects` already in each run's event log — so finished runs read like live ones. The panel previously answered this from live git state and went blank for history.
- **Activity** — the allow-list was team-shaped, so a Solo run's two lifecycle rows were the only ones that could survive and the useful view sat behind "Technical log". Solo runs now show their tool calls with outcomes and elapsed offsets; that switch is the raw firehose again, and says so.

## Accessibility

Three defects surfaced: activity rows reported empty labels, the header icon was exposed as its raw SF Symbol name, and small labels measured 4.5:1 against the card — on the floor, now 11.9:1. The panel had no accessibility audit; it has one.

## Also landed

In-flight work that shared these files during the same session and could not be separated cleanly, verified together: per-workspace reasoning effort, the standalone image artifact renderer, ChatGPT accounts starting under the Locus contract, and the `grill` schedule mode.

## Verification

Rebased onto `main` after #44 landed, and re-run: Python 658 · Swift unit 759 · Runs UI 7 including the new audit · design-system audit — all pass.