### PR TITLE
fix: question popup, honest run metrics, and file chips in listings

### DIFF
--- a/Docs/AGENT_TEAMS_FEATURE_GUIDE.md
+++ b/Docs/AGENT_TEAMS_FEATURE_GUIDE.md
@@ -34,7 +34,7 @@ Example: leave the composer in Work and send `Find why the tests fail and fix it
 
 ### Reliable plan approval
 
-Plan mode recognizes a completed plan through the structured plan tool and safe deterministic fallbacks. Clarifying questions do not trigger approval.
+Plan mode recognizes a completed plan through the structured plan tool and safe deterministic fallbacks. Clarifying questions do not trigger approval — they raise the question prompt instead (see below).
 
 After a successful planning turn, Locus offers:
 
@@ -43,6 +43,10 @@ After a successful planning turn, Locus offers:
 - **Cancel**: return to adaptive Work without implementing
 
 Queued work waits until the decision is resolved, and the pending choice survives reconnects. Use `1`–`3`, arrow keys, Return, or Escape; Escape maps to Cancel.
+
+### Questions from the agent
+
+When the agent asks the user a question — most prominently Grill mode's one-at-a-time clarifying questions — it calls the `ask_user_question` tool, and the question replaces the composer once the turn completes, the way plan approval does. The popup shows the question, its multiple-choice options when there are any (the agent's recommended answer preselected), and always a free-text row for typing your own answer. Grill turns that write the `❓` question block without calling the tool are detected from the text as a fallback. The answer is sent back as an ordinary user message; Escape dismisses the popup so you can answer in the composer instead, and queued work waits until the question is resolved or dismissed.
 
 Example: ask Plan mode to design a database migration. Choose Revise and send `Keep the old schema readable for one release`, then choose Proceed when the revised plan is ready.
 

--- a/Docs/AGENT_TEAMS_FEATURE_GUIDE.md
+++ b/Docs/AGENT_TEAMS_FEATURE_GUIDE.md
@@ -34,7 +34,7 @@ Example: leave the composer in Work and send `Find why the tests fail and fix it
 
 ### Reliable plan approval
 
-Plan mode recognizes a completed plan through the structured plan tool and safe deterministic fallbacks. Clarifying questions do not trigger approval — they raise the question prompt instead (see below).
+Plan mode recognizes a completed plan through the structured plan tool and safe deterministic fallbacks. Clarifying questions do not trigger approval — asked through the question tool, they raise the question prompt instead (see below).
 
 After a successful planning turn, Locus offers:
 

--- a/Locus.xcodeproj/project.pbxproj
+++ b/Locus.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		17E812738FBC0E5519E13696 /* ComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18BD6EB5EBD180B3E69FBD6 /* ComposerView.swift */; };
 		1AC847C6725FF657D83049F2 /* BrowserInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A65386A2C6C14183D519D510 /* BrowserInput.swift */; };
 		1C60596E5A4E13265770012D /* ApplicationLifecycleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A119AF362322FDA5B7F02E8D /* ApplicationLifecycleCoordinator.swift */; };
+		1D25C5EDA1ADB3E67413E96B /* QuestionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAE276C6EEC0680C848F97 /* QuestionModels.swift */; };
 		1D833F7E4F2DD3AA519B4825 /* WalletSignerService.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1A7536131C96359528103360 /* WalletSignerService.xpc */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1ECCDF20AF574867EC663003 /* CompanionSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE2B3114660DB1F97EBB87C /* CompanionSettingsView.swift */; };
 		207DD8C77D2FDB73A6B94F5F /* HostedScreenshotConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319231FBA55F2DE9A5EB9377 /* HostedScreenshotConsent.swift */; };
@@ -79,6 +80,7 @@
 		43D9BA9EBAF54B1CF65AFE29 /* GitWorkspaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFF112DFD138A58ACB32658 /* GitWorkspaceModel.swift */; };
 		4679DAB70FE7B88A97E3F6D9 /* RemoteEndpointTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EE3ED166C864419A854532 /* RemoteEndpointTester.swift */; };
 		473A0EEF2BC977577C962850 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0204C24A0102A8D20E3A23CE /* Theme.swift */; };
+		482040C006E65D3644FBD472 /* QuestionPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160A256D1C92F0937B961AB8 /* QuestionPromptView.swift */; };
 		48BD3B6277F1F074589C4A1F /* BrowserBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D7A27ACF9B37EC8F79B9D7 /* BrowserBridge.swift */; };
 		48FBD1BA57CDDEC3E2CE1FC8 /* WalletSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF3F3198B29CA75F89BD39 /* WalletSettingsView.swift */; };
 		491ECFC9EF82513DC5BF6E6A /* PinnedSummaryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535F3FB7D434799FB66DADAA /* PinnedSummaryModel.swift */; };
@@ -124,6 +126,7 @@
 		763176C60443FC7B886014DE /* CompanionSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = E940CB9835CFDD6B6864DD28 /* CompanionSecurity.swift */; };
 		77D7EC97E924FD976475CB02 /* PlanApprovalPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF0BEF00F2EA8083877CC21 /* PlanApprovalPromptView.swift */; };
 		78B4B59BB52C09E38B5C39CB /* ModelLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8FCD4DB1FD5A4E1FD862797 /* ModelLibraryService.swift */; };
+		7AB28660BBE371371C4FE6E6 /* QuestionPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160A256D1C92F0937B961AB8 /* QuestionPromptView.swift */; };
 		7B2082B330CFAE2C2D8D51D1 /* ScheduleModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD24095E0EA6433F8AF94214 /* ScheduleModels.swift */; };
 		7BDF45BDB2A7B99922CCBC2B /* BrowserFavicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = A256B308D8C600193136B212 /* BrowserFavicons.swift */; };
 		7DF85FCAE34A64B48D707FC7 /* GitRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821D2EE07104AAF4E9163C6A /* GitRemote.swift */; };
@@ -249,6 +252,7 @@
 		F931472E8E4FA66CB54043F5 /* ScheduleModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD24095E0EA6433F8AF94214 /* ScheduleModels.swift */; };
 		F9405ED899AAD041CF6BAD66 /* BackendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3793FC69B1D813ED07567A2E /* BackendService.swift */; };
 		FA376F12956F2CAE3B426C17 /* NotesDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154F2AD569E232B4B8A4909C /* NotesDocument.swift */; };
+		FB4E051B7DF5AA5AC0AE9EBF /* QuestionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAE276C6EEC0680C848F97 /* QuestionModels.swift */; };
 		FC0B36C3B5F1E9FE34F908C1 /* TranscriptModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED943A053F7F7F66F864BD69 /* TranscriptModels.swift */; };
 		FC22E1FCFE6A7F6863A1BF05 /* AgentTeams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F997982C2B7C5C5A6F8CB20 /* AgentTeams.swift */; };
 		FED1D1E807720C78D3AAC510 /* InspectorRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D508444E398AA3AB5441198 /* InspectorRail.swift */; };
@@ -320,12 +324,14 @@
 		12CD78F68FC2B3B1CBAFD1AD /* CodexComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexComponent.swift; sourceTree = "<group>"; };
 		154F2AD569E232B4B8A4909C /* NotesDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesDocument.swift; sourceTree = "<group>"; };
 		15FBD1A1C4963CEA3D54440E /* TranscriptSelectionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSelectionStore.swift; sourceTree = "<group>"; };
+		160A256D1C92F0937B961AB8 /* QuestionPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionPromptView.swift; sourceTree = "<group>"; };
 		1616CD8FA01FCC15741F95EF /* TaskWorkerRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskWorkerRuntime.swift; sourceTree = "<group>"; };
 		16740EAD75B3BC87EA7D49A7 /* FeatureLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureLogicTests.swift; sourceTree = "<group>"; };
 		1784B6FA8992300112DCC986 /* JSONValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValue.swift; sourceTree = "<group>"; };
 		17A2C2357DB9117DF77AA7E7 /* CompanionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionProtocol.swift; sourceTree = "<group>"; };
 		1A7536131C96359528103360 /* WalletSignerService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = WalletSignerService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		1AFF112DFD138A58ACB32658 /* GitWorkspaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceModel.swift; sourceTree = "<group>"; };
+		1BBAE276C6EEC0680C848F97 /* QuestionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionModels.swift; sourceTree = "<group>"; };
 		22DCECBAA7DADB611159A90E /* BrowserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserService.swift; sourceTree = "<group>"; };
 		28BF95EE575D10DBDE8FA1B3 /* PermissionPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionPromptView.swift; sourceTree = "<group>"; };
 		29912FD4FFA8E9056AD4FCA2 /* AgentTeamsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTeamsSettingsView.swift; sourceTree = "<group>"; };
@@ -633,6 +639,7 @@
 				D99C4113009BE46AB55CB21C /* ProviderAccounts.swift */,
 				FA2F4D55B6CB8B4C966BACBE /* ProviderModelCatalog.swift */,
 				B2F29AE63F7A646BB5043E54 /* ProxyConfigurator.swift */,
+				160A256D1C92F0937B961AB8 /* QuestionPromptView.swift */,
 				01EE3ED166C864419A854532 /* RemoteEndpointTester.swift */,
 				CA812E808A560BC759B643F5 /* SessionOutputWatcher.swift */,
 				4414AFBD9717B5359B81CE8B /* SessionOverviewView.swift */,
@@ -681,6 +688,7 @@
 				059B4B4EC6DB6EA4BF29D8E1 /* InspectorModels.swift */,
 				A3244D05902CA55ED7D6FB60 /* PlanningModels.swift */,
 				A074779950EBBB250C3F62FF /* ProviderModels.swift */,
+				1BBAE276C6EEC0680C848F97 /* QuestionModels.swift */,
 				AD24095E0EA6433F8AF94214 /* ScheduleModels.swift */,
 				603951DA29612321B84516AE /* SessionModels.swift */,
 				6AC2E6FEB488D4F4DA5260EE /* SettingsModels.swift */,
@@ -1196,6 +1204,8 @@
 				E5357DCEABE29A7A65F07F06 /* ProviderModelCatalog.swift in Sources */,
 				9B9504C3676C7751AAC78C90 /* ProviderModels.swift in Sources */,
 				C0E82F8A928841455031CFA2 /* ProxyConfigurator.swift in Sources */,
+				1D25C5EDA1ADB3E67413E96B /* QuestionModels.swift in Sources */,
+				482040C006E65D3644FBD472 /* QuestionPromptView.swift in Sources */,
 				4679DAB70FE7B88A97E3F6D9 /* RemoteEndpointTester.swift in Sources */,
 				7B2082B330CFAE2C2D8D51D1 /* ScheduleModels.swift in Sources */,
 				75FD85BD1189A435949FBFC0 /* SessionModels.swift in Sources */,
@@ -1302,6 +1312,8 @@
 				0A53CFAF4EFC8BE46070D11D /* ProviderModelCatalog.swift in Sources */,
 				E4829191758EFFB79898D48E /* ProviderModels.swift in Sources */,
 				28E5B70E920FE7BB78015876 /* ProxyConfigurator.swift in Sources */,
+				FB4E051B7DF5AA5AC0AE9EBF /* QuestionModels.swift in Sources */,
+				7AB28660BBE371371C4FE6E6 /* QuestionPromptView.swift in Sources */,
 				CCE0C9F7DA04FE0F2ED8D51E /* RemoteEndpointTester.swift in Sources */,
 				F931472E8E4FA66CB54043F5 /* ScheduleModels.swift in Sources */,
 				BA0CCBF4C4586CE85949BAAC /* SessionModels.swift in Sources */,

--- a/Locus/AgentTeams.swift
+++ b/Locus/AgentTeams.swift
@@ -1698,10 +1698,20 @@ struct OrchestrationRun: Identifiable, Codable, Hashable {
         case scheduledFor = "scheduled_for"
     }
 
+    /// Solo-swarm *eligible*: the backend stamps `manifest.solo_swarm` on every
+    /// non-Ask turn before any delegation happens, so this alone never proves
+    /// workers ran. Use `didDelegateWorkers` for that.
     var isSoloSwarm: Bool {
         guard runKind == "solo" else { return false }
         if manifest?["solo_swarm"]?.boolean == true { return true }
         return !(attempts ?? []).isEmpty
+    }
+
+    /// Evidence this Solo run actually spawned workers. The runs list payload
+    /// carries `job_count` (computed from job_attempts); the detail payload
+    /// carries the attempts themselves.
+    var didDelegateWorkers: Bool {
+        isSoloSwarm && ((jobCount ?? 0) > 0 || !(attempts ?? []).isEmpty)
     }
 
     var runScope: RunScope {

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -355,8 +355,12 @@ final class AppModel: ObservableObject {
     @Published var selectedMode: WorkMode = .work {
         didSet {
             // Changing modes is taking a stance on what happens next, so a
-            // pending "implement this plan?" prompt would only contradict it.
-            if selectedMode != oldValue { planApprovalPending = false }
+            // pending "implement this plan?" prompt — or an unanswered
+            // question — would only contradict it.
+            if selectedMode != oldValue {
+                planApprovalPending = false
+                clearPendingQuestion()
+            }
             if selectedMode != .ask { lastAgenticMode = selectedMode }
             // Just Chat is deliberately not a workspace surface. Remember the
             // inspector's prior state so leaving Chat restores exactly what
@@ -413,6 +417,13 @@ final class AppModel: ObservableObject {
     /// is replaced by PlanApprovalPromptView, the way permission requests are.
     @Published private(set) var planApprovalPending = false
     @Published private(set) var activePlan: PlanDocument?
+    /// The question a completed turn asked the user. While set, the composer
+    /// input is replaced by QuestionPromptView, the way plan approval is.
+    @Published private(set) var pendingUserQuestion: UserQuestion?
+    /// Captured from `question_ready` mid-turn; armed only when the turn
+    /// completes, so an interrupted or errored turn never offers a stale
+    /// question.
+    private var capturedQuestionThisTurn: UserQuestion?
     let gitWorkspace = GitWorkspaceModel()
     let workspaceFiles = WorkspaceFileModel()
     /// Deliberately not bridged into `objectWillChange`: the Notebook sheet
@@ -3612,6 +3623,7 @@ final class AppModel: ObservableObject {
         planApprovalPending = false
         planTodosChangedThisTurn = false
         planReadyThisTurn = false
+        clearPendingQuestion()
         // Agent-side slash commands (/init and friends) may write todos, but
         // running one is housekeeping, never a plan worth offering to build.
         turnDispatchedInPlanMode = dispatchedMode == .plan && !isSlashPassthrough
@@ -4001,6 +4013,7 @@ final class AppModel: ObservableObject {
         turnStartedAt = Date()
         planApprovalPending = false
         planTodosChangedThisTurn = false
+        clearPendingQuestion()
         turnDispatchedInPlanMode = false
         turnDispatchedMode = nil
         blocks.append(ChatBlock(kind: .user, text: text))
@@ -4078,7 +4091,8 @@ final class AppModel: ObservableObject {
     }
 
     private func drainQueuedMessages() {
-        guard !isBusy, !hasPendingPermission, !planApprovalPending, !queuedMessages.isEmpty else {
+        guard !isBusy, !hasPendingPermission, !planApprovalPending,
+              pendingUserQuestion == nil, !queuedMessages.isEmpty else {
             return
         }
         guard isAgentOnline else { return }
@@ -4180,6 +4194,7 @@ final class AppModel: ObservableObject {
         planApprovalPending = false
         planTodosChangedThisTurn = false
         planReadyThisTurn = false
+        clearPendingQuestion()
         turnDispatchedInPlanMode = selectedMode == .plan
         turnDispatchedMode = selectedMode
         sessionOverview.emit(.status(
@@ -8046,6 +8061,7 @@ final class AppModel: ObservableObject {
                 todos = []
                 activePlan = nil
                 planApprovalPending = false
+                clearPendingQuestion()
                 queuedMessages = []
                 restoredTranscriptContext = nil
                 // Pre-acknowledge the session's workspace so a later
@@ -9462,6 +9478,51 @@ final class AppModel: ObservableObject {
                 )
             }
         }
+    }
+
+    /// The chosen option's label, the typed elaboration, or both — the plain
+    /// prose the model reads back as the next user message.
+    nonisolated static func composedQuestionAnswer(
+        option: UserQuestionOption?, freeText: String
+    ) -> String? {
+        var parts: [String] = []
+        if let label = option?.label.trimmingCharacters(in: .whitespaces), !label.isEmpty {
+            parts.append(label)
+        }
+        let typed = freeText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !typed.isEmpty { parts.append(typed) }
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: "\n\n")
+    }
+
+    /// Sends the user's answer to the pending question as an ordinary user
+    /// message — the turn already ended, so there is nothing to unblock.
+    func resolveUserQuestion(option: UserQuestionOption?, freeText: String) {
+        guard pendingUserQuestion != nil,
+              let answer = Self.composedQuestionAnswer(option: option, freeText: freeText)
+        else { return }
+        guard isAgentOnline else {
+            showToast("Reconnect the local agent to answer")
+            return
+        }
+        pendingUserQuestion = nil
+        Task { [weak self] in
+            guard let self else { return }
+            send(answer, preservingDraftOnFailure: false, requeueingOnFailure: true)
+        }
+    }
+
+    /// Dismisses the question popup without answering; the question stays
+    /// readable in the transcript and the composer takes over.
+    func dismissUserQuestion() {
+        guard pendingUserQuestion != nil else { return }
+        pendingUserQuestion = nil
+        drainQueuedMessages()
+    }
+
+    private func clearPendingQuestion() {
+        pendingUserQuestion = nil
+        capturedQuestionThisTurn = nil
     }
 
     func openWorkspaceInFinder() {
@@ -13150,6 +13211,14 @@ final class AppModel: ObservableObject {
                 }
             }
 
+        case "question_ready":
+            if let raw = event["question"] as? [String: Any],
+               let question = decode(UserQuestion.self, from: raw),
+               !question.question.isEmpty || !question.options.isEmpty
+            {
+                capturedQuestionThisTurn = question
+            }
+
         case "background_services_changed":
             refreshBackgroundServices(recordingOutputs: (event["action"] as? String) == "start")
 
@@ -13202,8 +13271,19 @@ final class AppModel: ObservableObject {
             streamingAssistantID = nil
             streamedCharsThisTurn = 0
             streamingReply.resetTurn()
+            let assistantText = blocks.last(where: { $0.kind == .assistant })?.text ?? ""
+            if reason == "complete" {
+                if let captured = capturedQuestionThisTurn {
+                    pendingUserQuestion = captured
+                } else if dispatchedMode == .grill,
+                          let detected = QuestionSignalDetector.question(from: assistantText)
+                {
+                    // The Grill skill's ❓ block, for a model that wrote the
+                    // question but skipped the tool, or a backend without it.
+                    pendingUserQuestion = detected
+                }
+            }
             if reason == "complete", turnDispatchedInPlanMode, selectedMode == .plan {
-                let assistantText = blocks.last(where: { $0.kind == .assistant })?.text ?? ""
                 if !planReadyThisTurn,
                    let fallback = PlanSignalDetector.document(
                     from: assistantText,
@@ -13213,12 +13293,16 @@ final class AppModel: ObservableObject {
                     activePlan = fallback
                     planReadyThisTurn = true
                 }
+                // A structured question outranks the plan prompt: the model
+                // is explicitly still asking, not proposing.
                 planApprovalPending = planReadyThisTurn
+                    && pendingUserQuestion == nil
                     && !(activePlan?.steps.isEmpty ?? true)
                     && !PlanSignalDetector.isClarifyingResponse(assistantText)
             }
             planTodosChangedThisTurn = false
             planReadyThisTurn = false
+            capturedQuestionThisTurn = nil
             turnDispatchedInPlanMode = false
             turnDispatchedMode = nil
             turnDispatchedTeamRunID = nil
@@ -13255,6 +13339,7 @@ final class AppModel: ObservableObject {
             pendingRetry = false
             steeringState = nil
             planApprovalPending = false
+            clearPendingQuestion()
             planTodosChangedThisTurn = false
             turnDispatchedInPlanMode = false
             turnDispatchedMode = nil
@@ -13311,6 +13396,7 @@ final class AppModel: ObservableObject {
                 todos = []
                 activePlan = nil
                 planApprovalPending = false
+                clearPendingQuestion()
             } else if let text = event["text"] as? String, !text.isEmpty {
                 blocks.append(
                     ChatBlock(
@@ -13376,6 +13462,8 @@ final class AppModel: ObservableObject {
             todos = checkpoint.todos
             activePlan = checkpoint.activePlan
             planApprovalPending = false
+            // Questions are deliberately not persisted in checkpoints.
+            clearPendingQuestion()
             contextFiles = checkpoint.contextFiles
             queuedMessages = []
             restoredTranscriptContext = transcriptContext(from: checkpoint.blocks)
@@ -13402,6 +13490,7 @@ final class AppModel: ObservableObject {
             todos = []
             activePlan = nil
             planApprovalPending = false
+            clearPendingQuestion()
             planTodosChangedThisTurn = false
             pendingRetry = false
             isBusy = true
@@ -13420,6 +13509,7 @@ final class AppModel: ObservableObject {
             todos = []
             activePlan = nil
             planApprovalPending = false
+            clearPendingQuestion()
             queuedMessages = []
             streamingAssistantID = nil
             streamingReply.resetTurn()
@@ -13664,6 +13754,7 @@ final class AppModel: ObservableObject {
             todos = []
             activePlan = nil
             planApprovalPending = false
+            clearPendingQuestion()
             restoredTranscriptContext = nil
         }
         soloSwarmEnabled = true
@@ -14389,6 +14480,25 @@ final class AppModel: ObservableObject {
             )
             todos = activePlan?.steps.map { TodoItem(content: $0, status: .pending) } ?? []
             planApprovalPending = true
+        }
+        if ProcessInfo.processInfo.environment["LOCUS_UI_TESTING_QUESTION_PROMPT"] == "1" {
+            selectedMode = .grill
+            pendingUserQuestion = UserQuestion(
+                id: "seed-question-prompt",
+                title: "Retry backoff shape",
+                question: "Should retries back off exponentially or on a fixed interval?",
+                options: [
+                    UserQuestionOption(
+                        label: "Exponential with jitter",
+                        detail: "Spreads thundering herds"
+                    ),
+                    UserQuestionOption(
+                        label: "Fixed interval",
+                        detail: "Predictable, simpler to reason about"
+                    ),
+                ],
+                recommended: "Exponential with jitter"
+            )
         }
         seedUITestRunFixtureIfNeeded()
 
@@ -15979,6 +16089,26 @@ extension AppModel {
             resolvePlanApproval(decision == "approve" ? .proceed : .cancel)
             return .object(["resolved": .bool(true)])
         }
+        if kind == "question" {
+            guard let sessionID = CompanionPayload.string("chat_id", in: payload),
+                  sessionID == currentSessionID,
+                  let question = pendingUserQuestion else {
+                throw CompanionProtocolError(code: "approval_expired", message: "That question is no longer waiting.")
+            }
+            if decision == "dismiss" {
+                dismissUserQuestion()
+                return .object(["resolved": .bool(true)])
+            }
+            let freeText = CompanionPayload.string("text", in: payload) ?? ""
+            let option = question.options.first {
+                $0.label.caseInsensitiveCompare(decision) == .orderedSame
+            }
+            guard option != nil || !freeText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw CompanionProtocolError(code: "invalid_approval", message: "Choose an answer or type one.")
+            }
+            resolveUserQuestion(option: option, freeText: freeText)
+            return .object(["resolved": .bool(true)])
+        }
         guard let runID = CompanionPayload.string("run_id", in: payload),
               let run = visibleActivityRuns.first(where: { $0.id == runID }),
               let sessionID = run.sessionID,
@@ -16091,6 +16221,18 @@ extension AppModel {
                 "title": .string("Implementation plan is ready"),
                 "detail": .string("Approve to build it, or cancel and keep the plan."),
                 "decisions": .array([.string("approve"), .string("cancel")]),
+            ]))
+        }
+        if let question = pendingUserQuestion {
+            approvals.append(.object([
+                "kind": .string("question"),
+                "chat_id": .string(currentSessionID),
+                "title": .string(question.title),
+                "detail": .string(String(question.question.prefix(1_000))),
+                "recommended": question.recommended.nilIfEmpty.map(JSONValue.string) ?? .null,
+                "decisions": .array(
+                    question.options.map { .string($0.label) } + [.string("dismiss")]
+                ),
             ]))
         }
         return approvals

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -8120,6 +8120,12 @@ final class AppModel: ObservableObject {
     private func detachForegroundWorkerUIIfNeeded() {
         guard let runtime = taskWorkers[currentSessionID] else { return }
         runtime.queuedMessages = queuedMessages
+        // A question belongs to its chat: park it on the runtime so it comes
+        // back when this chat does, and never fronts another session — an
+        // answer sent there would start a turn in the wrong conversation.
+        if let captured = capturedQuestionThisTurn { runtime.capturedQuestion = captured }
+        if let pending = pendingUserQuestion { runtime.pendingQuestion = pending }
+        clearPendingQuestion()
         computerControl.cancelPendingActions()
         // No browser cancellation here, at any scope: the worker keeps running
         // in the background and its browser actions are served on its own
@@ -8150,6 +8156,9 @@ final class AppModel: ObservableObject {
         finalizeStreamingBlocks()
         streamingAssistantID = nil
         streamingReply.resetTurn()
+        // The previous session's question must not front this one; this
+        // session's own parked question is restored below.
+        clearPendingQuestion()
         currentSessionID = runtime.sessionID
         sendComputerControlCapability(to: runtime.service, sessionID: runtime.sessionID)
         sendSimulatorControlCapability(to: runtime.service, sessionID: runtime.sessionID)
@@ -8196,6 +8205,14 @@ final class AppModel: ObservableObject {
                 turnDispatchedMode = runtime.dispatchedMode
                 turnDispatchedTeamRunID = runtime.dispatchedTeamRunID
                 turnDispatchedInPlanMode = runtime.dispatchedInPlanMode
+                if let captured = runtime.capturedQuestion {
+                    runtime.capturedQuestion = nil
+                    capturedQuestionThisTurn = captured
+                }
+                if let question = runtime.pendingQuestion {
+                    runtime.pendingQuestion = nil
+                    pendingUserQuestion = question
+                }
                 if let pending = runtime.pendingForegroundEvent {
                     runtime.pendingForegroundEvent = nil
                     handle(pending)
@@ -9513,10 +9530,15 @@ final class AppModel: ObservableObject {
     }
 
     /// Dismisses the question popup without answering; the question stays
-    /// readable in the transcript and the composer takes over.
-    func dismissUserQuestion() {
+    /// readable in the transcript and the composer takes over. A partially
+    /// typed answer moves into the composer draft rather than vanishing.
+    func dismissUserQuestion(keepingDraft draft: String = "") {
         guard pendingUserQuestion != nil else { return }
         pendingUserQuestion = nil
+        let typed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !typed.isEmpty, draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            draftText = typed
+        }
         drainQueuedMessages()
     }
 
@@ -11628,6 +11650,14 @@ final class AppModel: ObservableObject {
         if type == "error" {
             state = .failed
             runtime.lastError = event["message"] as? String
+            runtime.capturedQuestion = nil
+        }
+        if type == "question_ready",
+           let raw = event["question"] as? [String: Any],
+           let question = decode(UserQuestion.self, from: raw),
+           !question.question.isEmpty || !question.options.isEmpty
+        {
+            runtime.capturedQuestion = question
         }
         if type == "turn_done" {
             let reason = event["reason"] as? String ?? "complete"
@@ -11639,6 +11669,10 @@ final class AppModel: ObservableObject {
             if runtime.dispatchedTeamRunID == nil {
                 state = reason == "complete" ? .completed : .failed
             }
+            if reason == "complete", let captured = runtime.capturedQuestion {
+                runtime.pendingQuestion = captured
+            }
+            runtime.capturedQuestion = nil
             runtime.startedAt = nil
             runtime.dispatchedMode = nil
             runtime.dispatchedTeamRunID = nil
@@ -11699,11 +11733,19 @@ final class AppModel: ObservableObject {
             )
         } else if type == "turn_done" {
             if state == .completed {
-                notifyTurnCompleteIfInactive(
-                    sessionID: runtime.sessionID,
-                    runID: notificationRunID,
-                    workspace: runtime.sessionInfo?.workspaceRoot ?? runtime.sessionInfo?.cwd
-                )
+                if runtime.pendingQuestion != nil {
+                    notifyNeedsAttentionIfInactive(
+                        body: "A background chat asked you a question.",
+                        sessionID: runtime.sessionID,
+                        runID: notificationRunID
+                    )
+                } else {
+                    notifyTurnCompleteIfInactive(
+                        sessionID: runtime.sessionID,
+                        runID: notificationRunID,
+                        workspace: runtime.sessionInfo?.workspaceRoot ?? runtime.sessionInfo?.cwd
+                    )
+                }
             } else if state == .failed || state == .interrupted {
                 notifyNeedsAttentionIfInactive(
                     body: "A background chat stopped and needs attention.",
@@ -16099,6 +16141,9 @@ extension AppModel {
                 dismissUserQuestion()
                 return .object(["resolved": .bool(true)])
             }
+            guard isAgentOnline else {
+                throw CompanionProtocolError(code: "runtime_offline", message: "That chat is no longer connected.", retryable: true)
+            }
             let freeText = CompanionPayload.string("text", in: payload) ?? ""
             let option = question.options.first {
                 $0.label.caseInsensitiveCompare(decision) == .orderedSame
@@ -16230,8 +16275,12 @@ extension AppModel {
                 "title": .string(question.title),
                 "detail": .string(String(question.question.prefix(1_000))),
                 "recommended": question.recommended.nilIfEmpty.map(JSONValue.string) ?? .null,
+                // "answer" is the free-text decision: the client sends it with
+                // a `text` field. Always advertised, so option-less questions
+                // stay answerable from the phone.
                 "decisions": .array(
-                    question.options.map { .string($0.label) } + [.string("dismiss")]
+                    question.options.map { .string($0.label) }
+                        + [.string("answer"), .string("dismiss")]
                 ),
             ]))
         }

--- a/Locus/ComposerView.swift
+++ b/Locus/ComposerView.swift
@@ -73,6 +73,12 @@ struct ComposerView: View {
                 PlanApprovalPromptView()
                     .frame(maxWidth: 740)
                     .transition(LocusMotion.transition(edge: .bottom, reduceMotion: reduceMotion))
+            } else if let question = model.pendingUserQuestion {
+                // A question the agent asked is the same kind of decision
+                // point; esc hands the answer back to the composer instead.
+                QuestionPromptView(question: question)
+                    .frame(maxWidth: 740)
+                    .transition(LocusMotion.transition(edge: .bottom, reduceMotion: reduceMotion))
             } else {
                 VStack(spacing: 0) {
                     if let popup = activePopup {

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -2143,13 +2143,19 @@ struct InspectorRunsTab: View {
     private func runSummaryStrip(_ run: OrchestrationRun, work: RunWork) -> some View {
         let files = work.files.count
         let tokens = swarmTotalTokens(run)
+        let tokensHelp = if let calls = swarmModelCalls(run) {
+            "Billed input + output across \(calls) model call\(calls == 1 ? "" : "s"). Each call re-sends the conversation and tool context."
+        } else {
+            "Billed input + output across every model call. Each call re-sends the conversation and tool context."
+        }
         return ViewThatFits(in: .horizontal) {
             HStack(alignment: .top, spacing: 10) {
                 summaryStat(runDuration(run), "Duration")
                 summaryStat(runStepCount(run, work: work).formatted(), "Steps")
                 summaryStat(files.formatted(), files == 1 ? "File" : "Files")
                 summaryStat(
-                    tokens?.formatted(.number.notation(.compactName)) ?? "—", "Tokens"
+                    tokens?.formatted(.number.notation(.compactName)) ?? "—", "Tokens",
+                    help: tokensHelp
                 )
             }
             Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 10) {
@@ -2160,7 +2166,8 @@ struct InspectorRunsTab: View {
                 GridRow {
                     summaryStat(files.formatted(), files == 1 ? "File" : "Files")
                     summaryStat(
-                        tokens?.formatted(.number.notation(.compactName)) ?? "—", "Tokens"
+                        tokens?.formatted(.number.notation(.compactName)) ?? "—", "Tokens",
+                        help: tokensHelp
                     )
                 }
             }
@@ -2172,7 +2179,7 @@ struct InspectorRunsTab: View {
         .accessibilityIdentifier("runs.summaryStrip")
     }
 
-    private func summaryStat(_ value: String, _ label: String) -> some View {
+    private func summaryStat(_ value: String, _ label: String, help: String? = nil) -> some View {
         VStack(alignment: .leading, spacing: 1) {
             Text(value)
                 .font(.locus(size: 15, weight: .semibold))
@@ -2185,6 +2192,7 @@ struct InspectorRunsTab: View {
                 .foregroundStyle(LocusTheme.textSecondary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .help(help ?? "")
         // One element, one phrase: read as "Steps, 4" rather than as two
         // unrelated fragments. A collapsed element does not carry a separate
         // accessibility value, so the number belongs in the label.

--- a/Locus/LocusApp.swift
+++ b/Locus/LocusApp.swift
@@ -317,6 +317,16 @@ struct LocusApp: App {
                 .padding(24)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
                 .background(LocusTheme.surfaceCanvas)
+        case "question-prompt":
+            Group {
+                if let question = model.pendingUserQuestion {
+                    QuestionPromptView(question: question)
+                        .frame(maxWidth: 740)
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+            .background(LocusTheme.surfaceCanvas)
         default:
             RootView()
         }

--- a/Locus/MarkdownRenderer.swift
+++ b/Locus/MarkdownRenderer.swift
@@ -907,16 +907,33 @@ private struct MarkdownBlocksView: View {
                     selectionSpan: selectionSpan(at: path),
                     onOpen: { open(artifact) }
                 )
-            } else if let artifact,
-                      MarkdownArtifactPromotion.allowsCard(nestingDepth: nestingDepth) {
-                WorkspaceArtifactCard(
-                    reference: artifact,
-                    selectionStore: selectionStore,
-                    selectionSpan: selectionSpan(at: path),
-                    onOpen: { open(artifact) }
-                )
             } else {
-                prose(runs, path: path)
+                switch MarkdownArtifactPromotion.presentation(nestingDepth: nestingDepth) {
+                case .fullCard:
+                    if let artifact {
+                        WorkspaceArtifactCard(
+                            reference: artifact,
+                            selectionStore: selectionStore,
+                            selectionSpan: selectionSpan(at: path),
+                            onOpen: { open(artifact) }
+                        )
+                    } else {
+                        prose(runs, path: path)
+                    }
+                case .compactChip:
+                    if let reference = MarkdownArtifactPromotion.leadingArtifact(
+                        in: runs, workspacePath: workspacePath
+                    ) {
+                        WorkspaceArtifactChipRow(
+                            reference: reference,
+                            onOpen: { open(reference) }
+                        ) {
+                            prose(runs, path: path)
+                        }
+                    } else {
+                        prose(runs, path: path)
+                    }
+                }
             }
 
         case .heading(let level, let runs):
@@ -1156,15 +1173,10 @@ private struct MarkdownBlocksView: View {
 
     private func standaloneArtifact(in runs: [MarkdownInlineRun]) -> WorkspaceArtifactReference? {
         guard runs.count == 1, let run = runs.first else { return nil }
-        let raw: String?
-        if let destination = run.destination {
-            raw = destination
-        } else if run.style.contains(.code) {
-            raw = run.text
-        } else {
-            raw = nil
-        }
-        return WorkspaceArtifactReference.classify(raw, workspacePath: workspacePath)
+        return WorkspaceArtifactReference.classify(
+            MarkdownArtifactPromotion.candidate(in: run),
+            workspacePath: workspacePath
+        )
     }
 
     private func open(_ url: URL) {
@@ -1196,15 +1208,53 @@ struct WorkspaceSourceLocation: Hashable, Sendable {
     let column: Int?
 }
 
-/// Whether a standalone workspace reference earns its own block-level card.
+/// How a workspace file reference presents at a given nesting depth.
+enum MarkdownArtifactPresentation {
+    case fullCard
+    case compactChip
+}
+
+/// Which presentation a standalone workspace reference earns.
 ///
 /// A file card is 58pt of chrome with three buttons. One sitting in a paragraph
 /// is a useful artifact; one per bullet turns a seven-file listing into a wall
-/// of cards, so inside a list the reference stays an inline link instead.
+/// of cards, so inside a list the reference renders as a single-line chip —
+/// the card's icon, metadata, and actions without the chrome.
 /// Images are content rather than chrome and are promoted at any depth by the
 /// caller before this is consulted.
 enum MarkdownArtifactPromotion {
-    static func allowsCard(nestingDepth: Int) -> Bool { nestingDepth == 0 }
+    static func presentation(nestingDepth: Int) -> MarkdownArtifactPresentation {
+        nestingDepth == 0 ? .fullCard : .compactChip
+    }
+
+    /// The file reference a nested paragraph leads with, if it is the only
+    /// one. A bullet like `` `AppModel.swift` — the composition root ``
+    /// promotes to a chip; a bullet comparing two files stays prose, so an
+    /// annotation's actions are never attributed to the wrong file.
+    static func leadingArtifact(
+        in runs: [MarkdownInlineRun],
+        workspacePath: String?
+    ) -> WorkspaceArtifactReference? {
+        guard let first = runs.first,
+              let reference = WorkspaceArtifactReference.classify(
+                candidate(in: first), workspacePath: workspacePath
+              ),
+              runs.dropFirst().allSatisfy({ run in
+                  WorkspaceArtifactReference.classify(
+                    candidate(in: run), workspacePath: workspacePath
+                  ) == nil
+              })
+        else { return nil }
+        return reference
+    }
+
+    /// The text a run offers as a possible workspace path: a link's
+    /// destination, or the literal text of inline code.
+    static func candidate(in run: MarkdownInlineRun) -> String? {
+        if let destination = run.destination { return destination }
+        if run.style.contains(.code) { return run.text }
+        return nil
+    }
 }
 
 enum WorkspaceArtifactKind: String, Hashable, Sendable {
@@ -1505,6 +1555,88 @@ private struct WorkspaceImageArtifactView: View {
         }
         .buttonStyle(.locus())
         .foregroundStyle(LocusTheme.muted)
+        .accessibilityLabel("\(title) \(reference.relativePath)")
+    }
+}
+
+/// The single-line variant of `WorkspaceArtifactCard` used inside lists: the
+/// card's icon, size, and actions without the 58pt of chrome that made a
+/// listing read as a wall. The paragraph's inline content renders inside it
+/// unchanged — the filename keeps its pill and the whole row stays one
+/// selection span — so nothing is re-typeset here. Reveal and Copy Path live
+/// in the context menu.
+private struct WorkspaceArtifactChipRow<Content: View>: View {
+    @Environment(\.locusAccent) private var accent
+    let reference: WorkspaceArtifactReference
+    let onOpen: () -> Void
+    private let content: Content
+
+    init(
+        reference: WorkspaceArtifactReference,
+        onOpen: @escaping () -> Void,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.reference = reference
+        self.onOpen = onOpen
+        self.content = content()
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(LocusTheme.paperDeep.opacity(0.9))
+                    .frame(width: 22, height: 22)
+                Image(systemName: reference.kind.symbol)
+                    .font(.locus(size: 10, weight: .semibold))
+                    .foregroundStyle(accent.actionColor)
+            }
+            content
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if let displaySize = reference.displaySize {
+                Text(displaySize)
+                    .font(.locus(size: 9))
+                    .foregroundStyle(LocusTheme.muted)
+                    .layoutPriority(1)
+            }
+            chipAction("Open", symbol: "arrow.up.forward.app", action: onOpen)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .frame(minHeight: 28)
+        .background(LocusTheme.white)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(LocusTheme.line, lineWidth: 1)
+        }
+        .contextMenu {
+            Button("Open") { onOpen() }
+            Button("Reveal in Finder") {
+                NSWorkspace.shared.activateFileViewerSelecting([reference.url])
+            }
+            Button("Copy Path") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(reference.relativePath, forType: .string)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(reference.kind.label) artifact, \(reference.relativePath)")
+    }
+
+    private func chipAction(
+        _ title: String,
+        symbol: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: symbol)
+                .labelStyle(.iconOnly)
+                .frame(width: 21, height: 21)
+        }
+        .buttonStyle(.locus())
+        .foregroundStyle(LocusTheme.muted)
+        .help(title)
         .accessibilityLabel("\(title) \(reference.relativePath)")
     }
 }

--- a/Locus/Models/QuestionModels.swift
+++ b/Locus/Models/QuestionModels.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+/// A question the agent asked the user, surfaced as an answer popup once the
+/// turn completes. Every field has a default so older agents and the
+/// text-detection fallback remain tolerant.
+struct UserQuestion: Codable, Hashable, Identifiable {
+    var id: String
+    var title: String
+    var question: String
+    var options: [UserQuestionOption]
+    var recommended: String
+
+    init(
+        id: String = UUID().uuidString,
+        title: String = "Question",
+        question: String = "",
+        options: [UserQuestionOption] = [],
+        recommended: String = ""
+    ) {
+        self.id = id
+        self.title = title
+        self.question = question
+        self.options = options
+        self.recommended = recommended
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, question, options, recommended
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(String.self, forKey: .id) ?? UUID().uuidString
+        title = try container.decodeIfPresent(String.self, forKey: .title) ?? "Question"
+        question = try container.decodeIfPresent(String.self, forKey: .question) ?? ""
+        options = try container.decodeIfPresent([UserQuestionOption].self, forKey: .options) ?? []
+        recommended = try container.decodeIfPresent(String.self, forKey: .recommended) ?? ""
+    }
+
+    /// The option the recommendation names, when it matches one exactly.
+    var recommendedOptionIndex: Int? {
+        guard !recommended.isEmpty else { return nil }
+        return options.firstIndex {
+            $0.label.caseInsensitiveCompare(recommended) == .orderedSame
+        }
+    }
+}
+
+/// One selectable answer. Decodes from either a bare string or an object.
+struct UserQuestionOption: Codable, Hashable {
+    var label: String
+    var detail: String
+
+    init(label: String, detail: String = "") {
+        self.label = label
+        self.detail = detail
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case label, detail
+    }
+
+    init(from decoder: Decoder) throws {
+        if let single = try? decoder.singleValueContainer(),
+           let text = try? single.decode(String.self)
+        {
+            label = text
+            detail = ""
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        label = try container.decodeIfPresent(String.self, forKey: .label) ?? ""
+        detail = try container.decodeIfPresent(String.self, forKey: .detail) ?? ""
+    }
+}
+
+/// Recovers a question from a completed turn's text when the agent wrote the
+/// Grill skill's `❓ **Qn** - **Title**: body` + `➡️ recommendation` block but
+/// did not call the `ask_user_question` tool (or the backend predates it).
+///
+/// Deliberately conservative: without the ❓ marker there is no question, so
+/// ordinary prose that happens to end in a question mark never raises the
+/// popup — that broader sniff is `PlanSignalDetector.isClarifyingResponse`'s
+/// separate, suppression-only job.
+enum QuestionSignalDetector {
+    static func question(from text: String) -> UserQuestion? {
+        let allLines = text.split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        guard let start = allLines.lastIndex(where: { line in
+            stripped(line.trimmingCharacters(in: .whitespaces), prefixes: questionMarkers) != nil
+        }) else { return nil }
+
+        var bodyLines: [String] = []
+        var recommended = ""
+        for raw in allLines[start...] {
+            let trimmed = raw.trimmingCharacters(in: .whitespaces)
+            if let rest = stripped(trimmed, prefixes: recommendationMarkers) {
+                recommended = stripEmphasis(rest)
+                break
+            }
+            bodyLines.append(raw)
+        }
+
+        guard let firstLine = bodyLines.first?.trimmingCharacters(in: .whitespaces),
+              let headline = stripped(firstLine, prefixes: questionMarkers)
+        else { return nil }
+
+        let (title, remainder) = titleAndRemainder(in: headline)
+        let restLines = remainder.nilIfEmpty.map { [$0] } ?? []
+        let tail = bodyLines.dropFirst().map { $0.trimmingCharacters(in: .whitespaces) }
+        let options = listItems(in: tail).map {
+            UserQuestionOption(label: stripEmphasis($0))
+        }
+        // Extracted choices become option rows; keeping them in the body too
+        // would show every choice twice.
+        let prose = options.isEmpty ? Array(tail) : tail.filter { listItem(in: $0) == nil }
+        let body = (restLines + prose)
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !body.isEmpty || !title.isEmpty else { return nil }
+        return UserQuestion(
+            title: title.nilIfEmpty ?? "Question",
+            question: body,
+            options: Array(options.prefix(8)),
+            recommended: recommended
+        )
+    }
+
+    /// Emoji markers with and without the variation selector: the two forms
+    /// are distinct graphemes, and models emit both.
+    private static let questionMarkers = ["\u{2753}\u{FE0F}", "\u{2753}"]
+    private static let recommendationMarkers = ["\u{27A1}\u{FE0F}", "\u{27A1}"]
+
+    private static func stripped(_ line: String, prefixes: [String]) -> String? {
+        for prefix in prefixes where line.hasPrefix(prefix) {
+            return String(line.dropFirst(prefix.count))
+                .trimmingCharacters(in: .whitespaces)
+        }
+        return nil
+    }
+
+    /// Splits `**Q1** - **Reddit scope**: Should …` into the title and the
+    /// question text that follows it, tolerating a missing Qn label.
+    private static func titleAndRemainder(in headline: String) -> (String, String) {
+        let patterns = [
+            #"^\*\*[^*]*\*\*\s*[-–—]\s*\*\*([^*]+)\*\*\s*:?\s*"#,
+            #"^\*\*([^*]+)\*\*\s*:?\s*"#,
+        ]
+        for pattern in patterns {
+            guard let expression = try? NSRegularExpression(pattern: pattern),
+                  let match = expression.firstMatch(
+                    in: headline,
+                    range: NSRange(headline.startIndex..., in: headline)
+                  ),
+                  let whole = Range(match.range(at: 0), in: headline),
+                  let titleRange = Range(match.range(at: 1), in: headline)
+            else { continue }
+            return (
+                String(headline[titleRange]).trimmingCharacters(in: .whitespaces),
+                String(headline[whole.upperBound...]).trimmingCharacters(in: .whitespaces)
+            )
+        }
+        return ("", headline)
+    }
+
+    private static func listItems(in lines: [String]) -> [String] {
+        lines.compactMap(listItem(in:))
+    }
+
+    private static func listItem(in line: String) -> String? {
+        guard line.range(
+            of: #"^(?:[-*+]\s+|\d+[.)]\s+)(.+)$"#,
+            options: .regularExpression
+        ) != nil else { return nil }
+        return line.replacingOccurrences(
+            of: #"^(?:[-*+]\s+|\d+[.)]\s+)"#,
+            with: "",
+            options: .regularExpression
+        ).trimmingCharacters(in: .whitespaces).nilIfEmpty
+    }
+
+    private static func stripEmphasis(_ text: String) -> String {
+        text.replacingOccurrences(of: "**", with: "")
+            .trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Locus/Models/ScheduleModels.swift
+++ b/Locus/Models/ScheduleModels.swift
@@ -54,7 +54,7 @@ enum WorkMode: String, CaseIterable, Codable, Identifiable {
         case .plan:
             "Inspect files if useful, but do not modify anything. Ask clarifying questions when needed. When the plan is final and decision-complete, call submit_plan exactly once with its title, summary, ordered steps, and test scenarios; do not call submit_plan for a question or partial plan."
         case .grill:
-            "Stress-test the request with the activated $grilling skill: map the design tree of decisions, ask exactly one highest-leverage frontier question at a time with your recommended answer, and discover facts from the workspace yourself instead of asking for them. Do not modify anything, and do not implement until the user explicitly confirms the shared understanding."
+            "Stress-test the request with the activated $grilling skill: map the design tree of decisions, ask exactly one highest-leverage frontier question at a time with your recommended answer, and discover facts from the workspace yourself instead of asking for them. Deliver each question by calling ask_user_question with its title, question, options, and your recommended answer, then end your turn. Do not modify anything, and do not implement until the user explicitly confirms the shared understanding."
         }
     }
 }

--- a/Locus/Models/ScheduleModels.swift
+++ b/Locus/Models/ScheduleModels.swift
@@ -52,7 +52,7 @@ enum WorkMode: String, CaseIterable, Codable, Identifiable {
         case .work:
             "Solve the request using the workspace and tools when useful. Choose whether to answer, inspect, plan, or implement from the request itself. Follow the current permission policy for every action."
         case .plan:
-            "Inspect files if useful, but do not modify anything. Ask clarifying questions when needed. When the plan is final and decision-complete, call submit_plan exactly once with its title, summary, ordered steps, and test scenarios; do not call submit_plan for a question or partial plan."
+            "Inspect files if useful, but do not modify anything. Ask clarifying questions when needed by calling ask_user_question with your options and recommended answer. When the plan is final and decision-complete, call submit_plan exactly once with its title, summary, ordered steps, and test scenarios; do not call submit_plan for a question or partial plan."
         case .grill:
             "Stress-test the request with the activated $grilling skill: map the design tree of decisions, ask exactly one highest-leverage frontier question at a time with your recommended answer, and discover facts from the workspace yourself instead of asking for them. Deliver each question by calling ask_user_question with its title, question, options, and your recommended answer, then end your turn. Do not modify anything, and do not implement until the user explicitly confirms the shared understanding."
         }

--- a/Locus/Models/TranscriptModels.swift
+++ b/Locus/Models/TranscriptModels.swift
@@ -242,7 +242,8 @@ struct CompactToolActivitySummary: Equatable {
                 .last
                 .map(String.init) ?? name
 
-            if name.contains("request_user_input") || name.contains("ask_question") {
+            if name.contains("request_user_input") || name.contains("ask_question")
+                || name.contains("user_question") {
                 self = .question
             } else if name.contains("update_plan") || name.contains("todo_write")
                         || name.contains("submit_plan") {

--- a/Locus/PinnedSummaryModel.swift
+++ b/Locus/PinnedSummaryModel.swift
@@ -315,7 +315,8 @@ enum PinnedSummary {
 
     /// Live agent activities describe the current session's subagents while a
     /// team runs; once they are gone, the session's team runs stand in. Plain
-    /// solo turns are excluded — every chat turn is a run.
+    /// and non-delegating solo turns are excluded — every chat turn is a run,
+    /// and eligibility (`isSoloSwarm`) alone is not delegation.
     static func subagents(
         activities: [AgentActivity],
         runs: [OrchestrationRun],
@@ -329,7 +330,7 @@ enum PinnedSummary {
         if !live.isEmpty { return live }
         guard !sessionID.isEmpty else { return [] }
         return runs
-            .filter { $0.sessionID == sessionID && ($0.runKind == "team" || $0.isSoloSwarm) }
+            .filter { $0.sessionID == sessionID && ($0.runKind == "team" || $0.didDelegateWorkers) }
             .sorted { $0.updatedAt > $1.updatedAt }
             .compactMap { run -> SubagentRow? in
                 guard let status = subagentStatus(run.state) else { return nil }

--- a/Locus/QuestionPromptView.swift
+++ b/Locus/QuestionPromptView.swift
@@ -1,0 +1,304 @@
+import SwiftUI
+
+/// The composer-replacing prompt for a question the agent asked. Same
+/// contract as `PlanApprovalPromptView`: the question is a decision point, so
+/// the decision replaces the input. Options are keyboard-driven; a free-text
+/// row is always present, and `esc` hands the answer back to the composer.
+struct QuestionPromptView: View {
+    @EnvironmentObject private var model: AppModel
+
+    let question: UserQuestion
+
+    @State private var selection = 0
+    @State private var answerText = ""
+    @FocusState private var panelFocused: Bool
+    @FocusState private var textFocused: Bool
+
+    private enum Row: Hashable {
+        /// Index into `question.options`.
+        case option(Int)
+        /// A freeform recommendation with no option list to live in.
+        case recommendation
+        case freeText
+    }
+
+    private var rows: [Row] {
+        var rows: [Row] = question.options.indices.map(Row.option)
+        if question.options.isEmpty, !question.recommended.isEmpty {
+            rows.append(.recommendation)
+        }
+        rows.append(.freeText)
+        return rows
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+                .padding(.horizontal, 13)
+                .padding(.top, 12)
+            if !question.question.isEmpty {
+                bodyCard
+                    .padding(.horizontal, 13)
+                    .padding(.top, 9)
+            }
+            options
+                .padding(.horizontal, 8)
+                .padding(.vertical, 8)
+        }
+        .locusCard(radius: 13)
+        .overlay {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .stroke(LocusTheme.signalDeep.opacity(0.55), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.08), radius: 22, y: 9)
+        .focusable()
+        .focusEffectDisabled()
+        .focused($panelFocused)
+        .onKeyPress(.upArrow) {
+            guard !textFocused else { return .ignored }
+            selection = max(selection - 1, 0)
+            return .handled
+        }
+        .onKeyPress(.downArrow) {
+            guard !textFocused else { return .ignored }
+            selection = min(selection + 1, rows.count - 1)
+            return .handled
+        }
+        .onKeyPress(.return) {
+            guard !textFocused else { return .ignored }
+            confirm(rows[min(selection, rows.count - 1)])
+            return .handled
+        }
+        .onKeyPress(.escape) {
+            model.dismissUserQuestion()
+            return .handled
+        }
+        .onKeyPress(characters: CharacterSet(charactersIn: "123456789")) { press in
+            guard !textFocused,
+                  press.modifiers.isEmpty,
+                  let digit = Int(press.characters),
+                  (1...rows.count).contains(digit)
+            else { return .ignored }
+            confirm(rows[digit - 1])
+            return .handled
+        }
+        .onTapGesture { panelFocused = true }
+        .onAppear {
+            panelFocused = true
+            selection = defaultSelection
+        }
+        .onChange(of: textFocused) { _, focused in
+            if focused, let index = rows.firstIndex(of: .freeText) {
+                selection = index
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Question from the agent")
+        .accessibilityIdentifier("questionPrompt.panel")
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("QUESTION")
+                .font(.locus(size: 8, weight: .bold))
+                .tracking(0.8)
+                .foregroundStyle(LocusTheme.signalDeep)
+            HStack(spacing: 7) {
+                Image(systemName: "questionmark.circle")
+                    .font(.locus(size: 12, weight: .semibold))
+                    .foregroundStyle(LocusTheme.signalDeep)
+                    .accessibilityHidden(true)
+                Text(question.title)
+                    .font(.locus(size: 12, weight: .bold))
+                    .foregroundStyle(LocusTheme.ink)
+            }
+        }
+    }
+
+    private var bodyCard: some View {
+        Text(question.question)
+            .font(.locus(size: 10, weight: .medium))
+            .foregroundStyle(LocusTheme.ink)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(10)
+            .background(LocusTheme.paperDeep.opacity(0.65))
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .accessibilityIdentifier("questionPrompt.body")
+    }
+
+    private var options: some View {
+        VStack(spacing: 1) {
+            ForEach(Array(rows.enumerated()), id: \.element) { index, row in
+                switch row {
+                case .option(let optionIndex):
+                    optionRow(
+                        index: index,
+                        title: question.options[optionIndex].label,
+                        detail: question.options[optionIndex].detail,
+                        recommended: question.recommendedOptionIndex == optionIndex,
+                        identifier: "questionPrompt.option.\(optionIndex)"
+                    )
+                case .recommendation:
+                    optionRow(
+                        index: index,
+                        title: question.recommended,
+                        detail: "The agent's recommended answer",
+                        recommended: true,
+                        identifier: "questionPrompt.recommendation"
+                    )
+                case .freeText:
+                    freeTextRow(index: index)
+                }
+            }
+            Text("esc dismisses and answers in the composer")
+                .font(.locus(size: 8))
+                .foregroundStyle(LocusTheme.muted)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 8)
+                .padding(.top, 5)
+        }
+    }
+
+    private func optionRow(
+        index: Int,
+        title: String,
+        detail: String,
+        recommended: Bool,
+        identifier: String
+    ) -> some View {
+        let isSelected = index == selection
+        return Button {
+            confirm(rows[index])
+        } label: {
+            HStack(spacing: 8) {
+                Text(isSelected ? "❯" : " ")
+                    .font(.locus(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(LocusTheme.signalDeep)
+                    .frame(width: 10)
+                Text("\(index + 1).")
+                    .font(.locus(size: 10, design: .monospaced))
+                    .foregroundStyle(LocusTheme.muted)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(.locus(size: 11, weight: isSelected ? .semibold : .regular))
+                        .foregroundStyle(LocusTheme.ink)
+                    if !detail.isEmpty {
+                        Text(detail)
+                            .font(.locus(size: 8))
+                            .foregroundStyle(LocusTheme.muted)
+                    }
+                }
+                .lineLimit(1)
+                Spacer()
+                if recommended {
+                    Text("Recommended")
+                        .font(.locus(size: 8, weight: .semibold))
+                        .foregroundStyle(LocusTheme.signalDeep)
+                        .padding(.horizontal, 5)
+                        .frame(height: 15)
+                        .background(LocusTheme.paperDeep)
+                        .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+                }
+                if isSelected {
+                    Text("↵")
+                        .font(.locus(size: 8, design: .monospaced))
+                        .foregroundStyle(LocusTheme.muted)
+                }
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 38)
+            .background(isSelected ? LocusTheme.paperDeep : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.locus())
+        .onHover { hovering in
+            if hovering { selection = index }
+        }
+        .accessibilityLabel(title)
+        .accessibilityIdentifier(identifier)
+    }
+
+    private func freeTextRow(index: Int) -> some View {
+        let isSelected = index == selection
+        return HStack(spacing: 8) {
+            Text(isSelected ? "❯" : " ")
+                .font(.locus(size: 10, weight: .bold, design: .monospaced))
+                .foregroundStyle(LocusTheme.signalDeep)
+                .frame(width: 10)
+            Text("\(index + 1).")
+                .font(.locus(size: 10, design: .monospaced))
+                .foregroundStyle(LocusTheme.muted)
+            TextField("Type your own answer…", text: $answerText, axis: .vertical)
+                .textFieldStyle(.plain)
+                .font(.locus(size: 11))
+                .foregroundStyle(LocusTheme.ink)
+                .lineLimit(1...4)
+                .focused($textFocused)
+                .onSubmit { confirm(.freeText) }
+                .accessibilityIdentifier("questionPrompt.freeText")
+            if !answerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Button {
+                    confirm(.freeText)
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.locus(size: 13, weight: .semibold))
+                        .foregroundStyle(LocusTheme.signalDeep)
+                }
+                .buttonStyle(.locus())
+                .help("Send answer")
+                .accessibilityIdentifier("questionPrompt.submit")
+            } else if isSelected {
+                Text("↵")
+                    .font(.locus(size: 8, design: .monospaced))
+                    .foregroundStyle(LocusTheme.muted)
+            }
+        }
+        .padding(.horizontal, 8)
+        .frame(minHeight: 38)
+        .background(isSelected ? LocusTheme.paperDeep : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .contentShape(Rectangle())
+        .onTapGesture { textFocused = true }
+        .onHover { hovering in
+            if hovering { selection = index }
+        }
+    }
+
+    // MARK: - Behavior
+
+    private var defaultSelection: Int {
+        if let recommended = question.recommendedOptionIndex,
+           let index = rows.firstIndex(of: .option(recommended))
+        {
+            return index
+        }
+        if let index = rows.firstIndex(of: .recommendation) { return index }
+        return rows.firstIndex(of: .freeText) ?? 0
+    }
+
+    private func confirm(_ row: Row) {
+        switch row {
+        case .option(let optionIndex):
+            model.resolveUserQuestion(
+                option: question.options[optionIndex],
+                freeText: answerText
+            )
+        case .recommendation:
+            model.resolveUserQuestion(
+                option: UserQuestionOption(label: question.recommended),
+                freeText: answerText
+            )
+        case .freeText:
+            let typed = answerText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !typed.isEmpty else {
+                textFocused = true
+                return
+            }
+            model.resolveUserQuestion(option: nil, freeText: typed)
+        }
+    }
+}

--- a/Locus/QuestionPromptView.swift
+++ b/Locus/QuestionPromptView.swift
@@ -153,9 +153,12 @@ struct QuestionPromptView: View {
                     freeTextRow(index: index)
                 }
             }
+            // `muted` measures under the audit's 4.5:1 floor at 1x on the
+            // bare panel; standalone hint text takes the secondary role, the
+            // way the Runs panel's small text does.
             Text("esc dismisses and answers in the composer")
                 .font(.locus(size: 8))
-                .foregroundStyle(LocusTheme.muted)
+                .foregroundStyle(LocusTheme.textSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 8)
                 .padding(.top, 5)
@@ -224,14 +227,20 @@ struct QuestionPromptView: View {
 
     private func freeTextRow(index: Int) -> some View {
         let isSelected = index == selection
+        // Unlike the option rows, this row is not a Button, so its decorative
+        // glyphs would surface as bare StaticTexts — the blank caret
+        // placeholder reads as zero-contrast "text" to the audit. The
+        // TextField carries the row's semantics.
         return HStack(spacing: 8) {
             Text(isSelected ? "❯" : " ")
                 .font(.locus(size: 10, weight: .bold, design: .monospaced))
                 .foregroundStyle(LocusTheme.signalDeep)
                 .frame(width: 10)
+                .accessibilityHidden(true)
             Text("\(index + 1).")
                 .font(.locus(size: 10, design: .monospaced))
                 .foregroundStyle(LocusTheme.muted)
+                .accessibilityHidden(true)
             TextField("Type your own answer…", text: $answerText, axis: .vertical)
                 .textFieldStyle(.plain)
                 .font(.locus(size: 11))
@@ -255,6 +264,7 @@ struct QuestionPromptView: View {
                 Text("↵")
                     .font(.locus(size: 8, design: .monospaced))
                     .foregroundStyle(LocusTheme.muted)
+                    .accessibilityHidden(true)
             }
         }
         .padding(.horizontal, 8)

--- a/Locus/QuestionPromptView.swift
+++ b/Locus/QuestionPromptView.swift
@@ -70,7 +70,7 @@ struct QuestionPromptView: View {
             return .handled
         }
         .onKeyPress(.escape) {
-            model.dismissUserQuestion()
+            model.dismissUserQuestion(keepingDraft: answerText)
             return .handled
         }
         .onKeyPress(characters: CharacterSet(charactersIn: "123456789")) { press in

--- a/Locus/TaskWorkerRuntime.swift
+++ b/Locus/TaskWorkerRuntime.swift
@@ -56,6 +56,12 @@ final class ChatWorkerRuntime {
     var streamingBlockID: UUID?
     var streamingText = ""
     var streamingReasoning = ""
+    /// A question_ready captured while this chat runs in the background; armed
+    /// into `pendingQuestion` when its turn completes.
+    var capturedQuestion: UserQuestion?
+    /// A completed background turn's unanswered question, promoted to the
+    /// popup when the chat is brought to the foreground.
+    var pendingQuestion: UserQuestion?
 
     var occupiesExecutionSlot: Bool {
         switch executionState {

--- a/LocusTests/AccentPropagationTests.swift
+++ b/LocusTests/AccentPropagationTests.swift
@@ -58,6 +58,36 @@ final class AccentPropagationTests: XCTestCase {
         try assertMarkdownArtifactFollowsAccent(text: "- `notes.md`")
     }
 
+    func testListItemFileReferenceMountsAChipNotProse() throws {
+        // Same-length names, one resolving to a real workspace file and one
+        // not: if the chip failed to mount, both bullets would render as the
+        // identical pill-styled prose and the images could not differ.
+        let workspace = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("locus-chip-mount-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workspace) }
+        try Data("notes".utf8).write(to: workspace.appendingPathComponent("notes.md"))
+
+        let lime = selection(.lime)
+        apply(lime)
+        let chip = mount(StableMarkdownHost(
+            accent: AccentBox(lime),
+            text: "- `notes.md`",
+            workspacePath: workspace.path
+        ))
+        let prose = mount(StableMarkdownHost(
+            accent: AccentBox(lime),
+            text: "- `notas.md`",
+            workspacePath: workspace.path
+        ))
+        let chipImage = try XCTUnwrap(snapshot(chip))
+        let proseImage = try XCTUnwrap(snapshot(prose))
+        XCTAssertGreaterThan(
+            differingPixels(chipImage, proseImage), 0,
+            "A resolvable list-item file reference must mount the chip's chrome"
+        )
+    }
+
     func testMarkdownArtifactCardFollowsAccentWithoutBeingRebuilt() throws {
         // A top-level reference mounts the full card.
         try assertMarkdownArtifactFollowsAccent(text: "`notes.md`")

--- a/LocusTests/AccentPropagationTests.swift
+++ b/LocusTests/AccentPropagationTests.swift
@@ -52,7 +52,18 @@ final class AccentPropagationTests: XCTestCase {
         super.tearDown()
     }
 
+    func testMarkdownArtifactChipFollowsAccentWithoutBeingRebuilt() throws {
+        // A list-item reference mounts the compact chip, whose kind icon is
+        // accent-tinted.
+        try assertMarkdownArtifactFollowsAccent(text: "- `notes.md`")
+    }
+
     func testMarkdownArtifactCardFollowsAccentWithoutBeingRebuilt() throws {
+        // A top-level reference mounts the full card.
+        try assertMarkdownArtifactFollowsAccent(text: "`notes.md`")
+    }
+
+    private func assertMarkdownArtifactFollowsAccent(text: String) throws {
         let workspace = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("locus-accent-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(
@@ -69,7 +80,7 @@ final class AccentPropagationTests: XCTestCase {
         let box = AccentBox(lime)
         let live = mount(StableMarkdownHost(
             accent: box,
-            text: "- `notes.md`",
+            text: text,
             workspacePath: workspace.path
         ))
         let onLime = try XCTUnwrap(snapshot(live))
@@ -84,18 +95,18 @@ final class AccentPropagationTests: XCTestCase {
         // values keeps the assertion out of the display's colour space.
         let rebuilt = mount(StableMarkdownHost(
             accent: AccentBox(pink),
-            text: "- `notes.md`",
+            text: text,
             workspacePath: workspace.path
         ))
         let rebuiltOnPink = try XCTUnwrap(snapshot(rebuilt))
 
         XCTAssertGreaterThan(
             differingPixels(onLime, onPink), 0,
-            "The mounted card kept the previous accent instead of following the change"
+            "The mounted artifact tile kept the previous accent instead of following the change"
         )
         XCTAssertEqual(
             differingPixels(onPink, rebuiltOnPink), 0,
-            "A mounted card must match one built fresh under the same accent"
+            "A mounted artifact tile must match one built fresh under the same accent"
         )
     }
 

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -1238,6 +1238,19 @@ final class AppModelTests: XCTestCase {
         XCTAssertEqual(untitled.title, "Question")
         XCTAssertEqual(untitled.question, "Which port should the server bind?")
         XCTAssertEqual(untitled.recommended, "8791")
+
+        // The emoji markers come in both grapheme forms: with the variation
+        // selector and without. Models emit both.
+        let withSelector = try XCTUnwrap(QuestionSignalDetector.question(
+            from: "\u{2753}\u{FE0F} **Q2** - **Port**: Which port?\n\u{27A1}\u{FE0F} 8791"
+        ))
+        XCTAssertEqual(withSelector.title, "Port")
+        XCTAssertEqual(withSelector.recommended, "8791")
+        let bareArrow = try XCTUnwrap(QuestionSignalDetector.question(
+            from: "\u{2753} **Q2** - **Port**: Which port?\n\u{27A1} 8791"
+        ))
+        XCTAssertEqual(bareArrow.title, "Port")
+        XCTAssertEqual(bareArrow.recommended, "8791")
     }
 
     @MainActor

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -1171,6 +1171,75 @@ final class AppModelTests: XCTestCase {
         ))
     }
 
+    func testUserQuestionDecodesPartialPayloadsAndStringOptions() throws {
+        let question = try JSONDecoder().decode(
+            UserQuestion.self,
+            from: Data(#"{"question":"Which store?","options":["SQLite",{"label":"Core Data","detail":"Heavier"}]}"#.utf8)
+        )
+        XCTAssertEqual(question.title, "Question")
+        XCTAssertEqual(question.question, "Which store?")
+        XCTAssertEqual(question.options.map(\.label), ["SQLite", "Core Data"])
+        XCTAssertEqual(question.options.last?.detail, "Heavier")
+        XCTAssertTrue(question.recommended.isEmpty)
+        XCTAssertFalse(question.id.isEmpty)
+
+        let recommended = UserQuestion(
+            options: [UserQuestionOption(label: "SQLite")],
+            recommended: "sqlite"
+        )
+        XCTAssertEqual(recommended.recommendedOptionIndex, 0, "label matching is case-insensitive")
+    }
+
+    func testQuestionDetectorParsesTheGrillBlock() throws {
+        let text = """
+        Mapping the design tree first.
+
+        ❓ **Q1** - **Reddit scope**: Should "latest posts" mean the site-wide feed or one subreddit?
+
+        - Site-wide /new feed
+        - A subreddit argument
+
+        ➡️ Site-wide /new feed
+        """
+        let question = try XCTUnwrap(QuestionSignalDetector.question(from: text))
+        XCTAssertEqual(question.title, "Reddit scope")
+        XCTAssertEqual(
+            question.question,
+            #"Should "latest posts" mean the site-wide feed or one subreddit?"#
+        )
+        XCTAssertEqual(
+            question.options.map(\.label),
+            ["Site-wide /new feed", "A subreddit argument"]
+        )
+        XCTAssertEqual(question.recommended, "Site-wide /new feed")
+        XCTAssertEqual(question.recommendedOptionIndex, 0)
+    }
+
+    func testQuestionDetectorNeedsTheMarkerAndSurvivesSparseBlocks() throws {
+        XCTAssertNil(
+            QuestionSignalDetector.question(from: "Should the retries back off exponentially?"),
+            "prose ending in a question mark is not the Grill block"
+        )
+        XCTAssertNil(QuestionSignalDetector.question(from: ""))
+
+        // No options, no recommendation, multi-paragraph body.
+        let sparse = try XCTUnwrap(QuestionSignalDetector.question(
+            from: "❓ **Q3** - **Storage**: Where should results persist?\n\nThe workspace has no database yet."
+        ))
+        XCTAssertEqual(sparse.title, "Storage")
+        XCTAssertTrue(sparse.question.contains("no database yet"))
+        XCTAssertTrue(sparse.options.isEmpty)
+        XCTAssertTrue(sparse.recommended.isEmpty)
+
+        // Missing the bold title convention entirely.
+        let untitled = try XCTUnwrap(QuestionSignalDetector.question(
+            from: "❓ Which port should the server bind?\n➡️ 8791"
+        ))
+        XCTAssertEqual(untitled.title, "Question")
+        XCTAssertEqual(untitled.question, "Which port should the server bind?")
+        XCTAssertEqual(untitled.recommended, "8791")
+    }
+
     @MainActor
     func testAdaptiveWorkPromptDecorationNamesTheNeutralMode() {
         let model = AppModel(startImmediately: false)
@@ -4030,6 +4099,9 @@ final class AppModelTests: XCTestCase {
             tool("q3", "request_user_input"),
         ]).title, "Asked 3 questions")
         XCTAssertEqual(CompactToolActivitySummary(tools: [
+            tool("q1", "ask_user_question"),
+        ]).title, "Asked a question")
+        XCTAssertEqual(CompactToolActivitySummary(tools: [
             tool("e1", "apply_patch"),
             tool("e2", "edit_file"),
         ]).title, "Edited files")
@@ -4406,6 +4478,159 @@ final class AppModelTests: XCTestCase {
         model.handleEventForTesting(["type": "turn_done"])
 
         XCTAssertTrue(model.planApprovalPending, "an agent that omits the reason completed normally")
+    }
+
+    private static let questionReadyEvent: [String: Any] = [
+        "type": "question_ready",
+        "question": [
+            "id": "q-1",
+            "title": "Reddit scope",
+            "question": "Site-wide feed or one subreddit?",
+            "options": [
+                ["label": "Site-wide /new feed", "detail": ""],
+                "A subreddit argument",
+            ],
+            "recommended": "Site-wide /new feed",
+        ] as [String: Any],
+    ]
+
+    @MainActor
+    func testQuestionReadyArmsThePopupWhenTheTurnCompletes() {
+        let model = AppModel(startImmediately: false)
+        model.turnDispatchedMode = .grill
+        model.isBusy = true
+
+        model.handleEventForTesting(Self.questionReadyEvent)
+        XCTAssertNil(model.pendingUserQuestion, "the popup waits for the turn to finish")
+
+        model.handleEventForTesting(["type": "turn_done", "reason": "complete"])
+
+        let question = model.pendingUserQuestion
+        XCTAssertEqual(question?.title, "Reddit scope")
+        XCTAssertEqual(
+            question?.options.map(\.label),
+            ["Site-wide /new feed", "A subreddit argument"]
+        )
+        XCTAssertEqual(question?.recommendedOptionIndex, 0)
+    }
+
+    @MainActor
+    func testInterruptedTurnNeverOffersItsQuestion() {
+        let model = AppModel(startImmediately: false)
+        model.turnDispatchedMode = .grill
+        model.isBusy = true
+
+        model.handleEventForTesting(Self.questionReadyEvent)
+        model.handleEventForTesting(["type": "turn_done", "reason": "interrupted"])
+
+        XCTAssertNil(model.pendingUserQuestion, "a stopped run was already a decision")
+
+        // The captured question must not leak into the next turn either.
+        model.handleEventForTesting(["type": "turn_done", "reason": "complete"])
+        XCTAssertNil(model.pendingUserQuestion)
+    }
+
+    @MainActor
+    func testGrillTurnFallsBackToDetectingTheQuestionBlock() {
+        let model = AppModel(startImmediately: false)
+        model.turnDispatchedMode = .grill
+        model.isBusy = true
+        model.blocks.append(ChatBlock(
+            kind: .assistant,
+            text: "❓ **Q1** - **Scope**: Site-wide feed or one subreddit?\n\n➡️ Site-wide"
+        ))
+
+        model.handleEventForTesting(["type": "turn_done", "reason": "complete"])
+
+        XCTAssertEqual(model.pendingUserQuestion?.title, "Scope")
+        XCTAssertEqual(model.pendingUserQuestion?.recommended, "Site-wide")
+    }
+
+    @MainActor
+    func testWorkTurnsDoNotSniffQuestionsFromText() {
+        let model = AppModel(startImmediately: false)
+        model.turnDispatchedMode = .work
+        model.isBusy = true
+        model.blocks.append(ChatBlock(
+            kind: .assistant,
+            text: "❓ **Q1** - **Scope**: Site-wide feed or one subreddit?\n\n➡️ Site-wide"
+        ))
+
+        model.handleEventForTesting(["type": "turn_done", "reason": "complete"])
+
+        XCTAssertNil(model.pendingUserQuestion, "the fallback is Grill's contract, not Work's")
+    }
+
+    @MainActor
+    func testStructuredQuestionOutranksPlanApproval() {
+        let model = AppModel(startImmediately: false)
+        model.selectedMode = .plan
+        model.turnDispatchedInPlanMode = true
+        model.turnDispatchedMode = .plan
+        model.isBusy = true
+
+        model.handleEventForTesting([
+            "type": "plan_ready",
+            "plan": [
+                "id": "p-1", "title": "The plan", "summary": "",
+                "steps": ["Inspect", "Fix"], "tests": [],
+            ] as [String: Any],
+        ])
+        model.handleEventForTesting(Self.questionReadyEvent)
+        model.handleEventForTesting(["type": "turn_done", "reason": "complete"])
+
+        XCTAssertNotNil(model.pendingUserQuestion)
+        XCTAssertFalse(
+            model.planApprovalPending,
+            "a model still asking is not yet proposing"
+        )
+    }
+
+    @MainActor
+    func testQuestionClearsOnModeSwitchDismissAndError() {
+        let arm = { () -> AppModel in
+            let model = AppModel(startImmediately: false)
+            model.selectedMode = .grill
+            model.turnDispatchedMode = .grill
+            model.isBusy = true
+            model.handleEventForTesting(Self.questionReadyEvent)
+            model.handleEventForTesting(["type": "turn_done", "reason": "complete"])
+            XCTAssertNotNil(model.pendingUserQuestion)
+            return model
+        }
+
+        let switched = arm()
+        switched.selectedMode = .work
+        XCTAssertNil(switched.pendingUserQuestion)
+
+        let dismissed = arm()
+        dismissed.dismissUserQuestion()
+        XCTAssertNil(dismissed.pendingUserQuestion)
+
+        let errored = arm()
+        errored.handleEventForTesting(["type": "error", "message": "boom"])
+        XCTAssertNil(errored.pendingUserQuestion)
+    }
+
+    func testComposedQuestionAnswerJoinsOptionAndElaboration() {
+        XCTAssertEqual(
+            AppModel.composedQuestionAnswer(
+                option: UserQuestionOption(label: "SQLite"), freeText: ""
+            ),
+            "SQLite"
+        )
+        XCTAssertEqual(
+            AppModel.composedQuestionAnswer(option: nil, freeText: "  Use Postgres  "),
+            "Use Postgres"
+        )
+        XCTAssertEqual(
+            AppModel.composedQuestionAnswer(
+                option: UserQuestionOption(label: "SQLite"),
+                freeText: "but only if it stays single-writer"
+            ),
+            "SQLite\n\nbut only if it stays single-writer"
+        )
+        XCTAssertNil(AppModel.composedQuestionAnswer(option: nil, freeText: "   "))
     }
 
     @MainActor

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -1084,17 +1084,62 @@ final class FeatureLogicTests: XCTestCase {
         )
     }
 
-    func testFileCardsAreReservedForTopLevelReferences() {
+    func testFileReferencesGetFullCardAtTopLevelAndChipInLists() {
         // A reply that lists a directory writes one bullet per file. Promoting
         // each of those to a 58pt card with three buttons turned a seven-file
-        // answer into a wall of chrome, which is what made the reply read as a
-        // raw dump rather than an answer.
-        XCTAssertTrue(MarkdownArtifactPromotion.allowsCard(nestingDepth: 0))
-        XCTAssertFalse(
-            MarkdownArtifactPromotion.allowsCard(nestingDepth: 1),
-            "inside a list the reference stays an inline, still-clickable link"
+        // answer into a wall of chrome, so nested references take the compact
+        // chip tier instead of losing the tile entirely.
+        XCTAssertEqual(MarkdownArtifactPromotion.presentation(nestingDepth: 0), .fullCard)
+        XCTAssertEqual(
+            MarkdownArtifactPromotion.presentation(nestingDepth: 1), .compactChip,
+            "inside a list the reference keeps a tile, just a single-line one"
         )
-        XCTAssertFalse(MarkdownArtifactPromotion.allowsCard(nestingDepth: 2))
+        XCTAssertEqual(MarkdownArtifactPromotion.presentation(nestingDepth: 2), .compactChip)
+    }
+
+    func testLeadingArtifactPromotesAnnotatedBulletsButNotComparisons() throws {
+        let workspace = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("locus-chip-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workspace) }
+        try Data("a".utf8).write(to: workspace.appendingPathComponent("notes.md"))
+        try Data("b".utf8).write(to: workspace.appendingPathComponent("todo.md"))
+
+        func reference(_ runs: [MarkdownInlineRun]) -> WorkspaceArtifactReference? {
+            MarkdownArtifactPromotion.leadingArtifact(in: runs, workspacePath: workspace.path)
+        }
+
+        // A bare backticked name and a bare link both promote.
+        XCTAssertEqual(
+            reference([.init(text: "notes.md", style: .code)])?.relativePath, "notes.md"
+        )
+        XCTAssertEqual(
+            reference([.init(text: "notes.md", destination: "notes.md")])?.relativePath,
+            "notes.md"
+        )
+        // The answer contract annotates every bullet; the annotation rides
+        // along instead of demoting the reference to prose.
+        XCTAssertEqual(
+            reference([
+                .init(text: "notes.md", style: .code),
+                .init(text: " — the working notes"),
+            ])?.relativePath,
+            "notes.md"
+        )
+        // Prose that merely mentions a file does not lead with it.
+        XCTAssertNil(reference([
+            .init(text: "see "),
+            .init(text: "notes.md", style: .code),
+        ]))
+        // A comparison of two files stays prose: a chip's actions would be
+        // attributed to just one of them.
+        XCTAssertNil(reference([
+            .init(text: "notes.md", style: .code),
+            .init(text: " duplicates "),
+            .init(text: "todo.md", style: .code),
+        ]))
+        // Names that resolve to nothing in the workspace never promote.
+        XCTAssertNil(reference([.init(text: "missing.md", style: .code)]))
     }
 
     @MainActor

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -1462,6 +1462,15 @@ final class FeatureLogicTests: XCTestCase {
         XCTAssertTrue(RunScope.soloSwarm.includes(explicit))
         XCTAssertFalse(RunScope.teams.includes(explicit))
         XCTAssertTrue(RunScope.all.includes(ordinary))
+
+        // Eligibility keeps the Solo scope; delegation needs real evidence
+        // (job_count in the list payload, attempts in the detail payload).
+        let counted = try decodeRun(",\"manifest\":{\"solo_swarm\":true},\"job_count\":3")
+        XCTAssertFalse(explicit.didDelegateWorkers)
+        XCTAssertFalse(neverDelegated.didDelegateWorkers)
+        XCTAssertFalse(ordinary.didDelegateWorkers)
+        XCTAssertTrue(legacy.didDelegateWorkers)
+        XCTAssertTrue(counted.didDelegateWorkers)
     }
 
     func testZoomedChatWidthIsClampedToTheUsableRange() {

--- a/LocusTests/PinnedSummaryTests.swift
+++ b/LocusTests/PinnedSummaryTests.swift
@@ -294,9 +294,11 @@ final class PinnedSummaryTests: XCTestCase {
          "team_name":"Checkers","created_at":1,"updated_at":2,"last_seq":0,
          "pinned":false,"legacy":false,"recoverable":false,"run_kind":"team"}
         """)
+        // Production stamps `manifest.solo_swarm` on every non-Ask turn, so the
+        // fixture must carry it too — eligibility alone stays excluded.
         let soloTurn = try decodeRun("""
         {"id":"solo-1","session_id":"s","state":"running","request":"Fix bug",
-         "created_at":1,"updated_at":3,"last_seq":0,
+         "created_at":1,"updated_at":3,"last_seq":0,"manifest":{"solo_swarm":true},
          "pinned":false,"legacy":false,"recoverable":false,"run_kind":"solo"}
         """)
         let otherSession = try decodeRun("""
@@ -304,11 +306,36 @@ final class PinnedSummaryTests: XCTestCase {
          "created_at":1,"updated_at":4,"last_seq":0,
          "pinned":false,"legacy":false,"recoverable":false,"run_kind":"team"}
         """)
-        let fallback = PinnedSummary.subagents(activities: [], runs: [soloTurn, otherSession, teamRun], sessionID: "s")
-        XCTAssertEqual(fallback.map(\.id), ["team-1"])
-        XCTAssertEqual(fallback.first?.name, "Checkers")
-        XCTAssertEqual(fallback.first?.status, .working)
-        XCTAssertEqual(fallback.first?.runID, "team-1")
+        let delegatedByJobs = try decodeRun("""
+        {"id":"solo-2","session_id":"s","state":"completed","request":"Sweep tests",
+         "created_at":1,"updated_at":5,"last_seq":0,"manifest":{"solo_swarm":true},
+         "job_count":2,"completed_job_count":2,
+         "pinned":false,"legacy":false,"recoverable":false,"run_kind":"solo"}
+        """)
+        let delegatedByAttempts = try decodeRun("""
+        {"id":"solo-3","session_id":"s","state":"completed","request":"Audit",
+         "created_at":1,"updated_at":6,"last_seq":0,"manifest":{"solo_swarm":true},
+         "attempts":[{"run_id":"solo-3","job_id":"worker-1","attempt":1,
+                      "attempt_id":"worker-1:1","state":"completed","goal":"Read API"}],
+         "pinned":false,"legacy":false,"recoverable":false,"run_kind":"solo"}
+        """)
+        let fallback = PinnedSummary.subagents(activities: [], runs: [soloTurn, otherSession, teamRun, delegatedByJobs, delegatedByAttempts], sessionID: "s")
+        XCTAssertEqual(fallback.map(\.id), ["solo-3", "solo-2", "team-1"])
+        XCTAssertEqual(fallback.last?.name, "Checkers")
+        XCTAssertEqual(fallback.last?.status, .working)
+        XCTAssertEqual(fallback.last?.runID, "team-1")
+        XCTAssertEqual(fallback.first?.name, "Solo")
+
+        // Regression: a session of ordinary eligible-but-alone turns must not
+        // masquerade as subagents ("Subagents 8" for a chat with zero workers).
+        let plainTurns = try (0..<8).map { index in
+            try decodeRun("""
+            {"id":"plain-\(index)","session_id":"s","state":"completed","request":"Turn \(index)",
+             "created_at":1,"updated_at":\(10 + index),"last_seq":0,"manifest":{"solo_swarm":true},
+             "pinned":false,"legacy":false,"recoverable":false,"run_kind":"solo"}
+            """)
+        }
+        XCTAssertTrue(PinnedSummary.subagents(activities: [], runs: plainTurns, sessionID: "s").isEmpty)
 
         let activity = AgentActivity(
             id: "job-1", agentName: "Reader", role: "researcher", provider: "", model: "",

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -2397,6 +2397,16 @@ final class LocusUITests: XCTestCase {
         app.launch()
         XCTAssertTrue(anyElement("planApproval.panel").waitForExistence(timeout: 10))
         try auditCurrentSurface()
+
+        app.terminate()
+        app.launchEnvironment["LOCUS_UI_TESTING_PLAN_APPROVAL"] = nil
+        app.launchEnvironment["LOCUS_UI_TESTING_QUESTION_PROMPT"] = "1"
+        app.launchEnvironment["LOCUS_UI_TESTING_ACCESSIBILITY_SURFACE"] = "question-prompt"
+        app.launch()
+        XCTAssertTrue(anyElement("questionPrompt.panel").waitForExistence(timeout: 10))
+        XCTAssertTrue(anyElement("questionPrompt.option.0").exists)
+        XCTAssertTrue(anyElement("questionPrompt.freeText").exists)
+        try auditCurrentSurface()
     }
 
     func testDocumentationScreenshots() {

--- a/agent/PROTOCOL.md
+++ b/agent/PROTOCOL.md
@@ -836,6 +836,31 @@ plan-decision boundary, not a general progress event.
 The client presents Proceed, Revise, and Cancel only after the surrounding Plan
 turn completes successfully. Reconnection replay preserves this event's order.
 
+### `question_ready`
+
+Emitted after the permission-free `ask_user_question` tool succeeds. The tool
+does not block the turn: the model is told to end its turn, and the client
+presents the question popup only after the surrounding turn completes with
+`reason: "complete"`. The user's answer returns as an ordinary `user_message`
+— there is no dedicated reply message. Reconnection replay preserves this
+event's order.
+
+```json
+{ "type": "question_ready", "question": {
+  "id": "8f38c1d2d9a04bc1", "title": "Reddit scope",
+  "question": "Should latest posts mean the site-wide feed or one subreddit?",
+  "options": [
+    { "label": "Site-wide /new feed", "detail": "" },
+    { "label": "One subreddit", "detail": "Passed as an argument" }
+  ],
+  "recommended": "Site-wide /new feed"
+} }
+```
+
+`options` may be empty; the client always offers a free-text answer. `recommended`
+is the model's suggested answer — an option label when it matches one, freeform
+otherwise.
+
 ### `steer_ack` / `steer_applied`
 
 `steer_ack {text, state}` accepts a steering message. `state` is
@@ -1016,8 +1041,9 @@ or `tool_result` for the same call.
 ```
 
 `id` (10 hex chars) correlates this call across all later events. `auto` is true
-when the tool runs without asking (safe tools `read_file`/`glob`/`grep`/`list_dir`,
-tools previously allowed with `always`, or `--dangerously-skip-permissions`).
+when the tool runs without asking (safe tools `read_file`/`glob`/`grep`/`list_dir`/
+`ask_user_question`, tools previously allowed with `always`, or
+`--dangerously-skip-permissions`).
 
 ### `permission_request`
 Only when `auto` is false. The turn blocks until a `permission_decision` arrives.

--- a/agent/ollama_code/agent_config.py
+++ b/agent/ollama_code/agent_config.py
@@ -24,6 +24,7 @@ ANSWER_CONTRACT = """Every turn ends with a written answer, for a reader who did
 - Scale length to the work. A single lookup is one to three sentences. A turn that ran several tools gets a short write-up: what you did, what you found, what changed, and anything the user now has to decide.
 - Add structure only when the work has structure. Prose beats a list when there are fewer than three points.
 - A bare list of names, paths, or values is not an answer. Every bullet says what the item is or why it matters: `AppModel.swift` on its own is noise, while "`AppModel.swift` - the composition root, and the largest file here" answers something.
+- Write workspace file references as backticked relative paths, one per bullet when enumerating files, with the annotation after a dash; the app renders each as an interactive file chip. After any file listing, close with a sentence or two of plain prose saying what the listing amounts to.
 - Cite what you actually observed: a path as `dir/file.swift:42`, the command you ran, the number you read. Never present an assumption as an observation, and say plainly when something was not verified.
 - Summarize tool output; never paste it back. No raw directory dumps, no reprinted file contents.
 - Close with concrete next steps only when real ones exist. Do not invent follow-up work to fill a section."""

--- a/agent/ollama_code/builtin_skills/grilling/SKILL.md
+++ b/agent/ollama_code/builtin_skills/grilling/SKILL.md
@@ -15,6 +15,8 @@ Each question should be formatted like so:
 ➡️ <your recommended answer>
 ```
 
+After writing the question block, deliver it by calling the `ask_user_question` tool with the same title, question body, the multiple choices as `options`, and the `➡️` recommendation as `recommended` — the app raises it as an answer popup. Then end your turn and wait. Keep the markdown block too: it is the transcript's readable record.
+
 Each answer reshapes the tree: settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier before asking the next single question. A question whose answer depends on the current question belongs later.
 
 Finding _facts_ is your job, never the user's. When a frontier question needs a fact from the environment, inspect the repository and available evidence directly; don't ask the user for anything you can discover safely. The _decisions_ are the user's: put each to them and wait.

--- a/agent/ollama_code/core.py
+++ b/agent/ollama_code/core.py
@@ -94,6 +94,7 @@ _SOLO_ROOT_ONLY_TOOLS = {
     "delegate_read_only",
     "todo_write",
     "submit_plan",
+    "ask_user_question",
     "capture_context_snapshot",
     "propose_memory",
     "record_skill_observation",
@@ -1334,6 +1335,7 @@ class AgentCore:
         self._clear_chatgpt_thread()
         self.tool_ctx.todos = []
         self.tool_ctx.plan_document = None
+        self.tool_ctx.user_question = None
         self._emit({"type": "todo_update", "todos": []})
         self.mcp.refresh(wait=False)
         self._emit_info()
@@ -1381,6 +1383,7 @@ class AgentCore:
         self._clear_chatgpt_thread()
         self.tool_ctx.todos = []
         self.tool_ctx.plan_document = None
+        self.tool_ctx.user_question = None
         self.tool_ctx.read_files.clear()
         self._last_user_message = None
         self._pending_computer_screenshot = None
@@ -1440,6 +1443,14 @@ class AgentCore:
                 "You are in Locus Plan mode: investigate, then call the "
                 "submit_plan tool exactly once with your final implementation "
                 "plan. Do not modify any files in this mode."
+            )
+        if self.agent_mode == "grill":
+            sections.append(
+                "You are in Locus Grill mode: after writing your question in "
+                "the transcript, deliver it by calling the ask_user_question "
+                "tool with the same title, question, options, and your "
+                "recommended answer, then end your turn. Do not modify any "
+                "files in this mode."
             )
         sections.append("## Locus answer contract\n" + ANSWER_CONTRACT)
         return "\n\n".join(sections)
@@ -3407,6 +3418,8 @@ class AgentCore:
             self._emit({"type": "todo_update", "todos": self.tool_ctx.todos})
         if tc.name == "submit_plan" and self.tool_ctx.plan_document is not None and ok:
             self._emit({"type": "plan_ready", "plan": dict(self.tool_ctx.plan_document)})
+        if tc.name == "ask_user_question" and self.tool_ctx.user_question is not None and ok:
+            self._emit({"type": "question_ready", "question": dict(self.tool_ctx.user_question)})
         return result
 
     def _targets_workspace(self, tc: ToolCall) -> bool:

--- a/agent/ollama_code/core.py
+++ b/agent/ollama_code/core.py
@@ -1442,7 +1442,8 @@ class AgentCore:
             sections.append(
                 "You are in Locus Plan mode: investigate, then call the "
                 "submit_plan tool exactly once with your final implementation "
-                "plan. Do not modify any files in this mode."
+                "plan. Ask clarifying questions through the ask_user_question "
+                "tool. Do not modify any files in this mode."
             )
         if self.agent_mode == "grill":
             sections.append(
@@ -1644,6 +1645,9 @@ class AgentCore:
         persisted_user_metadata: dict[str, Any] | None = None,
     ) -> None:
         """Run one local-agent turn."""
+        # A question belongs to the turn that asks it. A stale one would
+        # wrongly suppress the next turn's final-answer pass.
+        self.tool_ctx.user_question = None
         if self.provider == "chatgpt":
             self._run_chatgpt_turn(
                 user_text,
@@ -1859,6 +1863,10 @@ class AgentCore:
                     self._chatgpt_thread_protocol = manager.runtime_version
                     self._chatgpt_thread_history_revision = len(self.messages)
                     self._chatgpt_thread_needs_resume = False
+                    # A replacement thread's totals restart from zero; a stale
+                    # baseline from the retired thread would under-bill it.
+                    self._chatgpt_thread_total_input = 0
+                    self._chatgpt_thread_total_output = 0
                     self.session.append({
                         "type": "chatgpt_thread",
                         "thread_id": self._chatgpt_thread_id,
@@ -2222,18 +2230,35 @@ class AgentCore:
                 total = usage.get("total") if isinstance(usage.get("total"), dict) else {}
                 total_input = max(int(total.get("inputTokens") or 0), 0)
                 total_output = max(int(total.get("outputTokens") or 0), 0)
-                if (
-                    total_input < self._chatgpt_thread_total_input
-                    or total_output < self._chatgpt_thread_total_output
-                ):
-                    # The helper restarted or compacted the thread: totals reset.
-                    self._chatgpt_thread_total_input = 0
-                    self._chatgpt_thread_total_output = 0
-                delta_input = max(total_input - self._chatgpt_thread_total_input, 0)
-                delta_output = max(total_output - self._chatgpt_thread_total_output, 0)
+                delta_input = 0
+                delta_output = 0
                 if total_input or total_output:
+                    # A turn that reported no totals at all must leave the
+                    # baselines alone: zeros are absence, not a reset.
+                    if (
+                        total_input < self._chatgpt_thread_total_input
+                        or total_output < self._chatgpt_thread_total_output
+                    ):
+                        # The helper restarted or compacted the thread.
+                        self._chatgpt_thread_total_input = 0
+                        self._chatgpt_thread_total_output = 0
+                    delta_input = max(total_input - self._chatgpt_thread_total_input, 0)
+                    delta_output = max(total_output - self._chatgpt_thread_total_output, 0)
                     self._chatgpt_thread_total_input = total_input
                     self._chatgpt_thread_total_output = total_output
+                    if self._chatgpt_thread_id:
+                        # Re-stamp the resume marker so a resumed session
+                        # inherits the baselines along with the thread, rather
+                        # than re-billing the whole thread to its first turn.
+                        self.session.append({
+                            "type": "chatgpt_thread",
+                            "thread_id": self._chatgpt_thread_id,
+                            "protocol_version": self._chatgpt_thread_protocol,
+                            "history_revision": self._chatgpt_thread_history_revision,
+                            "tool_schema_fingerprint": self._chatgpt_thread_fingerprint,
+                            "total_input_tokens": self._chatgpt_thread_total_input,
+                            "total_output_tokens": self._chatgpt_thread_total_output,
+                        })
                 prompt = native_prompt_tokens or delta_input
                 completion = native_completion_tokens or delta_output
                 self.total_prompt_tokens += prompt
@@ -2639,6 +2664,11 @@ class AgentCore:
             # Team workers and background runs are collected programmatically.
             # Nobody is reading a write-up, and an extra call would be spent on
             # text that is thrown away.
+            return False
+        if self.tool_ctx.user_question is not None:
+            # The question is this turn's deliverable, and the tool result just
+            # told the model to end its turn and wait. A nudge here would talk
+            # over the pending popup.
             return False
         text = self._last_final_answer_text()
         if not text:
@@ -3733,6 +3763,14 @@ class AgentCore:
                 self._chatgpt_thread_protocol = str(marker["protocol_version"])
                 self._chatgpt_thread_history_revision = int(marker["history_revision"])
                 self._chatgpt_thread_needs_resume = True
+                # The resumed thread keeps its cumulative totals; without the
+                # stored baselines its first turn would re-bill all of them.
+                self._chatgpt_thread_total_input = max(
+                    int(marker.get("total_input_tokens") or 0), 0
+                )
+                self._chatgpt_thread_total_output = max(
+                    int(marker.get("total_output_tokens") or 0), 0
+                )
         self._pending_computer_screenshot = None
         self._ax_only_routes.clear()
         # Continue appending to the session the user resumed.

--- a/agent/ollama_code/core.py
+++ b/agent/ollama_code/core.py
@@ -345,6 +345,10 @@ class AgentCore:
         self._chatgpt_thread_protocol = ""
         self._chatgpt_thread_history_revision = 0
         self._chatgpt_thread_needs_resume = False
+        # The helper's ``total`` token usage is cumulative for the whole
+        # thread; these baselines let a turn claim only its own delta.
+        self._chatgpt_thread_total_input = 0
+        self._chatgpt_thread_total_output = 0
         self.max_iterations = iteration_limit(
             max_iterations or self.config.get("max_iterations")
         )
@@ -1391,6 +1395,8 @@ class AgentCore:
         self._chatgpt_thread_protocol = ""
         self._chatgpt_thread_history_revision = 0
         self._chatgpt_thread_needs_resume = False
+        self._chatgpt_thread_total_input = 0
+        self._chatgpt_thread_total_output = 0
 
     def chatgpt_parity_active(self, allow_tools: bool = True) -> bool:
         """True when this turn runs under the Codex-native parity contract.
@@ -2197,13 +2203,28 @@ class AgentCore:
                             "type": "note",
                             "text": "Locus could not write a closing summary for this turn.",
                         })
-                # A helper that reports a running ``total`` is authoritative;
-                # otherwise the per-call sum built above is the honest figure.
+                # The per-call sum built above is turn-scoped by construction.
+                # The helper's ``total`` is cumulative for the whole thread, so
+                # it may only stand in as a delta against the previous turn's
+                # baseline — attributing it wholesale re-billed the entire
+                # thread to every turn.
                 total = usage.get("total") if isinstance(usage.get("total"), dict) else {}
-                prompt = max(int(total.get("inputTokens") or 0), 0) or native_prompt_tokens
-                completion = (
-                    max(int(total.get("outputTokens") or 0), 0) or native_completion_tokens
-                )
+                total_input = max(int(total.get("inputTokens") or 0), 0)
+                total_output = max(int(total.get("outputTokens") or 0), 0)
+                if (
+                    total_input < self._chatgpt_thread_total_input
+                    or total_output < self._chatgpt_thread_total_output
+                ):
+                    # The helper restarted or compacted the thread: totals reset.
+                    self._chatgpt_thread_total_input = 0
+                    self._chatgpt_thread_total_output = 0
+                delta_input = max(total_input - self._chatgpt_thread_total_input, 0)
+                delta_output = max(total_output - self._chatgpt_thread_total_output, 0)
+                if total_input or total_output:
+                    self._chatgpt_thread_total_input = total_input
+                    self._chatgpt_thread_total_output = total_output
+                prompt = native_prompt_tokens or delta_input
+                completion = native_completion_tokens or delta_output
                 self.total_prompt_tokens += prompt
                 self.total_completion_tokens += completion
                 if self._interrupt.is_set():

--- a/agent/ollama_code/sessions.py
+++ b/agent/ollama_code/sessions.py
@@ -829,11 +829,27 @@ class SessionStore:
                         and isinstance(fingerprint, str) and fingerprint
                         and isinstance(revision, int) and revision >= 0
                     ):
+                        total_input = record.get("total_input_tokens")
+                        total_output = record.get("total_output_tokens")
                         latest = {
                             "thread_id": thread_id,
                             "protocol_version": protocol,
                             "tool_schema_fingerprint": fingerprint,
                             "history_revision": revision,
+                            # Token baselines ride the marker so a resumed
+                            # thread's first turn is billed as a delta, not the
+                            # thread's whole cumulative total. Older markers
+                            # simply lack them.
+                            "total_input_tokens": (
+                                total_input
+                                if isinstance(total_input, int) and total_input >= 0
+                                else 0
+                            ),
+                            "total_output_tokens": (
+                                total_output
+                                if isinstance(total_output, int) and total_output >= 0
+                                else 0
+                            ),
                         }
         except OSError:
             return None

--- a/agent/ollama_code/tool_registry.py
+++ b/agent/ollama_code/tool_registry.py
@@ -1062,7 +1062,8 @@ class ToolRegistry:
         adaptive delegation tool when available. The user's capability policy
         is applied against each canonical tool, the same gate `schemas()` uses.
         `submit_plan` joins only in Plan mode, where Locus's plan-approval flow
-        depends on it.
+        depends on it; `ask_user_question` joins every parity turn, so the
+        question popup works in Work and Grill as well.
         """
         schemas = [
             schema for schema in PARITY_TOOL_SCHEMAS
@@ -1074,11 +1075,11 @@ class ToolRegistry:
             and self._user_allows("delegate_read_only")
         ):
             schemas.append(DELEGATE_READ_ONLY_SCHEMA)
-        if plan_mode:
-            schemas.extend(
-                schema for schema in TOOL_SCHEMAS
-                if schema["function"]["name"] == "submit_plan"
-            )
+        wanted = {"ask_user_question", "submit_plan"} if plan_mode else {"ask_user_question"}
+        schemas.extend(
+            schema for schema in TOOL_SCHEMAS
+            if schema["function"]["name"] in wanted
+        )
         schemas.extend(
             schema for schema in self.simulator_schemas()
             if self._user_allows(schema["function"]["name"])

--- a/agent/ollama_code/tools.py
+++ b/agent/ollama_code/tools.py
@@ -45,6 +45,7 @@ IGNORE_DIRS = {
 #: Read-only tools that never require permission.
 SAFE_TOOLS = {
     "read_file", "glob", "grep", "list_dir", "todo_write", "submit_plan",
+    "ask_user_question",
     "search_workspace_knowledge", "search_memory", "propose_memory",
     "record_skill_observation", "capture_context_snapshot",
     "computer_list_apps", "computer_get_state",
@@ -72,6 +73,8 @@ class ToolContext:
 
     todos: list[dict[str, str]] = field(default_factory=list)
     plan_document: dict[str, Any] | None = None
+    #: The question this turn asked the user, surfaced as a popup by the app.
+    user_question: dict[str, Any] | None = None
     cwd: str = ""
     #: Files read this turn, so edit_file can warn about blind edits.
     read_files: set[str] = field(default_factory=set)
@@ -893,6 +896,39 @@ def _impl_submit_plan(args: dict[str, Any], ctx: ToolContext) -> str:
     return f"Plan submitted for approval ({len(steps)} steps)."
 
 
+def _impl_ask_user_question(args: dict[str, Any], ctx: ToolContext) -> str:
+    question = str(args.get("question") or "").strip()[:4_000]
+    if not question:
+        return "Error: 'question' is required."
+    title = str(args.get("title") or "").strip()[:160]
+    if not title:
+        title = question.splitlines()[0][:160]
+    raw_options = args.get("options")
+    options: list[dict[str, str]] = []
+    if isinstance(raw_options, list):
+        for item in raw_options[:8]:
+            if isinstance(item, dict):
+                label = str(item.get("label") or "").strip()[:200]
+                detail = str(item.get("detail") or "").strip()[:400]
+            else:
+                label = str(item).strip()[:200]
+                detail = ""
+            if label:
+                options.append({"label": label, "detail": detail})
+    recommended = str(args.get("recommended") or "").strip()[:600]
+    ctx.user_question = {
+        "id": secrets.token_hex(8),
+        "title": title,
+        "question": question,
+        "options": options,
+        "recommended": recommended,
+    }
+    return (
+        "Question delivered to the user. End your turn now and wait for "
+        "their answer before continuing."
+    )
+
+
 def _impl_search_workspace_knowledge(args: dict[str, Any], ctx: ToolContext) -> str:
     query = str(args.get("query") or "").strip()
     if not query:
@@ -1087,6 +1123,7 @@ _IMPLS: dict[str, Callable[[dict[str, Any], ToolContext], str]] = {
     "git_status": _impl_git_status,
     "git_diff": _impl_git_diff,
     "submit_plan": _impl_submit_plan,
+    "ask_user_question": _impl_ask_user_question,
     "search_workspace_knowledge": _impl_search_workspace_knowledge,
     "search_memory": _impl_search_memory,
     "propose_memory": _impl_propose_memory,
@@ -1334,6 +1371,31 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
             },
         },
         ["title", "summary", "steps", "tests"],
+    ),
+    _schema(
+        "ask_user_question",
+        "Ask the user one clarifying or decision question and end your turn; the app presents it as a popup and their answer arrives as the next user message. Supply multiple-choice options when the answer space is known, and always include your recommended answer. Call at most once per turn.",
+        {
+            "title": {"type": "string", "description": "Short question title."},
+            "question": {"type": "string", "description": "The full question, may span paragraphs."},
+            "options": {
+                "type": "array",
+                "description": "Possible answers, when the space is known.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string", "description": "Concise answer."},
+                        "detail": {"type": "string", "description": "What choosing it means."},
+                    },
+                    "required": ["label"],
+                },
+            },
+            "recommended": {
+                "type": "string",
+                "description": "Your recommended answer — an option label, or freeform.",
+            },
+        },
+        ["question"],
     ),
     _schema(
         "web_fetch",

--- a/agent/tests/test_agent_config.py
+++ b/agent/tests/test_agent_config.py
@@ -84,6 +84,10 @@ def test_answer_contract_is_locked_for_tool_modes_and_absent_from_just_chat():
         assert contract["editable"] is False
         assert contract["content"] == ANSWER_CONTRACT
         assert "A bare list of names, paths, or values is not an answer" in prompt
+        # File listings stay chip-promotable: the renderer needs bare
+        # backticked paths leading each bullet, and the reply still ends in
+        # prose rather than trailing off at the last filename.
+        assert "interactive file chip" in prompt
         # The editable layer cannot quietly cancel it: the contract is composed
         # into the locked half, which the runtime declares outranks user text.
         assert prompt.index("Locked answer contract") < prompt.index(
@@ -95,6 +99,7 @@ def test_answer_contract_is_locked_for_tool_modes_and_absent_from_just_chat():
         layer for layer in chat_layers if layer["name"] == "Locked answer contract"
     ]
     assert "A bare list of names" not in chat_prompt
+    assert "interactive file chip" not in chat_prompt
 
 
 def test_agent_configuration_round_trips_as_versioned_additive_payload():

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -3368,6 +3368,69 @@ def test_submit_plan_emits_structured_plan_ready(tmp_path):
     assert ready["plan"]["tests"] == ["Stream a 100 KB reply"]
 
 
+def test_ask_user_question_emits_structured_question_ready(tmp_path):
+    from ollama_code.ollama import ToolCall
+
+    responses = [
+        ChatResponse(tool_calls=[ToolCall("ask_user_question", {
+            "title": "Reddit scope",
+            "question": "Should latest posts mean the site-wide feed or one subreddit?",
+            # String options and object options both normalize.
+            "options": [
+                "Site-wide /new feed",
+                {"label": "One subreddit", "detail": "Passed as an argument"},
+            ],
+            "recommended": "Site-wide /new feed",
+        })], done=True),
+        ChatResponse(content_parts=["Question sent."], done=True),
+    ]
+    core = _core(tmp_path, responses)
+    events = []
+    core.on_event(events.append)
+
+    core.run_turn("stress-test the request")
+
+    ready = next(event for event in events if event["type"] == "question_ready")
+    question = ready["question"]
+    assert question["title"] == "Reddit scope"
+    assert question["question"].startswith("Should latest posts")
+    assert question["options"] == [
+        {"label": "Site-wide /new feed", "detail": ""},
+        {"label": "One subreddit", "detail": "Passed as an argument"},
+    ]
+    assert question["recommended"] == "Site-wide /new feed"
+    assert question["id"]
+    # Asking never prompts for permission.
+    assert not [event for event in events if event["type"] == "permission_request"]
+
+
+def test_ask_user_question_requires_a_question(tmp_path):
+    from ollama_code.ollama import ToolCall
+
+    responses = [
+        ChatResponse(tool_calls=[ToolCall("ask_user_question", {
+            "options": ["Yes", "No"],
+        })], done=True),
+        ChatResponse(content_parts=["No question."], done=True),
+    ]
+    core = _core(tmp_path, responses)
+    events = []
+    core.on_event(events.append)
+
+    core.run_turn("do the work")
+
+    assert not [event for event in events if event["type"] == "question_ready"]
+    result = next(event for event in events if event["type"] == "tool_result")
+    assert result["result"].startswith("Error:")
+
+
+def test_reset_conversation_clears_the_pending_question(tmp_path):
+    core = _core(tmp_path, [ChatResponse(content_parts=["ok"], done=True)])
+    core.tool_ctx.user_question = {"id": "abc", "question": "Stale?"}
+    core.reset_conversation()
+    assert core.tool_ctx.user_question is None
+
+
 def test_local_and_inline_reasoning_are_resumable_without_provider_state(tmp_path):
     core = _core(tmp_path, [
         ChatResponse(

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -3431,6 +3431,29 @@ def test_reset_conversation_clears_the_pending_question(tmp_path):
     assert core.tool_ctx.user_question is None
 
 
+def test_ask_user_question_suppresses_the_final_answer_nudge(tmp_path):
+    from ollama_code.ollama import ToolCall
+
+    responses = [
+        ChatResponse(tool_calls=[ToolCall("ask_user_question", {
+            "question": "Which feed should the script read?",
+        })], done=True),
+        ChatResponse(content_parts=[""], done=True),
+    ]
+    core = _core(tmp_path, responses)
+    events = []
+    core.on_event(events.append)
+
+    core.run_turn("do the work")
+
+    done = next(event for event in events if event["type"] == "turn_done")
+    assert done["reason"] == "complete"
+    # The question is the turn's deliverable. Without the guard the empty
+    # final text would trigger the nudge's extra tool-free model call, talking
+    # over the popup the model was just told to wait for.
+    assert core.client.calls == 2
+
+
 def test_local_and_inline_reasoning_are_resumable_without_provider_state(tmp_path):
     core = _core(tmp_path, [
         ChatResponse(

--- a/agent/tests/test_chatgpt_app_server.py
+++ b/agent/tests/test_chatgpt_app_server.py
@@ -778,11 +778,12 @@ def test_parity_schemas_add_submit_plan_only_in_plan_mode(tmp_path):
 class MeteredManagedRuntime(FakeManagedRuntime):
     """A helper that bills each model call separately, as the real one does."""
 
-    def __init__(self, *, total=None, calls=2, tools=()):
+    def __init__(self, *, total=None, calls=2, tools=(), include_last=True):
         super().__init__()
         self.total = total
         self.calls = calls
         self.tools = list(tools)
+        self.include_last = include_last
 
     def run_turn(self, *, text, event_handler, tool_handler=None, **_kwargs):
         self.turn_texts.append(text)
@@ -790,7 +791,9 @@ class MeteredManagedRuntime(FakeManagedRuntime):
             for name, arguments in self.tools:
                 tool_handler(name, arguments, f"call-{name}")
         for index in range(self.calls):
-            usage = {"last": {"inputTokens": 100, "outputTokens": 10 + index}}
+            usage = {}
+            if self.include_last:
+                usage["last"] = {"inputTokens": 100, "outputTokens": 10 + index}
             if self.total is not None:
                 usage["total"] = self.total
             event_handler({
@@ -828,7 +831,13 @@ def test_managed_turn_counts_every_model_call_and_tool_step(tmp_path):
     assert terminal["completion_tokens"] == 10 + 11 + 12
 
 
-def test_managed_turn_prefers_a_server_reported_total(tmp_path):
+def test_managed_turn_reports_the_per_call_sum_even_when_a_total_is_present(tmp_path):
+    """The thread ``total`` is cumulative; it must never displace the turn's own sum.
+
+    An earlier build preferred the total wholesale, so every turn re-billed
+    the whole thread and a trivial late turn read as tens of thousands of
+    tokens in the Runs panel.
+    """
     runtime = MeteredManagedRuntime(
         calls=2, total={"inputTokens": 900, "outputTokens": 90}
     )
@@ -836,10 +845,43 @@ def test_managed_turn_prefers_a_server_reported_total(tmp_path):
 
     terminal = _turn_done(core, runtime, allow_tools=False)
 
-    assert terminal["prompt_tokens"] == 900
-    assert terminal["completion_tokens"] == 90
+    assert terminal["prompt_tokens"] == 200
+    assert terminal["completion_tokens"] == 10 + 11
     assert terminal["model_calls"] == 2
     assert terminal["tool_steps"] == 0
+
+
+def test_managed_turn_attributes_only_the_thread_total_delta(tmp_path):
+    """Without per-call updates, a turn claims only its slice of the total."""
+    runtime = MeteredManagedRuntime(
+        calls=1, include_last=False,
+        total={"inputTokens": 900, "outputTokens": 90},
+    )
+    core = _managed_core(tmp_path, runtime)
+
+    first = _turn_done(core, runtime, allow_tools=False)
+    assert first["prompt_tokens"] == 900
+    assert first["completion_tokens"] == 90
+
+    runtime.total = {"inputTokens": 950, "outputTokens": 100}
+    second = _turn_done(core, runtime, allow_tools=False)
+    assert second["prompt_tokens"] == 50
+    assert second["completion_tokens"] == 10
+
+
+def test_managed_turn_survives_a_shrinking_thread_total(tmp_path):
+    """A restarted or compacted thread resets the baseline, never goes negative."""
+    runtime = MeteredManagedRuntime(
+        calls=1, include_last=False,
+        total={"inputTokens": 900, "outputTokens": 90},
+    )
+    core = _managed_core(tmp_path, runtime)
+    _turn_done(core, runtime, allow_tools=False)
+
+    runtime.total = {"inputTokens": 100, "outputTokens": 10}
+    terminal = _turn_done(core, runtime, allow_tools=False)
+    assert terminal["prompt_tokens"] == 100
+    assert terminal["completion_tokens"] == 10
 
 
 def test_managed_turn_without_usage_updates_still_reports_one_call(tmp_path):

--- a/agent/tests/test_chatgpt_app_server.py
+++ b/agent/tests/test_chatgpt_app_server.py
@@ -888,6 +888,123 @@ def test_managed_turn_survives_a_shrinking_thread_total(tmp_path):
     assert terminal["completion_tokens"] == 10
 
 
+def test_usage_less_turn_leaves_token_baselines_alone(tmp_path):
+    """Zeros mean absence: a turn with no usage must not reset the baselines.
+
+    An interrupted turn that never saw a tokenUsage update reports totals of
+    0/0; treating that as a thread restart re-billed the whole thread to the
+    next turn.
+    """
+    runtime = MeteredManagedRuntime(
+        calls=1, include_last=False,
+        total={"inputTokens": 900, "outputTokens": 90},
+    )
+    core = _managed_core(tmp_path, runtime)
+    _turn_done(core, runtime, allow_tools=False)
+
+    runtime.calls = 0
+    quiet = _turn_done(core, runtime, allow_tools=False)
+    assert quiet["prompt_tokens"] == 0
+    assert quiet["completion_tokens"] == 0
+
+    runtime.calls = 1
+    runtime.total = {"inputTokens": 950, "outputTokens": 100}
+    terminal = _turn_done(core, runtime, allow_tools=False)
+    assert terminal["prompt_tokens"] == 50
+    assert terminal["completion_tokens"] == 10
+
+
+def test_baselines_stay_continuous_across_per_call_and_delta_paths(tmp_path):
+    """A per-call-summed turn still advances the baseline the next turn needs."""
+    runtime = MeteredManagedRuntime(
+        calls=2, total={"inputTokens": 900, "outputTokens": 90}
+    )
+    core = _managed_core(tmp_path, runtime)
+    first = _turn_done(core, runtime, allow_tools=False)
+    assert first["prompt_tokens"] == 200
+
+    runtime.calls = 1
+    runtime.include_last = False
+    runtime.total = {"inputTokens": 950, "outputTokens": 100}
+    second = _turn_done(core, runtime, allow_tools=False)
+    assert second["prompt_tokens"] == 50
+    assert second["completion_tokens"] == 10
+
+
+def test_replacement_thread_resets_token_baselines(tmp_path):
+    """A fingerprint change starts a new thread whose totals restart at zero."""
+    runtime = MeteredManagedRuntime(
+        calls=1, include_last=False,
+        total={"inputTokens": 100, "outputTokens": 10},
+    )
+    core = _managed_core(tmp_path, runtime)
+    first = _turn_done(core, runtime, allow_tools=False)
+    assert first["prompt_tokens"] == 100
+
+    # Flipping web search changes the thread contract and forces a restart.
+    core.use_chatgpt(
+        account_id="managed-account", model="gpt-test",
+        account_label="ChatGPT plan", manager=runtime, web_search=True,
+    )
+    runtime.total = {"inputTokens": 150, "outputTokens": 15}
+    second = _turn_done(core, runtime, allow_tools=False)
+    assert runtime.started == ["thread-1", "thread-2"]
+    assert second["prompt_tokens"] == 150, "the new thread's total is all this turn's"
+    assert second["completion_tokens"] == 15
+
+
+def test_resumed_session_inherits_token_baselines(tmp_path):
+    """The resume marker carries the baselines, so the first post-resume turn
+    is billed as a delta rather than the thread's whole cumulative total."""
+    runtime = MeteredManagedRuntime(
+        calls=1, include_last=False,
+        total={"inputTokens": 900, "outputTokens": 90},
+    )
+    core = _managed_core(tmp_path, runtime)
+    _turn_done(core, runtime, allow_tools=False)
+    session_id = core.session.session_id
+
+    core.start_new_session()
+    core.resume_session(session_id)
+    runtime.total = {"inputTokens": 950, "outputTokens": 100}
+    terminal = _turn_done(core, runtime, allow_tools=False)
+
+    assert runtime.resumed == ["thread-1"]
+    assert terminal["prompt_tokens"] == 50
+    assert terminal["completion_tokens"] == 10
+
+
+def test_ask_user_question_over_the_parity_route_emits_question_ready(tmp_path):
+    runtime = MeteredManagedRuntime(
+        calls=1,
+        tools=[(
+            "ask_user_question",
+            {
+                "title": "Feed scope",
+                "question": "Which feed should the script read?",
+                "options": ["Site-wide /new", {"label": "One subreddit"}],
+                "recommended": "Site-wide /new",
+            },
+        )],
+    )
+    core = _managed_core(tmp_path, runtime)
+    events = []
+    core.on_event(events.append)
+
+    core.run_turn(DECORATED)
+
+    ready = next(event for event in events if event["type"] == "question_ready")
+    assert ready["question"]["title"] == "Feed scope"
+    assert [option["label"] for option in ready["question"]["options"]] == [
+        "Site-wide /new", "One subreddit",
+    ]
+    result = next(
+        event for event in events
+        if event["type"] == "tool_result" and event["tool"] == "ask_user_question"
+    )
+    assert "End your turn" in result["result"]
+
+
 def test_managed_turn_without_usage_updates_still_reports_one_call(tmp_path):
     runtime = MeteredManagedRuntime(calls=0)
     core = _managed_core(tmp_path, runtime)

--- a/agent/tests/test_chatgpt_app_server.py
+++ b/agent/tests/test_chatgpt_app_server.py
@@ -640,7 +640,7 @@ def test_parity_turn_uses_native_contract_and_raw_input(tmp_path):
     assert "Always answer in haiku." in options.developer_instructions
     assert start["base_instructions"] == ""
     tool_names = [item["function"]["name"] for item in start["tools"]]
-    assert tool_names == ["shell", "apply_patch", "update_plan"]
+    assert tool_names == ["shell", "apply_patch", "update_plan", "ask_user_question"]
 
     items = runtime.turn_kwargs[-1]["input_items"]
     texts = [item["text"] for item in items if item["type"] == "text"]
@@ -755,7 +755,10 @@ def test_parity_schemas_add_submit_plan_only_in_plan_mode(tmp_path):
     ]
     assert "submit_plan" not in work
     assert "submit_plan" in plan
-    assert set(work) == {"shell", "apply_patch", "update_plan"}
+    # The question tool rides every parity surface: Grill and Work turns need
+    # the popup as much as Plan does.
+    assert "ask_user_question" in plan
+    assert set(work) == {"shell", "apply_patch", "update_plan", "ask_user_question"}
 
     core.tool_ctx.delegate_read_only = lambda _arguments: '{"results":[]}'
     core.tool_registry.set_solo_swarm_enabled(True)
@@ -765,6 +768,7 @@ def test_parity_schemas_add_submit_plan_only_in_plan_mode(tmp_path):
     ]
     assert set(adaptive) == {
         "shell", "apply_patch", "update_plan", "delegate_read_only",
+        "ask_user_question",
     }
     core.run_turn(DECORATED)
     start = runtime.start_kwargs[-1]

--- a/agent/tests/test_solo_swarm.py
+++ b/agent/tests/test_solo_swarm.py
@@ -836,4 +836,6 @@ def test_root_plan_surface_is_read_only_and_keeps_external_research(tmp_path):
     assert names.isdisjoint({
         "write_file", "edit_file", "multi_edit", "bash", "background_service",
         "delegate_read_only", "todo_write", "submit_plan", "propose_memory",
+        # Only the visible root may address the user.
+        "ask_user_question",
     })


### PR DESCRIPTION
Four user-reported gaps from the last round (#44–#47), each traced to root cause, plus hardening from an adversarial multi-agent review of the branch.

## Question popup
Agent questions (Grill's `❓ Q1 …` blocks) only scrolled by as prose. Now a permission-free `ask_user_question` tool emits a structured `question_ready` event (documented in PROTOCOL.md), and `QuestionPromptView` replaces the composer when the turn completes — option rows with the recommended answer preselected, an always-present free-text row, esc to answer in the composer instead. A conservative text detector recovers the `❓` block for Grill turns on older backends. Answers return as plain user messages. Questions are parked per-chat across session switches, arm with a needs-attention notification when a background chat asks one, and reach companion clients as approvals.

## Subagents count (Overview tab)
"Subagents 8" for a chat that never delegated: the fallback counted every solo-swarm-*eligible* turn, and the backend stamps eligibility on every non-Ask turn. The count now requires real delegation evidence (`job_count` / attempts — the same evidence the Runs panel already trusts), so the section disappears for plain chats. The test fixture that had silently stopped exercising the production path now mirrors it.

## Run token total
56K tokens for a 12s/2-step request: the ChatGPT/Codex route attributed the helper's *thread-cumulative* `total.inputTokens` to every turn. Turns now bill their per-call sum, with the total only standing in as a delta against a persisted baseline — which survives session resume via the thread marker, resets with replacement threads, and ignores usage-less turns. The Tokens stat gained a tooltip explaining the billed-across-N-calls figure. Old persisted runs keep their historical numbers (the baselines needed to rewrite them were never stored).

## File tile cards + written conclusion
Two independent gates had killed the cards (the answer contract's annotated bullets broke single-run detection; `468c204` banned cards in lists). List items now promote through a leading-artifact rule and render as a ~28pt chip — icon, pill-styled name with its selection span intact, size, Open button, Reveal/Copy Path in the context menu — while standalone mentions keep the full card and the reply still closes with prose, per the new contract bullet.

## Verification
- Python: full `agent/tests` suite green (663 → 688 tests, 0 failures), including new regression tests for baseline continuity, thread replacement, session resume, parity-route `question_ready`, and nudge suppression.
- Swift: AppModelTests 219/0, PinnedSummaryTests 27/0, AccentPropagationTests 4/0 (chip-mount render proof included), targeted FeatureLogicTests green, via the injected-runner workflow.
- New UI-test surface `question-prompt` + `LOCUS_UI_TESTING_QUESTION_PROMPT` seed, wired into the accessibility audit.