### PR TITLE
Workspace links in text color; prompt option focus rings no longer overlap

### DIFF
--- a/Locus/MarkdownRenderer.swift
+++ b/Locus/MarkdownRenderer.swift
@@ -454,14 +454,16 @@ struct MarkdownInlineStyleSpec {
             spec.pillFill = LocusTheme.inlineCodeFill
         }
 
-        // A workspace file mentioned as inline code keeps the code pill's ink
-        // even though it navigates like a link; the blue-underline treatment
-        // is reserved for authored links and remote URLs.
-        if let link,
-           !(run.style.contains(.code) && run.destination == nil
-             && link.scheme == "locus-workspace") {
-            spec.foreground = LocusTheme.signalDeep
-            spec.isUnderlined = true
+        // A workspace file reference navigates like a link but reads like the
+        // text around it: a code run keeps its pill and ink, a plain run keeps
+        // only an underline. The accent treatment is reserved for remote URLs.
+        if let link {
+            if link.scheme != "locus-workspace" {
+                spec.foreground = LocusTheme.signalDeep
+                spec.isUnderlined = true
+            } else if !run.style.contains(.code) {
+                spec.isUnderlined = true
+            }
         }
 
         return spec

--- a/Locus/Theme.swift
+++ b/Locus/Theme.swift
@@ -729,6 +729,7 @@ private struct LocusButtonStyleBody: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorSchemeContrast) private var contrast
     @Environment(\.isFocused) private var isFocused
+    @Environment(\.isFocusEffectEnabled) private var focusEffectEnabled
     @Environment(\.isEnabled) private var isEnabled
     @State private var hovering = false
 
@@ -751,7 +752,12 @@ private struct LocusButtonStyleBody: View {
             .overlay {
                 RoundedRectangle(cornerRadius: kind == .icon ? 7 : 9, style: .continuous)
                     .stroke(
-                        isFocused ? LocusTheme.focusRing : Color.clear,
+                        // `isFocused` reports the nearest focusable ancestor,
+                        // so inside a focused prompt panel every button would
+                        // ring at once — those panels disable the focus
+                        // effect, and the ring has to honor that.
+                        isFocused && focusEffectEnabled
+                            ? LocusTheme.focusRing : Color.clear,
                         lineWidth: contrast == .increased ? 3 : 2
                     )
                     .padding(-2)

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -1246,39 +1246,39 @@ final class FeatureLogicTests: XCTestCase {
         XCTAssertEqual(spec.foreground, LocusTheme.ink)
     }
 
-    /// A file mentioned as inline code navigates like a link but reads like a
-    /// code pill: the blue-underline treatment stays reserved for authored
-    /// links and remote URLs.
-    func testWorkspaceFileCodeRunsKeepThePillInsteadOfLinkBlue() {
-        let classified = MarkdownInlineStyleSpec.resolve(
-            run: MarkdownInlineRun(text: "AppModel.swift:12", style: [.code]),
-            baseSize: 13,
-            baseWeight: .regular,
-            baseColor: LocusTheme.inkSoft,
-            inlineCodeSize: 12,
-            link: URL(string: "locus-workspace://open/AppModel.swift?line=12")
-        )
-        XCTAssertEqual(classified.foreground, LocusTheme.ink)
-        XCTAssertFalse(classified.isUnderlined)
-        XCTAssertEqual(classified.pillFill, LocusTheme.inlineCodeFill)
+    /// A workspace file reference navigates like a link but reads like the
+    /// text around it — code runs keep the pill and ink, authored or not, and
+    /// plain runs keep only an underline. The accent-blue treatment stays
+    /// reserved for remote URLs.
+    func testWorkspaceFileLinksKeepTheSurroundingTextColor() {
+        for destination in [nil, "AppModel.swift"] {
+            let codeRun = MarkdownInlineStyleSpec.resolve(
+                run: MarkdownInlineRun(
+                    text: "AppModel.swift:12",
+                    style: [.code],
+                    destination: destination
+                ),
+                baseSize: 13,
+                baseWeight: .regular,
+                baseColor: LocusTheme.inkSoft,
+                inlineCodeSize: 12,
+                link: URL(string: "locus-workspace://open/AppModel.swift?line=12")
+            )
+            XCTAssertEqual(codeRun.foreground, LocusTheme.ink)
+            XCTAssertFalse(codeRun.isUnderlined)
+            XCTAssertEqual(codeRun.pillFill, LocusTheme.inlineCodeFill)
+        }
 
-        let authored = MarkdownInlineStyleSpec.resolve(
-            run: MarkdownInlineRun(
-                text: "the model",
-                style: [.code],
-                destination: "AppModel.swift"
-            ),
+        let plain = MarkdownInlineStyleSpec.resolve(
+            run: MarkdownInlineRun(text: "the app model", destination: "AppModel.swift"),
             baseSize: 13,
             baseWeight: .regular,
             baseColor: LocusTheme.inkSoft,
             inlineCodeSize: 12,
             link: URL(string: "locus-workspace://open/AppModel.swift")
         )
-        // `signalDeep` mints a fresh accent-dynamic Color per access, so the
-        // link treatment is asserted structurally: underlined, and no longer
-        // the code pill's ink.
-        XCTAssertNotEqual(authored.foreground, LocusTheme.ink)
-        XCTAssertTrue(authored.isUnderlined)
+        XCTAssertEqual(plain.foreground, LocusTheme.inkSoft)
+        XCTAssertTrue(plain.isUnderlined)
 
         let remote = MarkdownInlineStyleSpec.resolve(
             run: MarkdownInlineRun(text: "docs", destination: "https://example.com"),
@@ -1288,6 +1288,9 @@ final class FeatureLogicTests: XCTestCase {
             inlineCodeSize: 12,
             link: URL(string: "https://example.com")
         )
+        // `signalDeep` mints a fresh accent-dynamic Color per access, so the
+        // link treatment is asserted structurally: underlined, and no longer
+        // the base color.
         XCTAssertNotEqual(remote.foreground, LocusTheme.inkSoft)
         XCTAssertTrue(remote.isUnderlined)
     }


### PR DESCRIPTION
## What changed

**Workspace file links read like the surrounding text.** PR #57 stopped *classified* inline-code file references from turning accent-blue, but references authored as markdown links (`[`file`](path)`) kept the blue-underline treatment — which is what the transcript's file chips render. Now every `locus-workspace://` link keeps the surrounding text's color: code runs keep their pill and ink with no underline, plain-text runs keep just an underline for affordance. Accent blue stays reserved for remote URLs.

**Question/plan prompt options no longer draw overlapping blue boxes.** `LocusButtonStyle` drew its focus ring from `\.isFocused`, which reports the nearest *focusable ancestor* — and the question, plan-approval, and permission prompts focus their own panel for keyboard driving. Every option button inside therefore ringed at once, and the ring's −2pt outset over 1pt row spacing made adjacent rings overlap. The ring now also honors `isFocusEffectEnabled`, which those panels already disable via `.focusEffectDisabled()`. Individually tab-focused buttons elsewhere keep their ring, including the increased-contrast width.

## Verification

- `testWorkspaceFileLinksKeepTheSurroundingTextColor` (reworked) covers classified and authored code runs (ink pill, no underline), plain-text workspace links (base color, underlined), and remote links (accent + underline).
- Rendered `QuestionPromptView` in a hosted window with the panel focused: no rings on option rows; the row-selection highlight and ❯ marker are unchanged.
- AppModel (219), TranscriptFollow, TranscriptSelection, and the markdown styling tests all pass locally via the injected-host runner; project file untouched (no new files, xcodegen-verified).