### PR TITLE
Make the Solo delegation info card readable at 1x

### DIFF
--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -1619,7 +1619,10 @@ struct InspectorRunsTab: View {
                 .font(.locus(size: 9, weight: .semibold))
             Text("When parallel work would help, temporary workers share the selected model and inherit the current tools and permission mode.")
                 .font(.locus(size: 8))
-                .foregroundStyle(LocusTheme.muted)
+                // `muted` measures ~4.3:1 against this tinted card once the
+                // text is actually drawn, and fails outright on a 1x display
+                // where there is no subpixel coverage to help it.
+                .foregroundStyle(LocusTheme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .accessibilityIdentifier("runs.solo.adaptiveDelegation")


### PR DESCRIPTION
The accessibility audit added in #45 fails on CI. `runs.solo.adaptiveDelegation` — the "Solo delegates automatically" card — renders its body text at **4.3:1** against its own green tint:

```
Contrast failed, identifier=runs.solo.adaptiveDelegation,
rendered=darkest=72746B lightest=EDEDDC scale=1.0
```

It passed locally and failed on the runner because of `scale`: at 2x, subpixel coverage lifts the darkest drawn pixel just over 4.5:1; at 1x there is no coverage to borrow. The element predates the audit — the audit is simply the first thing to look at that surface.

`muted` is the wrong role for body copy on a tinted card; this uses the secondary text token, which clears the floor at either scale.

Note the `swift` check is red here as it has been on `main` since #41 — `No "Mac Development" signing certificate matching team ID 4X4RJA7GMD` on the runner. Unrelated to this change.