### PR TITLE
test(ui): retry transcript toggle clicks that miss on slow CI runners

### DIFF
--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -117,6 +117,36 @@ final class LocusUITests: XCTestCase {
         element.coordinate(withNormalizedOffset: normalizedOffset).click()
     }
 
+    /// Clicks a disclosure toggle in the transcript and waits for its label to
+    /// become `expected`.
+    ///
+    /// On a busy CI runner the synthesized click occasionally lands while the
+    /// row is still settling from the previous interaction and misses the
+    /// toggle, so an unchanged label triggers another click. A toggle that was
+    /// hit but merely reported its new label late gets flipped back by that
+    /// retry, which is why every attempt waits for the expected label again
+    /// and the final wait is deliberately generous.
+    private func clickTranscriptToggle(
+        _ element: XCUIElement,
+        until expected: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let attempts = 3
+        for attempt in 1...attempts {
+            clickInTranscript(element, file: file, line: line)
+            let timeout: TimeInterval = attempt == attempts ? 10 : 3
+            if waitUntil(timeout: timeout, condition: { element.label == expected }) {
+                return
+            }
+        }
+        XCTFail(
+            "toggle label never became \"\(expected)\", still \"\(element.label)\"",
+            file: file,
+            line: line
+        )
+    }
+
     private func transcriptText(_ value: String) -> XCUIElement {
         app.descendants(matching: .any).matching(
             NSPredicate(format: "label == %@ OR value == %@", value, value)
@@ -646,8 +676,7 @@ final class LocusUITests: XCTestCase {
         let tableToggle = anyElement("message.table.collapse")
         XCTAssertTrue(tableToggle.waitForExistence(timeout: 3))
         XCTAssertEqual(tableToggle.label, "Collapse 11-row table")
-        clickInTranscript(tableToggle)
-        XCTAssertTrue(waitUntil { tableToggle.label == "Expand 11-row table" })
+        clickTranscriptToggle(tableToggle, until: "Expand 11-row table")
         let showTable = app.buttons["message.table.showAll"].firstMatch
         XCTAssertTrue(showTable.waitForExistence(timeout: 2))
         XCTAssertEqual(showTable.label, "Show all 11 rows")
@@ -660,8 +689,7 @@ final class LocusUITests: XCTestCase {
         let codeToggle = anyElement("message.codeBlock.collapse")
         XCTAssertTrue(codeToggle.waitForExistence(timeout: 3))
         XCTAssertEqual(codeToggle.label, "Collapse 25-line code block")
-        clickInTranscript(codeToggle)
-        XCTAssertTrue(waitUntil { codeToggle.label == "Expand 25-line code block" })
+        clickTranscriptToggle(codeToggle, until: "Expand 25-line code block")
         let showCode = app.buttons["message.codeBlock.showAll"].firstMatch
         XCTAssertTrue(showCode.waitForExistence(timeout: 2))
         XCTAssertEqual(showCode.label, "Show all 25 lines")


### PR DESCRIPTION
## What this changes

`testLongCodeAndTableStartExpandedThenCollapseWithoutChangingFullCopy` failed intermittently on CI (runs 33281425291 and 33287406310): it clicked a transcript collapse toggle and then waited only 3 seconds for the label to flip. On a busy runner the synthesized click occasionally lands while the row is still settling from the previous interaction and misses the toggle, or the label update outlasts the window.

A new `clickTranscriptToggle(_:until:)` helper clicks through the existing `clickInTranscript` (which scrolls the control into view) and waits for the expected label, re-issuing the click when it has not changed — up to 3 attempts, with a 10-second wait on the last. The retry is self-correcting: a click that landed but reported its label late gets flipped back and re-collapsed on the next attempt. If the label never becomes the expected value the helper fails the test, so the assertion semantics are unchanged — the collapse must actually happen, and the downstream copy assertion still requires all 25 source lines. Both fragile call sites in the test (the code toggle that flaked, and the table toggle with the identical pattern) now use it.

## How you verified it

- `xcodebuild build-for-testing -scheme Locus` (with `LOCUS_BUNDLE_MODE=skip`, CI signing overrides) — TEST BUILD SUCCEEDED
- `xcodebuild test-without-building -only-testing:LocusUITests/LocusUITests/testLongCodeAndTableStartExpandedThenCollapseWithoutChangingFullCopy` — passed (36.9s)

## Checklist

- [x] Commits are signed off (`git commit -s`) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Swift and Python suites pass (UI-test-only change; the touched test passes end to end)
- [x] New state/routes follow [the ownership boundaries](../Docs/Architecture.md), or the PR explains why the boundary should change (no app code touched)
- [x] The advisory `Tools/ReviewabilityReport.py` signals were reviewed; large files or diffs are intentional and independently understandable (+32/−4 in one test file)
- [x] New feature state/actions were kept out of `AppModel`, and new API handlers were kept out of `server.py` (n/a)
- [x] `xcodegen generate` run if `project.yml` or the file layout changed (no layout change)
- [x] No credential, key, token, or absolute local path added
- [x] User-visible changes have a `CHANGELOG.md` entry (no user-visible change)
- [x] Docs and UI strings still describe what the code now does