### PR TITLE
fix(agent): keep the proxy credential out of every child process environment

### DIFF
--- a/agent/ollama_code/api/runs.py
+++ b/agent/ollama_code/api/runs.py
@@ -22,6 +22,7 @@ from ..orchestration import (
     orchestration_fingerprint,
     parse_manifest,
 )
+from ..proxy import sanitized_child_environment
 from ..runstore import RunStoreError
 from ..session_runtime import session_has_active_run
 from ..sessions import SessionMeta, SessionStore
@@ -751,7 +752,7 @@ def task_landing_checks(
                     cwd=task.execution_path,
                     stdout=output_file,
                     stderr=subprocess.STDOUT,
-                    env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+                    env={**sanitized_child_environment(), "GIT_TERMINAL_PROMPT": "0"},
                     start_new_session=True,
                 )
                 with _LANDING_CHECK_LOCK:

--- a/agent/ollama_code/codex_app_server.py
+++ b/agent/ollama_code/codex_app_server.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from . import proxy
 from .paths import APP_DIR
 
 logger = logging.getLogger(__name__)
@@ -298,6 +299,7 @@ class CodexAppServerManager:
                 text=True,
                 timeout=10,
                 check=False,
+                env=proxy.sanitized_child_environment(),
             )
         except (OSError, subprocess.TimeoutExpired) as error:
             raise CodexAppServerError(f"Could not verify the ChatGPT helper: {error}") from error
@@ -316,7 +318,7 @@ class CodexAppServerManager:
                 raise CodexAppServerError("The bundled ChatGPT helper is unavailable")
             self._verify_version()
             self._prepare_home()
-            environment = dict(os.environ)
+            environment = proxy.sanitized_child_environment()
             environment["CODEX_HOME"] = str(self.codex_home)
             environment.pop("OPENAI_API_KEY", None)
             environment.pop("LOCUS_REMOTE_API_KEY", None)

--- a/agent/ollama_code/continuity.py
+++ b/agent/ollama_code/continuity.py
@@ -16,6 +16,7 @@ from typing import Any
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 from .memory import _master_key, memory_database
+from .proxy import sanitized_child_environment
 
 SNAPSHOT_TTL_SECONDS = 30 * 24 * 60 * 60
 MAX_SNAPSHOTS_PER_WORKSPACE = 50
@@ -54,6 +55,7 @@ def workspace_changed_files(workspace: str) -> list[str]:
     try:
         completed = subprocess.run(
             ["git", "-C", workspace, "status", "--porcelain=v1", "-z"],
+            env=sanitized_child_environment(),
             capture_output=True,
             check=False,
             timeout=5,

--- a/agent/ollama_code/core.py
+++ b/agent/ollama_code/core.py
@@ -1568,6 +1568,7 @@ class AgentCore:
             result = subprocess.run(
                 ["git", "rev-parse", "--show-toplevel"],
                 cwd=self.workspace_root,
+                env=proxy.sanitized_child_environment(),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,

--- a/agent/ollama_code/evaluation_runtime.py
+++ b/agent/ollama_code/evaluation_runtime.py
@@ -22,6 +22,7 @@ from .orchestration import (
     TeamOrchestrator,
     parse_manifest,
 )
+from .proxy import sanitized_child_environment
 from .worktrees import TaskCheckout, TaskCheckoutStore, WorktreeError
 
 EvaluationTeamRunner = Callable[[ChatService, str, dict[str, Any]], None]
@@ -352,7 +353,8 @@ def run_evaluation_suite(
 def _evaluation_changed_paths(task: TaskCheckout, current_tree: str) -> list[str]:
     result = subprocess.run(
         ["git", "diff", "--name-only", "-z", task.baseline_tree, current_tree, "--"],
-        cwd=task.execution_path, capture_output=True, timeout=120, check=False,
+        cwd=task.execution_path, env=sanitized_child_environment(),
+        capture_output=True, timeout=120, check=False,
     )
     if result.returncode != 0:
         raise WorktreeError(result.stderr.decode("utf-8", errors="replace").strip())

--- a/agent/ollama_code/evaluations.py
+++ b/agent/ollama_code/evaluations.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from .orchestration import OrchestrationBudget, OrchestrationError
+from .proxy import sanitized_child_environment
 from .runstore import RunStore, sanitize_event
 from .worktrees import TaskCheckoutStore, WorktreeError
 
@@ -290,6 +291,7 @@ def _grade_assertion(
         try:
             result = subprocess.run(
                 ["/bin/zsh", "-lc", command], cwd=root, text=True,
+                env=sanitized_child_environment(),
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 timeout=int(spec.get("timeout_seconds") or 120), check=False,
             )
@@ -446,7 +448,8 @@ def _is_git_workspace(workspace: str) -> bool:
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--is-inside-work-tree"],
-            cwd=workspace, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            cwd=workspace, env=sanitized_child_environment(),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             timeout=10, check=False,
         )
     except (OSError, subprocess.TimeoutExpired):

--- a/agent/ollama_code/knowledge.py
+++ b/agent/ollama_code/knowledge.py
@@ -21,6 +21,7 @@ from urllib.parse import urlsplit
 import requests
 
 from . import paths
+from .proxy import sanitized_child_environment
 
 MAX_FILE_BYTES = 2 * 1024 * 1024
 MAX_FILES = 20_000
@@ -290,7 +291,8 @@ class KnowledgeStore:
         try:
             result = subprocess.run(
                 ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
-                cwd=self.root, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                cwd=self.root, env=sanitized_child_environment(),
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
                 timeout=30, check=False,
             )
             if result.returncode == 0:

--- a/agent/ollama_code/openai_responses_multi_agent.py
+++ b/agent/ollama_code/openai_responses_multi_agent.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .proxy import sanitized_child_environment
+
 BETA_HEADER = "responses_multi_agent=v1"
 SAFE_TOOL_NAMES = frozenset({
     "read_file", "glob", "grep", "list_dir", "git_status", "git_diff",
@@ -141,7 +143,8 @@ class ReadOnlyWorkspaceTools:
                         "--glob", "!**/credentials", "--glob", "!**/credentials.json",
                         "--glob", "!**/service-account.json", "--", query, str(target),
                     ],
-                    cwd=self.root, text=True, stdout=subprocess.PIPE,
+                    cwd=self.root, env=sanitized_child_environment(),
+                    text=True, stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT, timeout=15, check=False,
                 )
             except FileNotFoundError:
@@ -164,7 +167,8 @@ class ReadOnlyWorkspaceTools:
                 ":(exclude)**/service-account.json",
             ]
             result = subprocess.run(
-                command, cwd=self.root, text=True, stdout=subprocess.PIPE,
+                command, cwd=self.root, env=sanitized_child_environment(),
+                text=True, stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT, timeout=20, check=False,
             )
             return result.stdout[:120_000]

--- a/agent/ollama_code/orchestration.py
+++ b/agent/ollama_code/orchestration.py
@@ -32,6 +32,7 @@ from .openai_responses_multi_agent import (
     OpenAIResponsesMultiAgentClient,
     OpenAIResponsesMultiAgentError,
 )
+from .proxy import sanitized_child_environment
 from .remote import AUTH_ANTHROPIC, RemoteClient
 from .runstore import RunStore
 
@@ -2602,6 +2603,7 @@ def collect_workspace_evidence(workspace: str) -> str:
             result = subprocess.run(
                 command,
                 cwd=root,
+                env=sanitized_child_environment(),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -1834,6 +1834,7 @@ def _task_diff(svc: ChatService, workspace_root: str, execution_path: str) -> st
     result = subprocess.run(
         ["git", "diff", "--binary", "--full-index", "HEAD", "--"],
         cwd=execution_path or workspace_root,
+        env=proxy.sanitized_child_environment(),
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/agent/ollama_code/worktrees.py
+++ b/agent/ollama_code/worktrees.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from .paths import APP_DIR
+from .proxy import sanitized_child_environment
 
 MAX_PATCH_BYTES = 128 * 1024 * 1024
 TASKS_DIR = APP_DIR / "tasks"
@@ -33,6 +34,7 @@ def is_git_workspace(workspace: str) -> bool:
     result = subprocess.run(
         ["git", "rev-parse", "--is-inside-work-tree"],
         cwd=workspace,
+        env=sanitized_child_environment(),
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         timeout=10,
@@ -720,10 +722,13 @@ def _changed_paths(checkout: Path, base: str, current: str) -> list[str]:
 
 
 def _git(cwd: Path, *arguments: str, env: dict[str, str] | None = None) -> str:
+    # env=None means "inherit os.environ" — sanitized either way, because git
+    # itself spawns model-adjacent children (hooks, credential helpers) and the
+    # exec-time environment stays ps-readable for the life of the process.
     result = subprocess.run(
         ["git", *arguments],
         cwd=cwd,
-        env=env,
+        env=sanitized_child_environment(env),
         text=True,
         capture_output=True,
         timeout=120,
@@ -739,6 +744,7 @@ def _git_bytes(cwd: Path, *arguments: str) -> bytes:
     result = subprocess.run(
         ["git", *arguments],
         cwd=cwd,
+        env=sanitized_child_environment(),
         capture_output=True,
         timeout=120,
         check=False,
@@ -753,6 +759,7 @@ def _git_input(cwd: Path, data: bytes, *arguments: str) -> subprocess.CompletedP
         ["git", *arguments],
         cwd=cwd,
         input=data,
+        env=sanitized_child_environment(),
         capture_output=True,
         timeout=120,
         check=False,

--- a/agent/tests/test_proxy.py
+++ b/agent/tests/test_proxy.py
@@ -22,6 +22,8 @@ import io
 import json
 import os
 import subprocess
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -519,6 +521,156 @@ def test_spawned_child_never_sees_the_raw_credential_var(tmp_path, monkeypatch):
     execute_tool("bash", {"command": "true"}, ToolContext(cwd=str(tmp_path)))
 
     assert "s3cret" not in str(calls[0][1]["env"])
+
+
+def test_codex_helper_env_is_credential_stripped(tmp_path, monkeypatch, credentialed_environ):
+    """Both ChatGPT helper spawns: the --version probe and the App Server
+    itself, which runs for the whole session with its exec-time environment
+    ps-readable the whole time."""
+    from ollama_code import codex_app_server as codex_mod
+
+    helper = tmp_path / "codex-app-server"
+    helper.write_text(f"#!/bin/sh\necho '{codex_mod.PINNED_CODEX_APP_SERVER_VERSION}'\n")
+    helper.chmod(0o755)
+    monkeypatch.delenv("LOCUS_CODEX_SKIP_VERSION_CHECK", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "user-api-key")
+
+    run_wrapper, run_calls = _recording(subprocess.run)
+    monkeypatch.setattr(codex_mod.subprocess, "run", run_wrapper)
+
+    real_popen = subprocess.Popen
+    popen_calls: list[tuple[tuple, dict]] = []
+
+    class _HelperStub:
+        stdout = None
+        stderr = None
+
+        def poll(self):
+            return None
+
+    def fake_popen(*args, **kwargs):
+        # Intercept only the App Server launch; the --version probe above runs
+        # through subprocess.run, whose internal Popen must stay real.
+        command = args[0] if args else kwargs.get("args")
+        if command and command[-1] == "stdio://":
+            popen_calls.append((args, kwargs))
+            return _HelperStub()
+        return real_popen(*args, **kwargs)
+
+    monkeypatch.setattr(codex_mod.subprocess, "Popen", fake_popen)
+
+    manager = codex_mod.CodexAppServerManager(
+        helper_path=str(helper), codex_home=tmp_path / "codex-home"
+    )
+    monkeypatch.setattr(manager, "_rpc", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(manager, "notify", lambda *_args, **_kwargs: None)
+
+    manager.ensure_started()
+
+    version_env = run_calls[0][1]["env"]
+    assert version_env["HTTP_PROXY"] == CLEAN
+    assert "s3cret" not in str(version_env)
+    env = popen_calls[0][1]["env"]
+    assert env["HTTP_PROXY"] == CLEAN
+    assert env["NO_PROXY"] == "localhost", "the proxy stays usable, just credential-free"
+    assert env["CODEX_HOME"] == str(tmp_path / "codex-home")
+    assert "OPENAI_API_KEY" not in env, "the manager's own key pops still apply"
+    assert "s3cret" not in str(env)
+
+
+def test_worktree_git_plumbing_env_is_credential_stripped(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    """Every spawn helper in worktrees.py: an env of None would hand the whole
+    credentialed parent environment to git and to whatever git runs."""
+    from ollama_code import worktrees
+
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(worktrees.subprocess, "run", wrapper)
+
+    worktrees.is_git_workspace(str(tmp_path))
+    worktrees._git(tmp_path, "version")
+    worktrees._git_bytes(tmp_path, "version")
+    worktrees._git_input(tmp_path, b"delta", "hash-object", "--stdin")
+
+    assert len(calls) == 4
+    for _args, kwargs in calls:
+        env = kwargs["env"]
+        assert env is not None
+        assert env["HTTP_PROXY"] == CLEAN
+        assert "s3cret" not in str(env)
+
+
+def test_worktree_private_index_env_override_is_still_sanitized(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    """capture_tree spawns git with {**os.environ, GIT_INDEX_FILE: ...}: the
+    override must survive, the credential must not ride along with it."""
+    from ollama_code import worktrees
+
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(worktrees.subprocess, "run", wrapper)
+
+    worktrees._git(tmp_path, "version", env={**os.environ, "GIT_INDEX_FILE": "/private-index"})
+
+    env = calls[0][1]["env"]
+    assert env["GIT_INDEX_FILE"] == "/private-index"
+    assert env["HTTP_PROXY"] == CLEAN
+    assert "s3cret" not in str(env)
+
+
+def _repository(path: Path) -> Path:
+    path.mkdir()
+    for arguments in (
+        ("init",),
+        ("config", "user.name", "Test"),
+        ("config", "user.email", "test@example.com"),
+    ):
+        subprocess.run(["git", *arguments], cwd=path, capture_output=True, check=True)
+    (path / "tracked.txt").write_text("base\n")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=path, capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=path, capture_output=True, check=True)
+    return path
+
+
+def test_landing_check_child_env_is_credential_stripped(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    """The landing-check runner executes explicit commands in a login shell for
+    up to ten minutes — the longest-lived, most script-shaped child there is."""
+    from ollama_code import worktrees
+    from ollama_code.api import runs as runs_mod
+
+    source = _repository(tmp_path / "source")
+    monkeypatch.setattr(worktrees, "TASKS_DIR", tmp_path / "tasks")
+    worktrees.TaskCheckoutStore.create(str(source), "task-landing")
+
+    wrapper, calls = _recording(subprocess.Popen)
+    monkeypatch.setattr(runs_mod.subprocess, "Popen", wrapper)
+
+    class _RunStoreStub:
+        def start_run(self, *_args, **_kwargs):
+            return None
+
+        def append_event(self, *_args, **_kwargs):
+            return None
+
+        def set_state(self, *_args, **_kwargs):
+            return None
+
+    service = SimpleNamespace(run_store=_RunStoreStub())
+
+    result = runs_mod.task_landing_checks(service, "task-landing", {"commands": ["true"]})
+
+    assert result["passed"] is True, "the check ran and exited 0 under the stripped env"
+    zsh_calls = [
+        (args, kwargs) for args, kwargs in calls
+        if args and args[0] and args[0][0] == "/bin/zsh"
+    ]
+    env = zsh_calls[0][1]["env"]
+    assert env["HTTP_PROXY"] == CLEAN
+    assert env["GIT_TERMINAL_PROMPT"] == "0", "the runner's own override survives"
+    assert "s3cret" not in str(env)
 
 
 def test_web_fetch_error_text_is_redacted(monkeypatch, credentialed_environ):

--- a/agent/tests/test_proxy.py
+++ b/agent/tests/test_proxy.py
@@ -673,6 +673,166 @@ def test_landing_check_child_env_is_credential_stripped(
     assert "s3cret" not in str(env)
 
 
+def test_evaluation_command_assertion_env_is_credential_stripped(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    """The eval-check runner executes configured commands in a login shell —
+    the same shape as the landing-check runner."""
+    from ollama_code import evaluations as evaluations_mod
+
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(evaluations_mod.subprocess, "run", wrapper)
+
+    ok, detail = evaluations_mod._grade_assertion(
+        {"kind": "command", "command": "true"}, tmp_path, "", []
+    )
+
+    assert ok, detail
+    env = calls[0][1]["env"]
+    assert env["HTTP_PROXY"] == CLEAN
+    assert "s3cret" not in str(env)
+
+
+def test_evaluation_git_probe_env_is_credential_stripped(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    from ollama_code import evaluations as evaluations_mod
+
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(evaluations_mod.subprocess, "run", wrapper)
+
+    evaluations_mod._is_git_workspace(str(tmp_path))
+
+    env = calls[0][1]["env"]
+    assert env["HTTP_PROXY"] == CLEAN
+    assert "s3cret" not in str(env)
+
+
+def test_multi_agent_workspace_tools_env_is_credential_stripped(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    """The hosted agents' read-only tools shell out to rg and git in the user
+    workspace; the grep call is recorded even when rg is not installed."""
+    from ollama_code import openai_responses_multi_agent as multi_agent_mod
+
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(multi_agent_mod.subprocess, "run", wrapper)
+
+    tools = multi_agent_mod.ReadOnlyWorkspaceTools(str(tmp_path))
+    tools.execute("grep", json.dumps({"query": "needle"}))
+    tools.execute("git_status", "{}")
+    tools.execute("git_diff", "{}")
+
+    assert calls, "no spawn was recorded"
+    for _args, kwargs in calls:
+        env = kwargs["env"]
+        assert env["HTTP_PROXY"] == CLEAN
+        assert "s3cret" not in str(env)
+
+
+def test_task_diff_env_is_credential_stripped(tmp_path, monkeypatch, credentialed_environ):
+    """server._task_diff falls back to raw git when no managed task is active."""
+    from ollama_code import server as server_mod
+
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(server_mod.subprocess, "run", wrapper)
+
+    server_mod._task_diff(SimpleNamespace(current_task=None), str(tmp_path), "")
+
+    env = calls[0][1]["env"]
+    assert env["HTTP_PROXY"] == CLEAN
+    assert "s3cret" not in str(env)
+
+
+def test_canonical_repository_env_is_credential_stripped(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    from ollama_code import core as core_mod
+
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(core_mod.subprocess, "run", wrapper)
+
+    # Duck-typed self: the method reads only workspace_root, so the full
+    # AgentCore constructor (MCP manager, config writes) stays out of the test.
+    core_mod.AgentCore._canonical_repository(SimpleNamespace(workspace_root=str(tmp_path)))
+
+    env = calls[0][1]["env"]
+    assert env["HTTP_PROXY"] == CLEAN
+    assert "s3cret" not in str(env)
+
+
+def test_evaluation_changed_paths_env_is_credential_stripped(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    from ollama_code import evaluation_runtime as evaluation_runtime_mod
+    from ollama_code.worktrees import TaskCheckout, WorktreeError
+
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(evaluation_runtime_mod.subprocess, "run", wrapper)
+
+    task = TaskCheckout(
+        id="task-env",
+        workspace_root=str(tmp_path),
+        execution_path=str(tmp_path),
+        baseline_tree="HEAD",
+        baseline_commit="HEAD",
+    )
+    with pytest.raises(WorktreeError):
+        evaluation_runtime_mod._evaluation_changed_paths(task, "HEAD")
+
+    env = calls[0][1]["env"]
+    assert env["HTTP_PROXY"] == CLEAN
+    assert "s3cret" not in str(env)
+
+
+def test_workspace_evidence_env_is_credential_stripped(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    from ollama_code import orchestration as orchestration_mod
+
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(orchestration_mod.subprocess, "run", wrapper)
+
+    orchestration_mod.collect_workspace_evidence(str(tmp_path))
+
+    assert len(calls) == 4, "status, diff stat, diff, and ls-files all spawn"
+    for _args, kwargs in calls:
+        env = kwargs["env"]
+        assert env["HTTP_PROXY"] == CLEAN
+        assert "s3cret" not in str(env)
+
+
+def test_continuity_status_env_is_credential_stripped(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    from ollama_code import continuity as continuity_mod
+
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(continuity_mod.subprocess, "run", wrapper)
+
+    continuity_mod.workspace_changed_files(str(tmp_path))
+
+    env = calls[0][1]["env"]
+    assert env["HTTP_PROXY"] == CLEAN
+    assert "s3cret" not in str(env)
+
+
+def test_knowledge_index_scan_env_is_credential_stripped(
+    tmp_path, monkeypatch, credentialed_environ
+):
+    from ollama_code import knowledge as knowledge_mod
+
+    store = knowledge_mod.KnowledgeStore(str(tmp_path), path=tmp_path / "knowledge.db")
+    wrapper, calls = _recording(subprocess.run)
+    monkeypatch.setattr(knowledge_mod.subprocess, "run", wrapper)
+
+    store._candidate_paths(None)
+
+    env = calls[0][1]["env"]
+    assert env["HTTP_PROXY"] == CLEAN
+    assert "s3cret" not in str(env)
+
+
 def test_web_fetch_error_text_is_redacted(monkeypatch, credentialed_environ):
     """requests raises InvalidURL naming the whole proxy URL when urllib3
     cannot parse the proxy host, and this string goes straight to the model."""


### PR DESCRIPTION
## Problem

`proxy.py` deliberately delivers the authenticated-proxy password over stdin and strips it from child environments via `sanitized_child_environment()`, because on macOS the exec-time environment block stays readable for the life of the process through `ps -Eww` (KERN_PROCARGS2). Several spawn sites bypassed that: they handed children the raw parent environment (`dict(os.environ)`, `{**os.environ, ...}`, or no `env=` at all), so a configured proxy credential was readable by any same-user process — including model-run bash commands — for as long as those children lived.

## Fix

Two commits, both routing every affected spawn through `proxy.sanitized_child_environment()`, layering per-site overrides (`CODEX_HOME`, `GIT_INDEX_FILE`, `GIT_TERMINAL_PROMPT`) on the sanitized base:

- **196e86b** — the three audited sites: the ChatGPT/Codex helper launch and its `--version` probe (`codex_app_server.py`), the worktree git plumbing (`worktrees.py`: `_git`, `_git_bytes`, `_git_input`, `is_git_workspace`), and the landing-check runner (`api/runs.py`).
- **6456e5d** — nine more sites of the same class found by a full sweep: the eval-check zsh runner and git probe (`evaluations.py`), the hosted agents' rg/git workspace tools (`openai_responses_multi_agent.py`), the task-diff fallback (`server.py`), the canonical-repository probe (`core.py`), evaluation changed-path listing (`evaluation_runtime.py`), workspace evidence collection (`orchestration.py`), the continuity status inventory (`continuity.py`), and the knowledge index scan (`knowledge.py`).

Because the sanitizer's userinfo strip is gated on `credential_applied`, user-owned proxy credentials inherited from the shell still pass through untouched in direct-connection mode — no behavior change there.

## Tests

Thirteen regression tests extend `test_proxy.py`'s spawn-site section using its existing `_recording` + `credentialed_environ` pattern, asserting on the `env` that actually reaches each child (the landing-check and eval runners are driven end-to-end so the child provably still works under the stripped environment). Both shell-runner tests were verified to fail against the unsanitized spawns.

A closing sweep of every `subprocess.run`/`Popen` in `agent/ollama_code/` confirms no spawn hands a child the raw parent environment anymore.

## Verification

- `agent/.venv/bin/python -m pytest agent/tests` — 671 passed
- `ruff check` on all touched files — clean