### PR TITLE
Make CI green again: wallet-chain signing override and 1x contrast sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,8 @@ jobs:
           actual="$(shasum -a 256 "$foundry_dir/$asset" | awk '{print $1}')"
           test "$actual" = "$expected"
           tar -xzf "$foundry_dir/$asset" -C "$foundry_dir"
-          LOCUS_ANVIL_BIN="$foundry_dir/anvil" Tools/RunWalletChainTests.sh
+          LOCUS_ANVIL_BIN="$foundry_dir/anvil" Tools/RunWalletChainTests.sh \
+            CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=
       - name: Direct and App Store release configurations compile
         env:
           LOCUS_BUNDLE_MODE: skip

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -1751,7 +1751,7 @@ struct InspectorRunsTab: View {
                 Text(runCategoryTitle(run).uppercased())
                     .font(.locus(size: 7, weight: .bold))
                     .tracking(0.5)
-                    .foregroundStyle(LocusTheme.muted)
+                    .foregroundStyle(LocusTheme.textSecondary)
             }
             .padding(.horizontal, 12)
             .frame(height: 31)
@@ -1790,7 +1790,12 @@ struct InspectorRunsTab: View {
                         .font(.locus(size: 11, weight: .bold))
                     Text(runStateTitle(run))
                         .font(.locus(size: 8, design: .monospaced))
-                        .foregroundStyle(LocusTheme.muted)
+                        // The darkest pixel `muted` glyphs draw at 1x is
+                        // #72746B — about 4.0:1 against the panel, under the
+                        // audit's 4.5:1 floor. Same class as the delegation
+                        // card fixed for #46, so every small text run on this
+                        // surface uses the secondary role instead.
+                        .foregroundStyle(LocusTheme.textSecondary)
                         .accessibilityIdentifier("runs.state")
                 }
                 Spacer()
@@ -1983,7 +1988,7 @@ struct InspectorRunsTab: View {
                             VStack(alignment: .leading, spacing: 3) {
                                 Text("Changed files")
                                     .font(.locus(size: 8))
-                                    .foregroundStyle(LocusTheme.muted)
+                                    .foregroundStyle(LocusTheme.textSecondary)
                                 ForEach(model.gitWorkspace.gitChanges.prefix(8)) { change in
                                     Text("\(change.status.marker)  \(change.path)")
                                         .font(.locus(size: 7, design: .monospaced))
@@ -1992,7 +1997,7 @@ struct InspectorRunsTab: View {
                                 if model.gitWorkspace.gitChanges.count > 8 {
                                     Text("+ \(model.gitWorkspace.gitChanges.count - 8) more")
                                         .font(.locus(size: 7))
-                                        .foregroundStyle(LocusTheme.muted)
+                                        .foregroundStyle(LocusTheme.textSecondary)
                                 }
                             }
                         }
@@ -2020,7 +2025,7 @@ struct InspectorRunsTab: View {
                         }
                     }
                     .font(.locus(size: 7, design: .monospaced))
-                    .foregroundStyle(LocusTheme.muted)
+                    .foregroundStyle(LocusTheme.textSecondary)
                     .padding(.top, 6)
                 }
                 .font(.locus(size: 8, weight: .semibold))
@@ -2044,7 +2049,7 @@ struct InspectorRunsTab: View {
                 if attempts.isEmpty && waitingJobs.isEmpty {
                     Text("No jobs were assigned for this run.")
                         .font(.locus(size: 8))
-                        .foregroundStyle(LocusTheme.muted)
+                        .foregroundStyle(LocusTheme.textSecondary)
                 } else {
                     ForEach(attempts) { attempt in
                         agentTreeRow(attempt, run: run)
@@ -2058,7 +2063,7 @@ struct InspectorRunsTab: View {
                                     .font(.locus(size: 8, weight: .bold))
                                 Text("· waiting")
                                     .font(.locus(size: 7, design: .monospaced))
-                                    .foregroundStyle(LocusTheme.muted)
+                                    .foregroundStyle(LocusTheme.textSecondary)
                             }
                             Text(job.goal)
                                 .font(.locus(size: 8))
@@ -2067,7 +2072,7 @@ struct InspectorRunsTab: View {
                             if !job.dependencies.isEmpty {
                                 Text("Runs after: \(job.dependencies.joined(separator: ", "))")
                                     .font(.locus(size: 7))
-                                    .foregroundStyle(LocusTheme.muted)
+                                    .foregroundStyle(LocusTheme.textSecondary)
                             }
                         }
                         .padding(.leading, 3)
@@ -2433,7 +2438,7 @@ struct InspectorRunsTab: View {
                 Spacer()
                 Text(activity.state.title)
                     .font(.locus(size: 7, design: .monospaced))
-                    .foregroundStyle(LocusTheme.muted)
+                    .foregroundStyle(LocusTheme.textSecondary)
             }
             Text(activity.goal)
                 .font(.locus(size: 8))
@@ -2443,7 +2448,7 @@ struct InspectorRunsTab: View {
                   activity.executionEngine.replacingOccurrences(of: "_", with: " ")]
                 .filter { !$0.isEmpty }.joined(separator: " · "))
                 .font(.locus(size: 7, design: .monospaced))
-                .foregroundStyle(LocusTheme.muted)
+                .foregroundStyle(LocusTheme.textSecondary)
                 .lineLimit(1)
             if !activity.output.isEmpty, activity.output != "Branch started" {
                 Text(activity.output)
@@ -2482,7 +2487,7 @@ struct InspectorRunsTab: View {
                 Spacer()
                 Text(attempt.state.replacingOccurrences(of: "_", with: " "))
                     .font(.locus(size: 7, design: .monospaced))
-                    .foregroundStyle(LocusTheme.muted)
+                    .foregroundStyle(LocusTheme.textSecondary)
             }
             Text(attempt.goal)
                 .font(.locus(size: 8))
@@ -2492,7 +2497,7 @@ struct InspectorRunsTab: View {
                   attempt.resolvedExecutionEngine.replacingOccurrences(of: "_", with: " ")]
                 .compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " · "))
                 .font(.locus(size: 7, design: .monospaced))
-                .foregroundStyle(LocusTheme.muted)
+                .foregroundStyle(LocusTheme.textSecondary)
                 .lineLimit(1)
             if let output = attempt.output, !output.isEmpty {
                 Text(output)
@@ -2504,7 +2509,7 @@ struct InspectorRunsTab: View {
             if !attempt.evidence.isEmpty {
                 Text("Evidence · \(attempt.evidence.joined(separator: ", "))")
                     .font(.locus(size: 7))
-                    .foregroundStyle(LocusTheme.muted)
+                    .foregroundStyle(LocusTheme.textSecondary)
                     .lineLimit(4)
             }
             if !attempt.uncertainties.isEmpty {
@@ -2515,7 +2520,7 @@ struct InspectorRunsTab: View {
             }
             Text("\(attempt.modelCalls) calls · \((attempt.promptTokens + attempt.completionTokens).formatted()) tokens")
                 .font(.locus(size: 7, design: .monospaced))
-                .foregroundStyle(LocusTheme.muted)
+                .foregroundStyle(LocusTheme.textSecondary)
         }
         .padding(8)
         .background(LocusTheme.white.opacity(0.55))
@@ -2596,7 +2601,7 @@ struct InspectorRunsTab: View {
                                 ? "Events will appear here as this run progresses."
                                 : "Try a different search term, or switch on Raw events.")
                                 .font(.locus(size: 8))
-                                .foregroundStyle(LocusTheme.muted)
+                                .foregroundStyle(LocusTheme.textSecondary)
                                 .multilineTextAlignment(.center)
                         }
                         .padding(24)
@@ -2676,7 +2681,7 @@ struct InspectorRunsTab: View {
 
     private func metricRow(_ title: String, _ value: String) -> some View {
         HStack {
-            Text(title).foregroundStyle(LocusTheme.muted)
+            Text(title).foregroundStyle(LocusTheme.textSecondary)
             Spacer()
             Text(value).fontWeight(.semibold)
         }
@@ -2733,11 +2738,11 @@ struct InspectorRunsTab: View {
                         .font(.locus(size: 8, weight: .bold))
                     Text("· \(attempt.state.replacingOccurrences(of: "_", with: " "))")
                         .font(.locus(size: 7, design: .monospaced))
-                        .foregroundStyle(LocusTheme.muted)
+                        .foregroundStyle(LocusTheme.textSecondary)
                 }
                 Text("\(attempt.provider ?? "Unknown provider") · \(attempt.model ?? "Unknown model") · \(attempt.resolvedExecutionEngine.replacingOccurrences(of: "_", with: " "))")
                     .font(.locus(size: 7, design: .monospaced))
-                    .foregroundStyle(LocusTheme.muted)
+                    .foregroundStyle(LocusTheme.textSecondary)
                     .lineLimit(1)
                 Text(attempt.goal)
                     .font(.locus(size: 8))
@@ -2752,12 +2757,12 @@ struct InspectorRunsTab: View {
                 if !attempt.evidence.isEmpty {
                     Text("Evidence · \(attempt.evidence.joined(separator: ", "))")
                         .font(.locus(size: 7))
-                        .foregroundStyle(LocusTheme.muted)
+                        .foregroundStyle(LocusTheme.textSecondary)
                         .lineLimit(3)
                 }
                 Text("\(attempt.modelCalls) calls · \(attempt.promptTokens + attempt.completionTokens) tokens · \(attempt.elapsedMilliseconds) ms")
                     .font(.locus(size: 7, design: .monospaced))
-                    .foregroundStyle(LocusTheme.muted)
+                    .foregroundStyle(LocusTheme.textSecondary)
             }
             Spacer(minLength: 0)
             if !run.isSoloSwarm,
@@ -2796,7 +2801,7 @@ struct InspectorRunsTab: View {
                         HStack(alignment: .top, spacing: 8) {
                             Text("\(event.sequence)")
                                 .font(.locus(size: 7, design: .monospaced))
-                                .foregroundStyle(LocusTheme.muted)
+                                .foregroundStyle(LocusTheme.textSecondary)
                                 .frame(width: 30, alignment: .trailing)
                             Circle().fill(color(for: event.type)).frame(width: 6, height: 6).padding(.top, 3)
                             VStack(alignment: .leading, spacing: 2) {
@@ -2809,14 +2814,14 @@ struct InspectorRunsTab: View {
                                 if let detail = event.detail, detail != event.title {
                                     Text(detail)
                                         .font(.locus(size: 7, design: .monospaced))
-                                        .foregroundStyle(LocusTheme.muted)
+                                        .foregroundStyle(LocusTheme.textSecondary)
                                         .lineLimit(12)
                                         .textSelection(.enabled)
                                 }
                                 if let job = event.jobID {
                                     Text("job \(job)\(event.attemptID.map { " · \($0)" } ?? "")")
                                         .font(.locus(size: 7, design: .monospaced))
-                                        .foregroundStyle(LocusTheme.muted)
+                                        .foregroundStyle(LocusTheme.textSecondary)
                                 }
                             }
                             Spacer(minLength: 0)
@@ -2843,7 +2848,7 @@ struct InspectorRunsTab: View {
                                     .font(.locus(size: 9, weight: .bold))
                                 Text("attempt \(attempt.attempt)")
                                     .font(.locus(size: 7, design: .monospaced))
-                                    .foregroundStyle(LocusTheme.muted)
+                                    .foregroundStyle(LocusTheme.textSecondary)
                                 Spacer()
                                 if model.teamRunPresentation(
                                     for: run.id, durable: run
@@ -2878,11 +2883,11 @@ struct InspectorRunsTab: View {
                             Text(attempt.goal).font(.locus(size: 8)).lineLimit(4)
                             Text("\(attempt.role ?? "specialist") · \(attempt.state)")
                                 .font(.locus(size: 7, design: .monospaced))
-                                .foregroundStyle(LocusTheme.muted)
+                                .foregroundStyle(LocusTheme.textSecondary)
                             if let provider = attempt.provider, !provider.isEmpty {
                                 Text("\(provider) · \(attempt.model ?? "")")
                                     .font(.locus(size: 7, design: .monospaced))
-                                    .foregroundStyle(LocusTheme.muted)
+                                    .foregroundStyle(LocusTheme.textSecondary)
                             }
                             if let output = attempt.output, !output.isEmpty {
                                 Text(output)

--- a/Tools/RunWalletChainTests.sh
+++ b/Tools/RunWalletChainTests.sh
@@ -63,6 +63,8 @@ if ! curl -fsS \
 fi
 
 cd "$repo_root"
+# Extra arguments pass through to xcodebuild. CI and contributors outside
+# the team append `CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=` (CONTRIBUTING.md).
 LOCUS_BUNDLE_MODE=skip \
 xcodebuild test \
   -project Locus.xcodeproj \
@@ -71,4 +73,5 @@ xcodebuild test \
   -destination 'platform=macOS' \
   -only-testing:LocusWalletChainTests \
   LOCUS_ANVIL_RPC_URL="$rpc_url" \
-  LOCUS_ANVIL_VERSION="$pinned_version"
+  LOCUS_ANVIL_VERSION="$pinned_version" \
+  "$@"


### PR DESCRIPTION
Fixes the two failures that have kept CI red on every run since #43.

## swift job — Pinned Anvil wallet-chain integration

#43 moved Debug signing to an Apple Development identity on team 4X4RJA7GMD, with the documented convention that CI and outside contributors append `CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=`. The workflow got that override on the unit-test and UI-test steps, but the wallet-chain step's xcodebuild call lives inside `Tools/RunWalletChainTests.sh` and never received it — every run since fails with *No signing certificate "Mac Development" found*.

The script now forwards extra arguments to xcodebuild, and CI passes the same override the other two steps use. Team-local runs are unchanged.

## ui job — testRunsPanelPassesAnAccessibilityAudit

The audit added in #45 has failed one element per run — the delegation card (#45), then `runs.state` (#46, #47) — because `continueAfterFailure = false` stops at the first unhandled issue. The failure attachments show all of them are one class: at 1x, the darkest pixel `muted` glyphs below ~9pt draw is `#72746B`, ≈4.0:1 against the panel, under the 4.5:1 floor (at 2x subpixel coverage lifts the same text over it, so it never reproduces locally on Retina).

This retires the class instead of the next instance: every small information-carrying text run on the audited runs surfaces moves `muted` → `textSecondary` (the exact call #46 made for the card — measured 10.7:1 after that fix). Icons and decorative marks stay `muted`.

## Verification

- `xcodebuild build-for-testing` for the Locus scheme (Debug, `CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=`) succeeds — also exercises the override against the new manual Debug signing config
- `Tools/AuditDesignSystem.sh` passes; `zsh -n` on the changed script passes
- The 1x contrast measurement itself only reproduces on CI runners, so the ui job on this PR is the authoritative check