### PR TITLE
test(transcript): route raw coordinate clicks through clickInTranscript

### DIFF
--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -702,9 +702,7 @@ final class LocusUITests: XCTestCase {
         }, "collapsed code must still copy all 25 source lines")
         XCTAssertEqual(transcript.frame.width, initialWidth, accuracy: 1)
 
-        showCode.coordinate(
-            withNormalizedOffset: CGVector(dx: 0.12, dy: 0.5)
-        ).click()
+        clickInTranscript(showCode, normalizedOffset: CGVector(dx: 0.12, dy: 0.5))
         XCTAssertTrue(waitUntil {
             self.anyElement("message.codeBlock.collapse").label
                 == "Collapse 25-line code block"
@@ -3175,9 +3173,7 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(anyElement("message.00000000-0000-0000-0000-000000000202").exists)
         XCTAssertTrue(anyElement("message.00000000-0000-0000-0000-000000000204").exists)
 
-        firstGroup.coordinate(
-            withNormalizedOffset: CGVector(dx: 0.15, dy: 0.5)
-        ).click()
+        clickInTranscript(firstGroup, normalizedOffset: CGVector(dx: 0.15, dy: 0.5))
         XCTAssertTrue(anyElement(
             "thinkingActivity.entry.00000000-0000-0000-0000-000000000201.0"
         ).waitForExistence(timeout: 3))


### PR DESCRIPTION
## What this changes

`testLongCodeAndTableStartExpandedThenCollapseWithoutChangingFullCopy` intermittently failed on CI at its final assertion: the re-expand of the code block clicked the "Show all 25 lines" control with a raw `coordinate(...).click()`, which misses when the runner's smaller display leaves the control below the fold (it failed twice in a row on the v2.1.0 tag run and passed on rerun). The table half of the same test already routes the identical interaction through `clickInTranscript`, which waits for existence and scrolls the control into the visible part of the transcript before the coordinate click — the code half now uses the same helper with the same 0.12 label-side offset.

A sweep over the file's other raw coordinate clicks found one more with the same hazard: the first thinking group in `testCollapsedThinkingGroupsReasoningWithoutEmptyAssistantRows` is a transcript row clicked at default window size with no visibility guard, and it now goes through the helper too. The remaining raw coordinate clicks are deliberate and safe: three are guarded by `scrollTranscriptDown`/`isVisiblyInside` loops, two target always-visible overlay buttons (`activity.remove`, `jumpToLatest`), one is an account-editor sheet field, and the appearance-audit click runs under explicitly pinned window sizes.

## How you verified it

Deleted the stale `Locus.app` from DerivedData, then ran the affected test in isolation:

`LOCUS_CODEX_CACHE=… xcodebuild test -only-testing:LocusUITests/LocusUITests/testLongCodeAndTableStartExpandedThenCollapseWithoutChangingFullCopy CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=`

Passed in 39s (`** TEST SUCCEEDED **`). Two earlier runs of the same command failed before launch with the known machine-local LaunchServices error caused by the installed Locus app being open; they never reached the test body. No unit-suite run: the change touches only `LocusUITests.swift`.

## Checklist

- [x] Commits are signed off (`git commit -s`) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] Swift and Python suites pass (only the affected UI test was run in isolation; the change is confined to `LocusUITests.swift`)
- [x] New state/routes follow [the ownership boundaries](../Docs/Architecture.md), or the PR explains why the boundary should change (no app code touched)
- [x] The advisory `Tools/ReviewabilityReport.py` signals were reviewed; large files or diffs are intentional and independently understandable (net −4 lines in one test file)
- [x] New feature state/actions were kept out of `AppModel`, and new API handlers were kept out of `server.py`
- [x] `xcodegen generate` run if `project.yml` or the file layout changed (no layout change)
- [x] No credential, key, token, or absolute local path added — including in a test fixture or a comment
- [x] A new Python dependency is pinned in `agent/requirements-runtime.lock` and listed in `Locus/Resources/ThirdPartyNotices.md` (no new dependency)
- [x] User-visible changes have a `CHANGELOG.md` entry (test-only change)
- [x] Docs and UI strings still describe what the code now does