### PR TITLE
Scope Runs panel Overview and Activity to the selected run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,16 @@
 
 ### Fixed
 
+- **A run's Overview no longer borrows numbers from a run that is still
+  going.** Opening one run while another was executing folded both runs'
+  events into the same Files, Steps, and model readouts, and could make a
+  reload skip part of the open run's history when the live one had counted
+  further. Every fact in the Overview and Activity views now reads only the
+  selected run's own events. Two smaller repairs ride along: a file the run
+  created and then deleted is no longer listed as "created", and an expanded
+  request or "Show more" list no longer carries over into the next run you
+  open.
+
 - **Notes whose plain-text mirror went missing are no longer loaded as empty.**
   Each note is kept as a plain `.txt` alongside a formatting archive, and a note
   that had lost the `.txt` opened blank — so the first keystroke saved that

--- a/Locus/AgentTeams.swift
+++ b/Locus/AgentTeams.swift
@@ -1404,6 +1404,10 @@ struct OrchestrationEvent: Identifiable, Codable, Hashable {
     /// attempt carries the bounded output, while hundreds of token rows make
     /// the durable timeline and Accessibility tree needlessly expensive.
     var isTransientStream: Bool { type == "agent_job_stream" }
+    /// Most emitters stamp their run's id into the payload; a few backend
+    /// paths (landing checks, memory review) persist without one, so absence
+    /// means "the run this event was fetched for", not "no run".
+    var runID: String? { text("run_id") }
     var jobID: String? { text("job_id") }
     var attemptID: String? { text("attempt_id") }
     var nodeID: String? { text("node_id") }
@@ -1498,10 +1502,12 @@ struct RunWork: Equatable {
                 guard case .object(let object) = item,
                       let path = object["path"]?.string, !path.isEmpty else { continue }
                 if effects[path] == nil { order.append(path) }
+                let effect = object["effect"]?.string ?? "edit"
                 // A file created and then edited in the same run is still new to
-                // the reader, so "create" is the fact worth keeping.
-                if effects[path] != "create" {
-                    effects[path] = object["effect"]?.string ?? "edit"
+                // the reader, so "create" is the fact worth keeping — but a later
+                // delete undoes the creation rather than being masked by it.
+                if effects[path] != "create" || effect == "delete" {
+                    effects[path] = effect
                 }
             }
         }

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -5128,7 +5128,11 @@ final class AppModel: ObservableObject {
 
     func loadOrchestrationRun(_ runID: String, terminal: Bool = false) async {
         let sameRun = selectedOrchestrationRun?.id == runID
-        let afterSequence = sameRun ? orchestrationEvents.map(\.sequence).max() ?? 0 : 0
+        // Sequences are numbered per run, and the array can hold a second,
+        // still-executing run's events: a watermark taken across both would
+        // skip this run's tail whenever the other run had counted further.
+        let afterSequence = sameRun
+            ? orchestrationEvents(for: runID).map(\.sequence).max() ?? 0 : 0
         let transport = orchestrationBackend(for: runID)
         let transportKey = transport.currentBaseURL.absoluteString
         let loadKey = "\(transportKey)|\(runID)|\(afterSequence)|\(terminal ? "terminal" : "routine")"
@@ -5190,8 +5194,11 @@ final class AppModel: ObservableObject {
     }
 
     func backfillOrchestrationEvents(_ runID: String) async {
+        // Strict on the stamp, unlike the selected-run reads: this can run for
+        // the live run while a different run's unstamped events fill the array,
+        // and counting those would inflate the watermark past unseen events.
         let after = orchestrationEvents
-            .filter { $0.text("run_id") == runID }
+            .filter { $0.runID == runID }
             .map(\.sequence)
             .max() ?? 0
         let transport = orchestrationBackend(for: runID)
@@ -5213,6 +5220,27 @@ final class AppModel: ObservableObject {
             // The inspector can still reload the full run on demand. A failed
             // reconnect backfill must not disturb the active transcript.
         }
+    }
+
+    /// Events attributable to one run, read out of the shared array.
+    ///
+    /// `handle(_:)` deliberately appends for both the selected run and the one
+    /// currently executing, so while a historical run is open during a live
+    /// turn the array interleaves two runs — folding it whole credited the
+    /// live run's files, steps, and model to whichever run was on screen.
+    /// Every per-run fact must read through this filter. An event without a
+    /// `run_id` stamp can only have arrived via the per-run fetch for the
+    /// selected run (live appends are admitted by their stamp), so it counts
+    /// as the requested run's rather than being dropped.
+    func orchestrationEvents(for runID: String) -> [OrchestrationEvent] {
+        Self.runScopedEvents(orchestrationEvents, runID: runID)
+    }
+
+    nonisolated static func runScopedEvents(
+        _ events: [OrchestrationEvent],
+        runID: String
+    ) -> [OrchestrationEvent] {
+        events.filter { $0.runID == nil || $0.runID == runID }
     }
 
     nonisolated static func mergeOrchestrationEvents(

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -1426,7 +1426,11 @@ struct InspectorRunsTab: View {
             } else if showingRunDetail,
                       let detailRunID,
                       let run = model.runRecord(for: detailRunID) {
+                // A different run is a different document: re-identifying the
+                // subtree resets scroll, "Show N more" lists, and disclosure
+                // groups instead of carrying one run's expansions into another.
                 runBody(run)
+                    .id(run.id)
             } else if showingRunDetail {
                 ProgressView("Loading run…")
                     .controlSize(.small)
@@ -1441,6 +1445,9 @@ struct InspectorRunsTab: View {
             }
         }
         .onChange(of: model.pendingDispatchPlan) { _, value in draftPlan = value }
+        // Tab-level state, so a run switch would otherwise carry it over and
+        // open the next run's request pre-expanded.
+        .onChange(of: detailRunID) { requestExpanded = false }
         .task(id: model.runsNavigationRequest?.id) {
             guard let request = model.runsNavigationRequest else {
                 showingRunDetail = false
@@ -2361,7 +2368,7 @@ struct InspectorRunsTab: View {
     }
 
     private func runWork(_ run: OrchestrationRun) -> RunWork {
-        RunWork(events: model.orchestrationEvents)
+        RunWork(events: model.orchestrationEvents(for: run.id))
     }
 
     private func technicalDetails(_ run: OrchestrationRun) -> some View {
@@ -2406,7 +2413,7 @@ struct InspectorRunsTab: View {
     /// Provider and model are reported on the turn's terminal event, which the
     /// run row itself does not carry.
     private func runModelLabel(_ run: OrchestrationRun) -> String? {
-        guard let terminal = model.orchestrationEvents.last(where: {
+        guard let terminal = model.orchestrationEvents(for: run.id).last(where: {
             $0.type == "turn_done" || $0.type == "orchestration_completed"
         }) else { return nil }
         let name = terminal.text("model") ?? ""
@@ -2566,7 +2573,8 @@ struct InspectorRunsTab: View {
     }
 
     private func activity(_ run: OrchestrationRun) -> some View {
-        VStack(spacing: 0) {
+        let groups = activityGroups(run)
+        return VStack(spacing: 0) {
             HStack {
                 TextField("Filter run activity", text: $filter)
                     .textFieldStyle(.roundedBorder)
@@ -2585,7 +2593,7 @@ struct InspectorRunsTab: View {
                 timeline(run, showsFilter: false)
             } else {
                 ScrollView {
-                    if activityGroups.isEmpty {
+                    if groups.isEmpty {
                         VStack(spacing: 8) {
                             Image(systemName: "clock")
                                 .font(.locus(size: 20))
@@ -2603,7 +2611,7 @@ struct InspectorRunsTab: View {
                         .frame(maxWidth: .infinity)
                     } else {
                         LazyVStack(alignment: .leading, spacing: 0) {
-                            ForEach(activityGroups) { group in
+                            ForEach(groups) { group in
                                 Text(group.title.uppercased())
                                     .font(.locus(size: 7, weight: .bold))
                                     .tracking(0.6)
@@ -2792,7 +2800,7 @@ struct InspectorRunsTab: View {
             }
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(filteredEvents) { event in
+                    ForEach(filteredEvents(run)) { event in
                         HStack(alignment: .top, spacing: 8) {
                             Text("\(event.sequence)")
                                 .font(.locus(size: 7, design: .monospaced))
@@ -3074,9 +3082,10 @@ struct InspectorRunsTab: View {
         draftPlan?.jobs.append(job)
     }
 
-    private var filteredEvents: [OrchestrationEvent] {
+    private func filteredEvents(_ run: OrchestrationRun) -> [OrchestrationEvent] {
         let query = filter.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let durableEvents = model.orchestrationEvents.filter { !$0.isTransientStream }
+        let durableEvents = model.orchestrationEvents(for: run.id)
+            .filter { !$0.isTransientStream }
         guard !query.isEmpty else { return durableEvents }
         return durableEvents.filter { event in
             [
@@ -3180,8 +3189,8 @@ struct InspectorRunsTab: View {
         var id: String { title }
     }
 
-    private var activityGroups: [ActivityGroup] {
-        let visible = withoutRedundantWork(filteredEvents.filter(isUserFacingEvent))
+    private func activityGroups(_ run: OrchestrationRun) -> [ActivityGroup] {
+        let visible = withoutRedundantWork(filteredEvents(run).filter(isUserFacingEvent))
         // Phase headings describe a team's shape. A solo turn that delegated
         // nothing has one phase, and filing its whole timeline under a "Solo
         // workers" heading described workers that never existed.

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -5750,6 +5750,81 @@ final class FeatureLogicTests: XCTestCase {
         XCTAssertEqual(work.commands.map(\.ok), [false])
     }
 
+    func testRunWorkDropsAFileCreatedAndThenDeletedInTheSameRun() throws {
+        let work = RunWork(events: try runEvents([
+            [
+                "seq": 1, "type": "tool_result", "tool": "write_file", "ok": true,
+                "event_id": "a", "summary": "write scratch.py",
+                "file_effects": [["path": "scratch.py", "effect": "create"]],
+            ],
+            [
+                "seq": 2, "type": "tool_result", "tool": "delete_file", "ok": true,
+                "event_id": "b", "summary": "delete scratch.py",
+                "file_effects": [["path": "scratch.py", "effect": "delete"]],
+            ],
+            [
+                "seq": 3, "type": "tool_result", "tool": "write_file", "ok": true,
+                "event_id": "c", "summary": "write kept.py",
+                "file_effects": [["path": "kept.py", "effect": "create"]],
+            ],
+        ]))
+
+        // "Created" must not survive the file's own deletion; a file that no
+        // longer exists cannot be listed and offered to open.
+        XCTAssertEqual(work.files, [RunWork.FileChange(path: "kept.py", effect: "created")])
+    }
+
+    func testRunWorkListsAFileRecreatedAfterDeletionAsCreated() throws {
+        let work = RunWork(events: try runEvents([
+            [
+                "seq": 1, "type": "tool_result", "tool": "write_file", "ok": true,
+                "event_id": "a", "summary": "write app.py",
+                "file_effects": [["path": "app.py", "effect": "create"]],
+            ],
+            [
+                "seq": 2, "type": "tool_result", "tool": "delete_file", "ok": true,
+                "event_id": "b", "summary": "delete app.py",
+                "file_effects": [["path": "app.py", "effect": "delete"]],
+            ],
+            [
+                "seq": 3, "type": "tool_result", "tool": "write_file", "ok": true,
+                "event_id": "c", "summary": "write app.py",
+                "file_effects": [["path": "app.py", "effect": "create"]],
+            ],
+        ]))
+
+        XCTAssertEqual(work.files, [RunWork.FileChange(path: "app.py", effect: "created")])
+    }
+
+    func testRunScopedEventsSeparateInterleavedRuns() throws {
+        // While a historical run is open during a live turn, the shared array
+        // holds both: the selected run's fetched history (including backend
+        // events persisted without a run_id stamp) and the live run's stamped
+        // stream. Scoping must keep the former and exclude the latter.
+        let events = try runEvents([
+            ["seq": 1, "type": "run_started", "event_id": "a1", "run_id": "run-a"],
+            [
+                "seq": 2, "type": "tool_result", "tool": "bash", "ok": true,
+                "event_id": "a2", "summary": "$ pytest", "run_id": "run-a",
+            ],
+            ["seq": 3, "type": "orchestration_completed", "event_id": "a3"],
+            ["seq": 1, "type": "run_started", "event_id": "b1", "run_id": "run-b"],
+            [
+                "seq": 2, "type": "tool_result", "tool": "write_file", "ok": true,
+                "event_id": "b2", "summary": "write app.py", "run_id": "run-b",
+                "file_effects": [["path": "app.py", "effect": "create"]],
+            ],
+        ])
+
+        let scoped = AppModel.runScopedEvents(events, runID: "run-a")
+
+        XCTAssertEqual(scoped.map(\.id), ["a1", "a2", "a3"])
+        let work = RunWork(events: scoped)
+        XCTAssertTrue(work.files.isEmpty)
+        XCTAssertEqual(work.toolSteps, 1)
+        XCTAssertEqual(work.commands.map(\.summary), ["$ pytest"])
+    }
+
     func testRunWorkSeparatesUnavailableDelegationFromAnAgentDecliningIt() throws {
         let quiet = RunWork(events: try runEvents([
             ["seq": 1, "type": "note", "text": "Nothing to split here."],


### PR DESCRIPTION
## What this changes

Opening a finished run in the Runs panel while another run is streaming no longer shows you the *other* run's numbers.

`AppModel.handle()` appends live events for the executing run into `orchestrationEvents` even when a different, historical run is selected, so that array can hold two runs at once. The Overview added in #45 folded the whole array — so selecting run A while run B streamed credited B's files, tool steps, and terminal model label to A's Overview. The same unscoped fold also drove `loadOrchestrationRun`'s incremental-fetch watermark: sequences are numbered per run, so a live run that had counted further made the reload ask for `after_seq` past events the selected run had never loaded, silently dropping part of its history.

Every per-run read now goes through `AppModel.orchestrationEvents(for:)` — `RunWork`, the step count, the model label, the Activity timeline, and the raw-event list. The filter keeps an event when its `run_id` matches **or is absent**: a few backend paths (`landing_checks_*`, `memory_review_*`, `worktree_landed`) persist payloads without the stamp, and those can only have reached the array through the per-run fetch for the selected run, so a strict filter would have blanked those runs' history instead. Live-streamed events are always stamped by the `chat_service` emit pipeline, which is the path that caused the contamination. `backfillOrchestrationEvents` stays strict on the stamp, because it can target the live run while another run's unstamped history fills the array.

Two smaller repairs in the same surface:

- **A file created and then deleted in one run was still listed as "created."** `RunWork` kept `create` as the winning effect for a path so that create-then-edit reads as new, but that also masked a later `delete` — and the row offered to open a file that no longer exists. A delete now overrides; delete-then-recreate still reads as created.
- **Expansion state leaked across run selection.** `requestExpanded` is tab-level `@State`, and `SummaryList`'s "Show N more" counter is internal to a view SwiftUI reused across runs, so opening a long run and then a short one showed the second one pre-expanded. The request card resets when the detail run changes, and the detail subtree is re-identified per run so its lists and disclosure groups open fresh.

## How you verified it

- `xcodebuild build-for-testing -scheme Locus -configuration Debug -destination 'platform=macOS'` — **TEST BUILD SUCCEEDED**.
- Unit tests via the injected-host runner (a Locus debug instance was open in another session, which makes LaunchServices refuse to launch `xcodebuild test`):
  - `LocusTests.AppModelTests` — **209 tests, 0 failures**, covering the `loadOrchestrationRun` selection/merge paths the watermark change touches.
  - The seven `RunWork`/scoping tests in `FeatureLogicTests`, individually — 0 failures.
- Three new regression tests: `testRunScopedEventsSeparateInterleavedRuns` (interleaved two-run array, including an unstamped event, folded down to one run's work), `testRunWorkDropsAFileCreatedAndThenDeletedInTheSameRun`, and `testRunWorkListsAFileRecreatedAfterDeletionAsCreated`.
- No Python changed, so `pytest` was not run. UI tests were not run for the same LaunchServices reason as above; the existing `solo-swarm-work` fixture stamps `run_id` on every event, so the fixture-driven assertions are unaffected either way.

## Checklist

- [x] Commits are signed off (`git commit -s`) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Swift suites pass (`AppModelTests` + the `RunWork` tests; no Python touched)
- [x] New state/routes follow [the ownership boundaries](../Docs/Architecture.md)
- [x] The advisory `Tools/ReviewabilityReport.py` signals were reviewed; the diff is small and local to the Runs panel
- [ ] New feature state/actions were kept out of `AppModel` — **see note below**
- [x] `xcodegen generate` not needed; no `project.yml` or layout change
- [x] No credential, key, token, or absolute local path added
- [x] No new Python dependency
- [x] User-visible changes have a `CHANGELOG.md` entry
- [x] Docs and UI strings still describe what the code now does

**On the `AppModel` boundary:** this adds one read-only accessor (`orchestrationEvents(for:)`) plus a `nonisolated static` pure function beside the existing `mergeOrchestrationEvents`. `orchestrationEvents` is already `AppModel`-owned published state, and the filter has to sit next to the `handle()` append that creates the interleaving, so putting it anywhere else would leave the invariant undocumented at the point it is violated. No new feature state was introduced.

**Follow-up worth doing separately:** `RunStore.append_event` stamps `event_id`/`seq`/`occurred_at` into the payload but not `run_id`, which is why the client filter has to tolerate unstamped events at all. A one-line `safe.setdefault("run_id", run_id)` there would make new events self-describing; the lenient client filter still has to stay for rows already persisted without it.
