### PR TITLE
fix(release): refuse to package a public release without the component feed

### DIFF
--- a/Tools/GenerateAppcast.sh
+++ b/Tools/GenerateAppcast.sh
@@ -25,6 +25,20 @@ first_updater_build=17
     exit 1
 }
 
+# The appcast never travels alone: installed apps also resolve
+# LocusComponentFeedURL against releases/latest/download, so the release that
+# carries this feed must republish components.json and its archive(s) too.
+# Missing components fail a public (notarized) run outright; a feed-generation
+# dry run only warns, so it does not require building the component first.
+if ! "${repo_root}/Tools/VerifyComponentAssets.sh" "${zip_path:h}" >/dev/null; then
+    if [[ "${LOCUS_NOTARIZE:-0}" == "1" ]]; then
+        echo "error: refusing to prepare a public appcast without the component assets above." >&2
+        exit 1
+    fi
+    echo "WARNING: continuing without verified component assets (details above)." >&2
+    echo "Do not publish a release without components.json and its archive." >&2
+fi
+
 tools_root="${LOCUS_SPARKLE_TOOLS_DIR:-${repo_root}/.release-tools/Sparkle-${sparkle_version}}"
 tools_archive="${tools_root:h}/Sparkle-${sparkle_version}.tar.xz"
 if [[ ! -x "${tools_root}/bin/generate_appcast" ]]; then

--- a/Tools/PackageRelease.sh
+++ b/Tools/PackageRelease.sh
@@ -73,6 +73,15 @@ if [[ "${LOCUS_NOTARIZE:-0}" == "1" && "${zip_out:t}" != "Locus-macOS.zip" ]]; t
     echo "error: public direct-download releases must be named Locus-macOS.zip" >&2
     exit 1
 fi
+component_archives=()
+if [[ "${LOCUS_NOTARIZE:-0}" == "1" ]]; then
+    # The shipped app resolves LocusComponentFeedURL against
+    # releases/latest/download, so the release this zip is destined for must
+    # also republish components.json and the archive(s) it points at.
+    # Checked before any signing so a missing component fails in seconds,
+    # not after the notarization wait.
+    component_archives=("${(@f)$("${repo_root}/Tools/VerifyComponentAssets.sh" "${zip_out:h}")}")
+fi
 revision_label="${revision}"
 if [[ "${dirty}" == "1" ]]; then
     revision_label="${revision}-dirty"
@@ -227,5 +236,10 @@ fi
 /bin/ls -lh "${zip_out}"
 if [[ "${LOCUS_NOTARIZE:-0}" == "1" ]]; then
     "${repo_root}/Tools/GenerateAppcast.sh" "${zip_out}" "${zip_out:h}/appcast.xml"
-    echo "Upload Locus-macOS.zip and appcast.xml to the same draft GitHub release."
+    echo "Upload Locus-macOS.zip, appcast.xml, components.json, and" \
+        "${(j:, :)component_archives} to the same draft GitHub release."
+    echo "They travel together: installed apps resolve both the appcast and the"
+    echo "component feed via releases/latest/download, so a release published"
+    echo "without the component pair 404s the ChatGPT-plan download for every"
+    echo "installed copy."
 fi

--- a/Tools/VerifyComponentAssets.sh
+++ b/Tools/VerifyComponentAssets.sh
@@ -1,0 +1,77 @@
+#!/bin/zsh
+# Verifies that a release staging directory carries the ChatGPT-plan component
+# feed alongside the app. Installed 2.0.0+ apps resolve LocusComponentFeedURL
+# against releases/latest/download, so whichever release is "latest" must
+# serve components.json plus every archive it references — publishing one
+# without them 404s the ChatGPT-plan download for every installed copy, not
+# just users of the new version.
+#
+# Usage: VerifyComponentAssets.sh <release-staging-directory>
+# Diagnostics go to stderr; stdout is the verified archive filenames, one per
+# line, so callers can name them in their upload instructions.
+set -euo pipefail
+
+staging="${1:?usage: VerifyComponentAssets.sh <release-staging-directory>}"
+feed="${staging}/components.json"
+
+[[ -f "${feed}" ]] || {
+    echo "error: ${feed} is missing." >&2
+    echo "Every GitHub release must republish components.json and the archive(s)" >&2
+    echo "it references: installed apps fetch them via releases/latest/download," >&2
+    echo "so a release without them breaks the ChatGPT-plan download everywhere." >&2
+    echo "Run Tools/PackageComponents.sh \"${staging}\" first (or copy the assets" >&2
+    echo "from the previous release if the component is unchanged)." >&2
+    exit 1
+}
+
+# One line per component: "<archive-filename>\t<sha256>". Structural problems
+# (wrong schema, no components, a URL that does not point at this repository's
+# releases) fail here, before any hashing.
+entries="$(/usr/bin/python3 - "${feed}" <<'PYEOF'
+import json
+import sys
+import urllib.parse
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    feed = json.load(handle)
+if feed.get("schemaVersion") != 1:
+    sys.exit(f"error: components.json has unsupported schemaVersion {feed.get('schemaVersion')!r}")
+components = feed.get("components")
+if not isinstance(components, list) or not components:
+    sys.exit("error: components.json lists no components")
+for component in components:
+    url = component.get("url", "")
+    sha256 = component.get("sha256", "")
+    split = urllib.parse.urlsplit(url)
+    name = split.path.rsplit("/", 1)[-1]
+    if split.scheme != "https" or split.netloc != "github.com" \
+            or not split.path.startswith("/nahid-sparktales/locus/releases/"):
+        sys.exit(f"error: component URL does not point at this repository's releases: {url!r}")
+    if not name or len(sha256) != 64:
+        sys.exit(f"error: malformed component entry: {json.dumps(component)}")
+    print(f"{name}\t{sha256}")
+PYEOF
+)"
+
+archives=()
+while IFS=$'\t' read -r name sha256; do
+    archive="${staging}/${name}"
+    [[ -f "${archive}" ]] || {
+        echo "error: components.json references ${name}, which is not in ${staging}." >&2
+        echo "The feed and its archive must be published as a pair; run" >&2
+        echo "Tools/PackageComponents.sh \"${staging}\" to rebuild both together." >&2
+        exit 1
+    }
+    actual="$(/usr/bin/shasum -a 256 "${archive}" | /usr/bin/awk '{print $1}')"
+    [[ "${actual}" == "${sha256}" ]] || {
+        echo "error: ${name} does not match the sha256 recorded in components.json." >&2
+        echo "Clients verify that hash before installing, so publishing this pair" >&2
+        echo "would fail on every machine; run Tools/PackageComponents.sh" >&2
+        echo "\"${staging}\" to rebuild the feed and archive together." >&2
+        exit 1
+    }
+    archives+=("${name}")
+done <<< "${entries}"
+
+echo "Component feed verified: ${(j:, :)archives} staged with matching SHA-256." >&2
+printf '%s\n' "${archives[@]}"


### PR DESCRIPTION
## Why

Installed 2.0.0+ apps resolve `LocusComponentFeedURL` against `releases/latest/download`, so every new GitHub release must republish `components.json` and the `chatgpt-plan-<ver>-<arch>.zip` it references — a release without them 404s the ChatGPT-plan download for **every installed copy**, not just users of the new version. Nothing enforced the pairing: `PackageComponents.sh` is a separate manual step, and `PackageRelease.sh`'s final instructions told the operator to upload only `Locus-macOS.zip` and `appcast.xml`.

## What

- **New `Tools/VerifyComponentAssets.sh`** — shared check for the release staging directory: `components.json` present, schemaVersion 1 with a non-empty component list, every URL pointing at this repository's releases over https, and each referenced archive staged beside the feed with the exact SHA-256 clients verify before installing. Every error states the consequence and the remediation (`Tools/PackageComponents.sh <dir>`, or copy the previous release's assets when the component is unchanged). Verified archive filenames go to stdout so callers can name them in instructions.
- **`Tools/PackageRelease.sh`** — runs the check as a preflight under `LOCUS_NOTARIZE=1`, before any signing, so a missing component fails in seconds instead of after the notarization wait. The final upload instructions now name all four assets (zip, appcast, feed, component archive) and explain why they travel together.
- **`Tools/GenerateAppcast.sh`** — hard-fails a notarized run without the component assets; a dry run warns loudly but continues, so feed generation can still be tested without building the component.

## Testing

- `zsh -n` passes on all three scripts.
- Fixture-tested the verifier: happy path emits the archive name; missing feed, missing archive, hash mismatch, foreign URL, wrong schemaVersion, and empty component list each fail with a specific message.
- Exercised the inserted caller logic verbatim in isolation (full runs need a Developer ID identity and built app): the `set -e` capture in `PackageRelease.sh` aborts on failure, and the `GenerateAppcast.sh` branch warns-and-continues on dry runs but exits 1 under `LOCUS_NOTARIZE=1`.
- CI never invokes these scripts, so the hard fail only ever stops a human operator.