### PR TITLE
Accept keyless local endpoints, stop guessing https for LAN addresses

### DIFF
--- a/Locus/AccountEditorView.swift
+++ b/Locus/AccountEditorView.swift
@@ -38,19 +38,39 @@ struct AccountEditorView: View {
 
     private var kind: ProviderKind { account.kind }
 
-    private var canSave: Bool {
-        if kind == .chatGPT { return true }
-        // A key is required to reach a provider; an endpoint that has one
-        // saved already does not need it typed again.
-        let hasKey = keyStored || !apiKey.trimmingCharacters(in: .whitespaces).isEmpty
-        let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        let effectiveKey = key.isEmpty && keyStored ? "saved-key" : key
-        return hasKey
-            && !resolvedBaseURL.isEmpty
-            && RemoteEndpointTester.securityError(
-                baseURL: resolvedBaseURL,
-                apiKey: effectiveKey
-            ) == nil
+    private var canSave: Bool { saveBlocker == nil }
+
+    /// Why Save is refused right now, or nil when it isn't. Rendered beside
+    /// the button: a control that goes dead without saying why is how "Locus
+    /// wouldn't accept my server" reports happen.
+    private var saveBlocker: String? {
+        Self.blocker(
+            kind: kind,
+            resolvedBaseURL: resolvedBaseURL,
+            keyStored: keyStored,
+            typedKey: apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    static func blocker(
+        kind: ProviderKind,
+        resolvedBaseURL: String,
+        keyStored: Bool,
+        typedKey: String
+    ) -> String? {
+        if kind == .chatGPT { return nil }
+        if resolvedBaseURL.isEmpty { return "Enter the endpoint URL." }
+        // A key is required to reach a hosted provider — an endpoint that has
+        // one saved already does not need it typed again — but a custom
+        // endpoint may genuinely have none, like a local llama.cpp server.
+        if !keyStored, typedKey.isEmpty, !kind.allowsEmptyAPIKey {
+            return "Add the \(kind.marketingName) key to save this account."
+        }
+        let effectiveKey = typedKey.isEmpty && keyStored ? "saved-key" : typedKey
+        return RemoteEndpointTester.securityError(
+            baseURL: resolvedBaseURL,
+            apiKey: effectiveKey
+        )
     }
 
     private var resolvedBaseURL: String {
@@ -188,7 +208,14 @@ struct AccountEditorView: View {
             }
             .formStyle(.grouped)
 
-            HStack {
+            HStack(spacing: 12) {
+                if let saveBlocker {
+                    Text(saveBlocker)
+                        .font(.locus(size: 9))
+                        .foregroundStyle(LocusTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("accountEditor.saveBlocker")
+                }
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .accessibilityIdentifier("accountEditor.cancel")
@@ -474,16 +501,12 @@ struct AccountEditorView: View {
             }
             return
         }
-        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        let effectiveKey = trimmedKey.isEmpty && keyStored ? "saved-key" : trimmedKey
-        if let error = RemoteEndpointTester.securityError(
-            baseURL: resolvedBaseURL,
-            apiKey: effectiveKey
-        ) {
-            testResult = error
+        if let saveBlocker {
+            testResult = saveBlocker
             testFailed = true
             return
         }
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         var updated = account
         updated.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
         updated.baseURLOverride = kind.allowsBaseURLOverride

--- a/Locus/AgentTeamsModel.swift
+++ b/Locus/AgentTeamsModel.swift
@@ -176,7 +176,7 @@ final class AgentTeamsModel: ObservableObject {
                 }
             case .providerAccount(let accountID):
                 guard let account = accounts.first(where: { $0.id == accountID }),
-                      account.hasKey
+                      account.isCredentialReady
                 else {
                     return .unavailableProvider(choice.providerName)
                 }

--- a/Locus/AppModel+Commands.swift
+++ b/Locus/AppModel+Commands.swift
@@ -219,7 +219,7 @@ extension AppModel {
             }
             return
         }
-        if let account, !account.hasKey {
+        if let account, !account.isCredentialReady {
             showToast("Add an API key for \(account.displayName) in Settings")
             settingsPresented = true
             return

--- a/Locus/AppModel+ModelRouter.swift
+++ b/Locus/AppModel+ModelRouter.swift
@@ -173,7 +173,7 @@ extension AppModel {
             )
         }
         guard settings.automaticModelRoutingAllowHosted else { return routes }
-        for account in providerAccounts where account.hasKey {
+        for account in providerAccounts where account.isCredentialReady {
             guard accountStatus[account.id]?.isHealthy == true else { continue }
             let model = account.preferredModel.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !model.isEmpty else { continue }

--- a/Locus/AppModel+TeamOps.swift
+++ b/Locus/AppModel+TeamOps.swift
@@ -104,7 +104,7 @@ extension AppModel {
                 ]
             case .providerAccount(let accountID):
                 guard let account = providerAccounts.first(where: { $0.id == accountID }),
-                      account.hasKey
+                      account.isCredentialReady
                 else { return nil }
                 if account.kind == .chatGPT {
                     route = [

--- a/Locus/ComposerView.swift
+++ b/Locus/ComposerView.swift
@@ -1394,7 +1394,7 @@ private struct ComposerTeamPickerPopover: View {
             guard let account = model.providerAccounts.first(where: { $0.id == accountID }) else {
                 return "A hosted provider used by this team is unavailable."
             }
-            if !account.hasKey {
+            if !account.isCredentialReady {
                 return "Reconnect \(account.displayName) before using this team."
             }
         }

--- a/Locus/ProviderAccounts.swift
+++ b/Locus/ProviderAccounts.swift
@@ -82,7 +82,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
         // Moonshot documents no prefix for these; guessing one would contradict
         // what the user is about to paste.
         case .kimiCode: "Kimi Code Console key"
-        case .custom: "API key"
+        case .custom: "API key (optional)"
         }
     }
 
@@ -97,6 +97,13 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     }
 
     var requiresAPIKey: Bool { self != .chatGPT }
+
+    /// Whether the account works with no key at all. Local OpenAI-compatible
+    /// servers (llama.cpp, LM Studio, vLLM, Ollama) usually run without
+    /// authentication; demanding a key forced people to invent one, which the
+    /// HTTPS rule then rejected on plain-HTTP LAN endpoints — leaving no way
+    /// to add the server at all.
+    var allowsEmptyAPIKey: Bool { self == .custom }
 
     var usesManagedChatGPTAuthentication: Bool { self == .chatGPT }
 
@@ -468,6 +475,13 @@ struct ProviderAccount: Identifiable, Codable, Hashable {
         kind.usesManagedChatGPTAuthentication
             || CredentialStore.has(account: credentialAccount)
     }
+
+    /// Whether the account has the credential it needs to take traffic:
+    /// managed ChatGPT auth, a stored key, or a kind that works without one.
+    /// Gates that decide "can this account be used" belong on this, not on
+    /// `hasKey` — that stays the literal fact that a credential is stored,
+    /// which display code (Key saved / No API key) still wants.
+    var isCredentialReady: Bool { hasKey || kind.allowsEmptyAPIKey }
 
     /// The window to budget this account against: what the user set, else
     /// the provider's published figure for the selected model, else none.

--- a/Locus/ProviderModelCatalog.swift
+++ b/Locus/ProviderModelCatalog.swift
@@ -21,7 +21,10 @@ enum ProviderModelCatalog {
 
     static func fetch(for account: ProviderAccount) async -> Result {
         let key = CredentialStore.get(account: account.credentialAccount) ?? ""
-        guard !key.isEmpty else {
+        // A custom endpoint may genuinely have no key — a local llama.cpp or
+        // LM Studio server, say — so probe it unauthenticated rather than
+        // giving up before the request.
+        guard !key.isEmpty || account.kind.allowsEmptyAPIKey else {
             return Result(models: account.kind.curatedModels, status: .noKey)
         }
         // Kimi Code serves chat completions and nothing else. Asking it for a
@@ -55,7 +58,13 @@ enum ProviderModelCatalog {
             let (data, response) = try await session.current.data(for: request)
             let status = (response as? HTTPURLResponse)?.statusCode ?? -1
             if status == 401 || status == 403 {
-                return Result(models: account.kind.curatedModels, status: .keyRejected)
+                // "Rejected the key" would be a riddle when none was sent.
+                return Result(
+                    models: account.kind.curatedModels,
+                    status: key.isEmpty
+                        ? .failed("The endpoint requires an API key.")
+                        : .keyRejected
+                )
             }
             guard (200..<300).contains(status) else {
                 // A single-model endpoint answering 404 here is normal, and its

--- a/Locus/RemoteEndpointTester.swift
+++ b/Locus/RemoteEndpointTester.swift
@@ -64,7 +64,7 @@ enum RemoteEndpointTester {
         var base = url.trimmingCharacters(in: .whitespacesAndNewlines)
         while base.hasSuffix("/") { base.removeLast() }
         guard !base.isEmpty else { return "" }
-        if !base.contains("://") { base = "https://" + base }
+        if !base.contains("://") { base = defaultScheme(for: base) + "://" + base }
         for suffix in ["/chat/completions", "/completions", "/messages"]
         where base.hasSuffix(suffix) {
             base.removeLast(suffix.count)
@@ -73,6 +73,69 @@ enum RemoteEndpointTester {
         while base.hasSuffix("/") { base.removeLast() }
         if !base.hasSuffix("/v1") { base += "/v1" }
         return base
+    }
+
+    /// The scheme to assume when someone types a bare `host:port`.
+    ///
+    /// `https` is the only safe guess for a name on the public internet, but
+    /// for localhost, mDNS names, and private-network IP literals it is almost
+    /// always wrong: local OpenAI-compatible servers (llama.cpp, LM Studio,
+    /// vLLM, Ollama) speak plain HTTP, and TLS certificates are rarely issued
+    /// for bare IPs. Guessing `https` there turns `ip:port/v1` into an opaque
+    /// SSL failure that never says the URL was rewritten. Public addresses
+    /// keep the `https` default: only hosts that cannot be on the public
+    /// internet earn the `http` guess. Mirrors the backend's
+    /// `_default_scheme` — the saved endpoint travels to the agent as typed,
+    /// so the two guesses must never disagree.
+    private static func defaultScheme(for schemelessInput: String) -> String {
+        // The two parsers only agree on a plain-ASCII, percent-free
+        // authority. `URL.host` percent-decodes and applies IDNA/UTS-46
+        // mapping — so "192%2E168%2E1%2E50" and a CJK IME's full-width
+        // "192。168。1。50" both become a dotted quad here while Python's
+        // urlsplit leaves them alone. Refuse to guess rather than let the
+        // app and the agent build different URLs from the same string.
+        //
+        // Taken by scalar, not by Character: `"/" + U+0301` is a single
+        // grapheme cluster, so a Character-wise scan would run past the slash
+        // and test a different string than Python's `split("/", 1)`.
+        let authority = schemelessInput.unicodeScalars.prefix { $0 != "/" }
+        guard authority.allSatisfy({ $0.isASCII }),
+              !authority.contains("%"),
+              let host = URL(string: "http://" + schemelessInput)?.host?.lowercased(),
+              !host.isEmpty
+        else { return "https" }
+        if host == "localhost" || host.hasSuffix(".localhost") || host.hasSuffix(".local") {
+            return "http"
+        }
+        // A colon can only reach a percent-free host inside a bracketed IPv6
+        // literal, and a local server is the only plausible reason to type one.
+        if host.contains(":") { return "http" }
+        guard let octets = strictIPv4Octets(host) else { return "https" }
+        let isPrivate = octets[0] == 10
+            || octets[0] == 127
+            || (octets[0] == 169 && octets[1] == 254)
+            || (octets[0] == 172 && (16...31).contains(octets[1]))
+            || (octets[0] == 192 && octets[1] == 168)
+        return isPrivate ? "http" : "https"
+    }
+
+    /// The octets of a canonical dotted-quad IPv4 literal, or nil. Strict on
+    /// purpose, to match Python's `ipaddress` (CVE-2021-29921 hardening): four
+    /// parts, ASCII digits only, no signs, no leading zeros — so
+    /// "192.168.001.050" is a hostname here on both sides, never an address.
+    private static func strictIPv4Octets(_ host: String) -> [UInt8]? {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return nil }
+        var octets: [UInt8] = []
+        for part in parts {
+            guard !part.isEmpty,
+                  part.allSatisfy({ ("0"..."9").contains($0) }),
+                  part == "0" || !part.hasPrefix("0"),
+                  let value = UInt8(part)
+            else { return nil }
+            octets.append(value)
+        }
+        return octets
     }
 
     static func securityError(baseURL: String, apiKey: String) -> String? {
@@ -217,7 +280,10 @@ enum RemoteEndpointTester {
             body = body.replacingOccurrences(of: apiKey, with: "[redacted]")
         }
         let hint = switch status {
-        case 401, 403: "The endpoint rejected the API key"
+        // "Rejected the key" would be a riddle when none was sent.
+        case 401, 403: apiKey.isEmpty
+            ? "The endpoint requires an API key"
+            : "The endpoint rejected the API key"
         case 400: "The endpoint rejected the request (400)"
         case 404: "Nothing answered at that path"
         case 429: "The endpoint is rate-limiting requests (429)"

--- a/Locus/Sheets.swift
+++ b/Locus/Sheets.swift
@@ -2818,7 +2818,7 @@ struct SettingsView: View {
                         .overlay(alignment: .bottomTrailing) {
                             Circle()
                                 .fill(
-                                    model.providerAccountsModel.accountStatus[account.id]?.isHealthy ?? account.hasKey
+                                    model.providerAccountsModel.accountStatus[account.id]?.isHealthy ?? account.isCredentialReady
                                         ? LocusTheme.success
                                         : LocusTheme.coral
                                 )

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -3471,6 +3471,129 @@ final class AppModelTests: XCTestCase {
         XCTAssertEqual(RemoteEndpointTester.normalizeBaseURL("   "), "")
     }
 
+    func testSchemelessLocalEndpointsDefaultToHTTP() {
+        // A local llama server pasted as "ip:port/v1" speaks plain HTTP;
+        // guessing https there produced an SSL error that read as "Locus
+        // wouldn't accept my server". This table is mirrored verbatim in the
+        // agent's test_schemeless_local_endpoints_default_to_http — the saved
+        // endpoint travels as typed, so the two guesses must never disagree.
+        let expectations: [(String, String)] = [
+            // Private-network hosts get http.
+            ("192.168.1.50:9931/v1", "http://192.168.1.50:9931/v1"),
+            ("10.0.0.7:8000", "http://10.0.0.7:8000/v1"),
+            ("172.16.4.2:8000", "http://172.16.4.2:8000/v1"),
+            ("127.0.0.1:11434", "http://127.0.0.1:11434/v1"),
+            ("localhost:9931", "http://localhost:9931/v1"),
+            ("studio.local:1234", "http://studio.local:1234/v1"),
+            ("[::1]:9931", "http://[::1]:9931/v1"),
+            // A typed scheme is never rewritten.
+            ("https://192.168.1.50:9931", "https://192.168.1.50:9931/v1"),
+            // Public addresses and hostnames keep the safe https default.
+            ("34.120.10.5:8000", "https://34.120.10.5:8000/v1"),
+            ("172.32.0.1:8000", "https://172.32.0.1:8000/v1"),
+            ("myserver:9931", "https://myserver:9931/v1"),
+            // Not-quite-IPs are hostnames, exactly as Python's ipaddress
+            // reads them: out-of-range, zero-padded, or percent-encoded
+            // octets must not flip the guess on one side only.
+            ("256.168.1.50:9931", "https://256.168.1.50:9931/v1"),
+            ("192.168.001.050:9931", "https://192.168.001.050:9931/v1"),
+            ("192%2E168%2E1%2E50:9931", "https://192%2E168%2E1%2E50:9931/v1"),
+            // URL.host applies IDNA/UTS-46 mapping and Python's urlsplit does
+            // not, so a non-ASCII authority — what a CJK IME emits in
+            // full-width mode — is never guessed at on either side.
+            ("192。168。1。50:9931", "https://192。168。1。50:9931/v1"),
+            ("１９２.168.1.50:9931", "https://１９２.168.1.50:9931/v1"),
+            ("studio。local:1234", "https://studio。local:1234/v1"),
+            ("café.local:8080", "https://café.local:8080/v1"),
+            // Only the authority has to be ASCII. A combining mark right
+            // after the first slash is one grapheme cluster with it, so a
+            // Character-wise scan would read the whole path as the authority
+            // and refuse a guess Python still makes.
+            ("192.168.1.50:9931/\u{0301}abc", "http://192.168.1.50:9931/\u{0301}abc/v1"),
+            ("192.168.1.50:9931/café", "http://192.168.1.50:9931/café/v1"),
+        ]
+        for (given, expected) in expectations {
+            XCTAssertEqual(RemoteEndpointTester.normalizeBaseURL(given), expected, given)
+        }
+    }
+
+    func testKeylessAuthFailureNamesTheMissingKey() {
+        // A keyless custom endpoint whose server wants auth must not be told
+        // its (nonexistent) key was rejected.
+        XCTAssertEqual(
+            RemoteEndpointTester.failureMessage(status: 401, data: Data(), apiKey: ""),
+            "The endpoint requires an API key."
+        )
+        XCTAssertEqual(
+            RemoteEndpointTester.failureMessage(status: 401, data: Data(), apiKey: "sk-x"),
+            "The endpoint rejected the API key."
+        )
+    }
+
+    func testAccountEditorExplainsWhySaveIsRefused() {
+        // A keyless local llama server is a legitimate custom endpoint.
+        XCTAssertNil(AccountEditorView.blocker(
+            kind: .custom,
+            resolvedBaseURL: "http://192.168.1.50:9931/v1",
+            keyStored: false,
+            typedKey: ""
+        ))
+        // Hosted providers still require their key, and say so.
+        XCTAssertEqual(
+            AccountEditorView.blocker(
+                kind: .codex,
+                resolvedBaseURL: "https://api.openai.com/v1",
+                keyStored: false,
+                typedKey: ""
+            ),
+            "Add the OpenAI API key to save this account."
+        )
+        // A key over plain HTTP may not leave the Mac — typed or stored.
+        XCTAssertEqual(
+            AccountEditorView.blocker(
+                kind: .custom,
+                resolvedBaseURL: "http://192.168.1.50:9931/v1",
+                keyStored: false,
+                typedKey: "secret"
+            ),
+            "API keys require HTTPS unless the endpoint is on this Mac."
+        )
+        XCTAssertEqual(
+            AccountEditorView.blocker(
+                kind: .custom,
+                resolvedBaseURL: "http://192.168.1.50:9931/v1",
+                keyStored: true,
+                typedKey: ""
+            ),
+            "API keys require HTTPS unless the endpoint is on this Mac."
+        )
+        // A keyless endpoint still has its URL shape checked.
+        XCTAssertEqual(
+            AccountEditorView.blocker(
+                kind: .custom,
+                resolvedBaseURL: "http://192.168.1.50:9931/v1?debug=1",
+                keyStored: false,
+                typedKey: ""
+            ),
+            "The endpoint URL cannot contain a query or fragment."
+        )
+        XCTAssertEqual(
+            AccountEditorView.blocker(
+                kind: .custom,
+                resolvedBaseURL: "",
+                keyStored: false,
+                typedKey: ""
+            ),
+            "Enter the endpoint URL."
+        )
+        XCTAssertNil(AccountEditorView.blocker(
+            kind: .chatGPT,
+            resolvedBaseURL: "",
+            keyStored: false,
+            typedKey: ""
+        ))
+    }
+
     func testProviderCredentialsRequireHTTPSExceptOnLoopback() {
         XCTAssertNotNil(
             RemoteEndpointTester.securityError(

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -3306,6 +3306,20 @@ final class FeatureLogicTests: XCTestCase {
         XCTAssertFalse(account.kind.allowsBaseURLOverride)
     }
 
+    func testCustomEndpointsWorkWithoutAStoredKey() {
+        // A local llama.cpp / LM Studio server usually has no auth at all, so
+        // the custom kind must be usable with no stored credential — while
+        // hosted providers keep demanding theirs.
+        let custom = ProviderAccount(kind: .custom, name: "Llama box")
+        XCTAssertTrue(custom.kind.allowsEmptyAPIKey)
+        XCTAssertTrue(custom.isCredentialReady)
+        XCTAssertEqual(custom.kind.keyPlaceholder, "API key (optional)")
+
+        let hosted = ProviderAccount(kind: .codex, name: "Work")
+        XCTAssertFalse(hosted.kind.allowsEmptyAPIKey)
+        XCTAssertFalse(hosted.isCredentialReady)
+    }
+
     func testAccountStoredBeforeCodexNativeParityDecodesWithTheDefaults() throws {
         // An account written before the parity fields existed carries none of
         // them; the accessors supply parity on, web search off, default effort.

--- a/agent/ollama_code/core.py
+++ b/agent/ollama_code/core.py
@@ -30,6 +30,7 @@ import json
 import os
 import platform
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -333,7 +334,39 @@ class AgentCore:
         self.client: Any = OllamaClient(self.host)
         self.model: str = model or str(self.config.get("model") or "")
         if self.provider == "remote":
-            self._build_remote_client()
+            try:
+                self._build_remote_client()
+            except ValueError as error:
+                # A keyless plain-HTTP LAN endpoint is a legitimate saved
+                # state, and load_config may have injected an API key from the
+                # environment (OPENAI_API_KEY, HF_TOKEN, …) that this endpoint
+                # cannot lawfully use. Booting without the env key honours
+                # both rules; dying here would leave no UI path back. The key
+                # only ever lives in config at boot via that injection — disk
+                # never stores it — so dropping it loses nothing the app will
+                # not re-send.
+                #
+                # Only the key may be dropped, and only when the key is what
+                # the endpoint refuses: re-validating without it separates
+                # "this URL needs no key" from "this URL is unusable", so a
+                # malformed endpoint still raises its own error rather than
+                # an irrelevant note about a credential.
+                if not str(self.config.get("remote_api_key") or ""):
+                    raise
+                try:
+                    validate_remote_url(
+                        normalize_base_url(
+                            str(self.config.get("remote_base_url") or "")
+                        )
+                    )
+                except ValueError:
+                    raise error from None
+                print(
+                    f"warning: ignoring environment API key: {error}",
+                    file=sys.stderr,
+                )
+                self.config["remote_api_key"] = ""
+                self._build_remote_client()
         elif self.provider == "chatgpt":
             self.host = "chatgpt://managed"
             self.model = model or str(self.config.get("chatgpt_model") or "")

--- a/agent/ollama_code/orchestration.py
+++ b/agent/ollama_code/orchestration.py
@@ -2833,7 +2833,15 @@ def _validate_route(route: dict[str, Any], name: str) -> None:
     if provider != "remote" or not str(route.get("base_url") or ""):
         raise OrchestrationError(f"provider route for {name} is unavailable")
     if not str(route.get("api_key") or ""):
-        raise OrchestrationError(f"provider credentials for {name} are missing")
+        # A custom endpoint may legitimately have none — a local llama.cpp or
+        # LM Studio server usually runs unauthenticated — and the app lets
+        # such an account be saved and selected, so refusing it here would
+        # fail the team run instead of the pre-flight check. Every other kind
+        # reaching this point is a hosted provider whose empty key really is a
+        # missing credential; an older app that sends no account_kind keeps
+        # the strict rule.
+        if str(route.get("account_kind") or "").lower() != "custom":
+            raise OrchestrationError(f"provider credentials for {name} are missing")
 
 
 def _openai_responses_eligible(profile: AgentProfile) -> bool:

--- a/agent/ollama_code/remote.py
+++ b/agent/ollama_code/remote.py
@@ -156,6 +156,65 @@ def resolve_auth_style(style: str, base_url: str) -> str:
     return AUTH_BEARER
 
 
+#: Address space that cannot be on the public internet: loopback, RFC1918,
+#: and link-local. Only these earn the plain-HTTP scheme guess below.
+_PRIVATE_IPV4_NETWORKS = tuple(
+    ipaddress.ip_network(block)
+    for block in (
+        "10.0.0.0/8",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+    )
+)
+
+
+def _default_scheme(schemeless_input: str) -> str:
+    """The scheme to assume when someone types a bare ``host:port``.
+
+    ``https`` is the only safe guess for a name on the public internet, but
+    for localhost, mDNS names, and private-network IP literals it is almost
+    always wrong: local OpenAI-compatible servers (llama.cpp, LM Studio,
+    vLLM, Ollama) speak plain HTTP, and TLS certificates are rarely issued
+    for bare IPs. Guessing ``https`` there turns ``ip:port/v1`` into an
+    opaque TLS failure that never says the URL was rewritten. Public
+    addresses keep the ``https`` default. Mirrors the app's
+    ``RemoteEndpointTester.defaultScheme`` — the endpoint is saved as typed,
+    so the two guesses must never disagree.
+    """
+    # The two parsers only agree on a plain-ASCII, percent-free authority.
+    # Swift's URL.host percent-decodes and applies IDNA/UTS-46 mapping — so
+    # "192%2E168%2E1%2E50" and a CJK IME's full-width "192。168。1。50" both
+    # become a dotted quad there while urlsplit leaves them alone. Refuse to
+    # guess rather than let the app and the agent build different URLs from
+    # the same string.
+    authority = schemeless_input.split("/", 1)[0]
+    if "%" in authority or not authority.isascii():
+        return "https"
+    try:
+        host = (urlsplit("http://" + schemeless_input).hostname or "").lower()
+    except ValueError:
+        host = ""
+    if not host:
+        return "https"
+    if host == "localhost" or host.endswith((".localhost", ".local")):
+        return "http"
+    if ":" in host:
+        # A bracketed IPv6 literal, and a local server is the only plausible
+        # reason to type one.
+        return "http"
+    try:
+        # Strict by design (CVE-2021-29921 hardening): "192.168.001.050" is a
+        # hostname here on both sides, never an address.
+        address = ipaddress.IPv4Address(host)
+    except ValueError:
+        return "https"
+    if any(address in network for network in _PRIVATE_IPV4_NETWORKS):
+        return "http"
+    return "https"
+
+
 def normalize_base_url(url: str) -> str:
     """Return a base URL ending in a single ``/v1``.
 
@@ -167,7 +226,7 @@ def normalize_base_url(url: str) -> str:
     if not base:
         return ""
     if "://" not in base:
-        base = "https://" + base
+        base = _default_scheme(base) + "://" + base
     for suffix in ("/chat/completions", "/completions", "/messages"):
         if base.endswith(suffix):
             base = base[: -len(suffix)]
@@ -266,6 +325,12 @@ class RemoteClient:
         if self.api_key:
             body = body.replace(self.api_key, "[redacted]")
         if status in (401, 403):
+            # "Rejected the key" would be a riddle when none was sent.
+            if not self.api_key:
+                return OllamaError(
+                    f"the endpoint requires an API key ({status}). "
+                    f"Add one to this account in Settings. {body}".strip()
+                )
             return OllamaError(
                 f"the endpoint rejected the API key ({status}). "
                 f"Check the key and that it has access to this model. {body}".strip()

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -860,6 +860,170 @@ def test_endpoint_urls_are_normalized():
     assert normalize_base_url("") == ""
 
 
+def test_schemeless_local_endpoints_default_to_http():
+    from ollama_code.remote import normalize_base_url
+
+    # A local llama server pasted as "ip:port/v1" speaks plain HTTP; guessing
+    # https there produced an opaque TLS failure. This table is mirrored
+    # verbatim in the app's testSchemelessLocalEndpointsDefaultToHTTP — the
+    # saved endpoint travels as typed, so the two guesses must never disagree.
+    for given, expected in [
+        # Private-network hosts get http.
+        ("192.168.1.50:9931/v1", "http://192.168.1.50:9931/v1"),
+        ("10.0.0.7:8000", "http://10.0.0.7:8000/v1"),
+        ("172.16.4.2:8000", "http://172.16.4.2:8000/v1"),
+        ("127.0.0.1:11434", "http://127.0.0.1:11434/v1"),
+        ("localhost:9931", "http://localhost:9931/v1"),
+        ("studio.local:1234", "http://studio.local:1234/v1"),
+        ("[::1]:9931", "http://[::1]:9931/v1"),
+        # A typed scheme is never rewritten.
+        ("https://192.168.1.50:9931", "https://192.168.1.50:9931/v1"),
+        # Public addresses and hostnames keep the safe https default.
+        ("34.120.10.5:8000", "https://34.120.10.5:8000/v1"),
+        ("172.32.0.1:8000", "https://172.32.0.1:8000/v1"),
+        ("myserver:9931", "https://myserver:9931/v1"),
+        # Not-quite-IPs are hostnames on both sides: out-of-range,
+        # zero-padded, or percent-encoded octets must not flip the guess.
+        ("256.168.1.50:9931", "https://256.168.1.50:9931/v1"),
+        ("192.168.001.050:9931", "https://192.168.001.050:9931/v1"),
+        ("192%2E168%2E1%2E50:9931", "https://192%2E168%2E1%2E50:9931/v1"),
+        # Swift's URL.host applies IDNA/UTS-46 mapping and urlsplit does not,
+        # so a non-ASCII authority — what a CJK IME emits in full-width mode —
+        # is never guessed at on either side.
+        ("192。168。1。50:9931", "https://192。168。1。50:9931/v1"),
+        ("１９２.168.1.50:9931", "https://１９２.168.1.50:9931/v1"),
+        ("studio。local:1234", "https://studio。local:1234/v1"),
+        ("café.local:8080", "https://café.local:8080/v1"),
+        # Only the authority has to be ASCII. A combining mark right after the
+        # first slash is one grapheme cluster with it, so Swift has to split
+        # the authority by code point as this does, or it would read the whole
+        # path as the authority and refuse a guess made here.
+        ("192.168.1.50:9931/́abc", "http://192.168.1.50:9931/́abc/v1"),
+        ("192.168.1.50:9931/café", "http://192.168.1.50:9931/café/v1"),
+    ]:
+        assert normalize_base_url(given) == expected, given
+
+
+def test_keyless_lan_endpoints_are_accepted():
+    from ollama_code.remote import RemoteClient, validate_remote_url
+
+    # No key means nothing secret travels, so plain HTTP on the LAN is the
+    # user's call — this is how a local llama.cpp/LM Studio box connects.
+    validate_remote_url("http://192.168.1.50:9931/v1", "")
+    client = RemoteClient("192.168.1.50:9931")
+    assert client.base_url == "http://192.168.1.50:9931/v1"
+    # With a key, the HTTPS rule still stands off-loopback.
+    with pytest.raises(ValueError):
+        validate_remote_url("http://192.168.1.50:9931/v1", "secret")
+
+
+def test_keyless_local_endpoint_sends_no_authorization(monkeypatch):
+    from ollama_code import remote as remote_mod
+
+    seen = {}
+
+    def fake_get(url, headers=None, timeout=None, allow_redirects=None):
+        seen["url"] = url
+        seen["headers"] = headers or {}
+        return FakeResponse(payload={"data": [{"id": "llama-3.1-8b-instruct"}]})
+
+    monkeypatch.setattr(remote_mod.requests, "get", fake_get)
+    # Exactly what the user types for a local llama server: bare host:port
+    # with /v1, no scheme, no key.
+    client = remote_mod.RemoteClient("192.168.1.50:9931/v1")
+
+    models = client.list_models()
+
+    assert client.base_url == "http://192.168.1.50:9931/v1"
+    assert seen["url"] == "http://192.168.1.50:9931/v1/models"
+    # A server with no auth must not be sent an empty bearer token.
+    assert "Authorization" not in seen["headers"]
+    assert models[0]["name"] == "llama-3.1-8b-instruct"
+
+
+def test_keyless_custom_team_route_is_accepted():
+    from ollama_code.orchestration import AgentProfile
+
+    def member(route):
+        return {
+            "id": "writer",
+            "name": "Local llama",
+            "model": "llama-3.1-8b-instruct",
+            "role": "implementer",
+            "instructions": "Write carefully",
+            "capabilities": [],
+            "access_ceiling": "workspace_write",
+            "timeout_seconds": 60,
+            "token_limit": 8_000,
+            "metering": "self_hosted",
+            "route": route,
+        }
+
+    remote = {
+        "provider": "remote",
+        "base_url": "http://192.168.1.50:9931/v1",
+        "api_key": "",
+        "account_label": "Local llama",
+    }
+    # A custom endpoint may legitimately have no key, and the app now lets one
+    # be saved and routed — refusing it here would fail the run rather than
+    # the pre-flight check.
+    parsed = AgentProfile.parse(member({**remote, "account_kind": "custom"}))
+    assert parsed.route["base_url"] == "http://192.168.1.50:9931/v1"
+    # A hosted provider's empty key really is a missing credential, and so is
+    # an unlabelled route from an app too old to say which kind it is.
+    for route in ({**remote, "account_kind": "codex"}, remote):
+        with pytest.raises(ValueError, match="credentials"):
+            AgentProfile.parse(member(route))
+
+
+def test_keyless_auth_failure_names_the_missing_key():
+    from ollama_code.remote import RemoteClient
+
+    class FakeResponse:
+        status_code = 401
+        text = ""
+
+        def json(self):
+            return {"error": {"message": "auth required"}}
+
+    keyless = RemoteClient("http://127.0.0.1:9931")
+    assert "requires an API key" in str(keyless._error(FakeResponse()))
+    keyed = RemoteClient("http://127.0.0.1:9931", api_key="sk-x")
+    assert "rejected the API key" in str(keyed._error(FakeResponse()))
+
+
+def test_env_api_key_cannot_crash_a_keyless_http_lan_boot(tmp_path, capsys):
+    # A saved keyless custom endpoint persists provider="remote" with a plain
+    # HTTP LAN URL. If the user also has OPENAI_API_KEY/HF_TOKEN exported,
+    # load_config injects it — and that key may not ride an http LAN URL. The
+    # agent must boot without the environment's key, not die before serving.
+    core = AgentCore(
+        cwd=str(tmp_path),
+        config={
+            "provider": "remote",
+            "remote_base_url": "http://192.168.1.50:9931/v1",
+            "remote_api_key": "sk-from-environment",
+            "model": "test-model",
+        },
+    )
+    assert core.provider == "remote"
+    assert core.client.api_key == ""
+    assert "ignoring environment API key" in capsys.readouterr().err
+    # A loopback endpoint may keep the injected key — the rule is about the
+    # key leaving the machine, not about env keys in general.
+    kept = AgentCore(
+        cwd=str(tmp_path),
+        config={
+            "provider": "remote",
+            "remote_base_url": "http://127.0.0.1:9931/v1",
+            "remote_api_key": "sk-from-environment",
+            "model": "test-model",
+        },
+    )
+    assert kept.client.api_key == "sk-from-environment"
+
+
 def test_remote_client_sends_bearer_token(monkeypatch):
     from ollama_code import remote as remote_mod
 


### PR DESCRIPTION
Someone who had just downloaded the app reported on Reddit that a local llama server at `ip:9931/v1` "wasn't accepted by Locus." They were right, and there was no way through.

## The trap

Three rules combined to make the honest configuration impossible:

| Typed into the Custom endpoint editor | Result before |
|---|---|
| `192.168.x.y:9931/v1`, no key | Save silently disabled — no message |
| `192.168.x.y:9931/v1`, dummy key | Saved, but rewritten to `https://`, so every probe died with an opaque SSL error |
| `http://192.168.x.y:9931/v1`, no key | Save silently disabled |
| `http://192.168.x.y:9931/v1`, dummy key | "API keys require HTTPS unless the endpoint is on this Mac" |

A custom endpoint demanded an API key ([`ProviderAccounts.swift`](../blob/main/Locus/ProviderAccounts.swift) `requiresAPIKey`), a scheme-less address was rewritten to `https`, and a key over plain HTTP was refused off-loopback. Typing the address alone left Save dead; inventing a key to satisfy the first rule tripped the third. `canSave` and `save()` also checked the same condition, so the error branch inside `save()` was unreachable and the user only ever saw a disabled button — which is why the report was as vague as "it wasn't accepted."

## The fix

**Keyless custom endpoints.** Local OpenAI-compatible servers (llama.cpp, LM Studio, vLLM, Ollama) usually run unauthenticated, so `ProviderKind.allowsEmptyAPIKey` lets such an account save, list its models over an unauthenticated probe, and be selected. Every other kind still requires its credential.

**A credential-readiness split.** Gates that decide whether an account can be *used* now ask `isCredentialReady` (`hasKey || kind.allowsEmptyAPIKey`) — the model picker, teams validation, team routes, automatic routing, the composer, and the health dot. `hasKey` stays the literal "a credential is stored," which the Settings row and the editor's placeholder still want. The agent's team-route validator learned the same rule from the route's `account_kind`, so a keyless member is caught by the pre-flight check or not at all, instead of failing mid-run about credentials an endpoint legitimately does not have; a route from an older app that names no kind keeps the strict rule.

**Scheme guessing scoped to genuinely local addresses.** A scheme-less address is only rewritten to `http` when the host cannot be on the public internet: `localhost`, an mDNS name, a bracketed IPv6 literal, or a loopback/RFC1918/link-local IPv4 literal. Everything else — public IPs included — keeps the `https` default.

**Messages that say what is wrong.** Save explains why it is disabled instead of going dead, and a 401 from an endpoint that was sent no key says one is *required* rather than that the key was *rejected* — in the account editor, the model catalogue, and the agent alike.

**A boot crash.** The agent no longer dies when a saved keyless HTTP LAN endpoint meets an API key injected from the environment (`OPENAI_API_KEY`, `HF_TOKEN` and friends). It drops that key with a warning and serves — but only when the key is what the endpoint refuses, so a malformed endpoint still raises its own error.

## Swift/Python parity is the load-bearing part

The endpoint is stored **as typed** and normalized independently by the app and the agent, so any disagreement means the app tests one URL while the agent talks to another. The guess therefore:

- refuses any authority that is not plain ASCII and percent-free — `URL.host` percent-decodes and applies IDNA/UTS-46 mapping where `urlsplit` does not, so `192%2E168%2E1%2E50` and a CJK IME's full-width `192。168。1。50` both became dotted quads on the Swift side only;
- parses dotted quads strictly on both sides — no leading zeros or signs, matching Python's `ipaddress` (CVE-2021-29921 hardening), so `192.168.001.050` is a hostname everywhere;
- takes the authority by **code point**, not grapheme cluster — `"/" + U+0301` is one cluster, so a `Character`-wise scan ran past the slash and tested the whole path as the authority.

Both test suites carry the same table so the two implementations cannot drift apart silently.

## Verification

- **Swift 851 tests, Python 688 tests**, ruff, design-system audit, protocol manifest, and pbxproj currency all pass.
- A **differential harness** ran both real implementations over 80 adversarial inputs — leading zeros, signed octets, percent-encoding, fullwidth/ideographic separators, combining marks, `172.15`/`172.16`/`172.31`/`172.32` range edges, bracketed IPv6 — with **zero mismatches**.
- The real `RemoteClient` was driven against an **actual keyless plain-HTTP server**: bare `127.0.0.1:port/v1` resolved to `http`, and `check()`, `list_models()`, and a chat turn all succeeded with **no `Authorization` header sent**.

## Deliberately not changed

The HTTPS-key exemption is still **loopback-only** — a key over plain HTTP to a LAN host is still refused. Widening it to RFC1918 is a real security judgment and belongs in its own change; nothing here relaxes it.
