### PR TITLE
Run one CI suite per change instead of two

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,18 @@
 name: CI
 
+# A pull request used to be tested twice over: once for the branch push and
+# again for the pull_request event, two full suites racing on the same commit.
+# That doubled the ui job's exposure to a flaky wait without adding any signal,
+# because the pull_request run is the stricter of the pair — it diffs against
+# the PR base rather than the previous push. Branches are covered through their
+# pull request; main and release tags keep their own runs, and a branch without
+# a pull request can still be run by hand.
 on:
   push:
+    branches: [main]
+    tags: ["v*"]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   wallet-signer:


### PR DESCRIPTION
## Why

`ci.yml` had bare triggers:

```yaml
on:
  push:
  pull_request:
```

So every push to a branch with an open PR started **two complete CI runs against the same commit** — five jobs each, with a ~30-minute `ui` job in both — on separate runners. That is where the duplicate rows in `gh pr checks` come from:

```
swift  pass  22m10s  .../runs/33359062192/...   ← push run
swift  pass  17m30s  .../runs/33359064175/...   ← pull_request run, same commit
```

The second run contributed no signal. The `pull_request` run is the stricter of the pair: the advisory reviewability report resolves `LOCUS_REVIEW_BASE` from `github.event.pull_request.base.sha` there, versus the weaker `github.event.before` fallback on a push. What the extra run *did* contribute was a second chance to land on a flaky wait — which is exactly how this surfaced. On PR #58 the `push` twin failed twice while the `pull_request` twin passed the identical commit, and a red X on a PR that is actually green costs a rerun and a re-read every time.

## What changed

```yaml
on:
  push:
    branches: [main]
    tags: ["v*"]
  pull_request:
  workflow_dispatch:
```

- **Branches** are covered by their pull request, once.
- **main** keeps its own run, so a merge is still verified — this is what caught the flake on main itself.
- **Release tags** (`v*`) keep theirs; `v2.1.0` had one.
- **`workflow_dispatch`** covers the one case this otherwise loses: a branch pushed before its PR exists can still be run on demand.

## Reviewer notes

- Halves runner time per PR push (~35 min of macOS minutes) and halves exposure to the flaky `ui` wait that PR #61 addresses at its source. The two changes are complementary: #61 removes the flake, this removes the second dice roll.
- No job definition changes — YAML validated, all five jobs (`wallet-signer`, `python`, `swift`, `mobile`, `ui`) intact.
- `LOCUS_REVIEW_BASE`'s `|| github.event.before` fallback still applies to main and tag pushes; PRs keep the better base.
- This PR is its own demonstration: it should produce a single run rather than a pair.