### PR TITLE
Extract session catalog and transcript presentation ownership

### DIFF
--- a/Locus.xcodeproj/project.pbxproj
+++ b/Locus.xcodeproj/project.pbxproj
@@ -76,7 +76,9 @@
 		2C48811226A5E53CECD51253 /* FeatureLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16740EAD75B3BC87EA7D49A7 /* FeatureLogicTests.swift */; };
 		2CD0E6983960ABBCD416A18E /* AppModel+SettingsAndProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B115BC8D846B904BD7A381 /* AppModel+SettingsAndProvider.swift */; };
 		2CE0A7AB4FEB8B3E0630F2F9 /* TeamRunLiveModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCB3095568BA552C019498D /* TeamRunLiveModel.swift */; };
+		2D421BE291663B06A58C4C8F /* TranscriptPresentationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0E76969AEB69AC1D510292 /* TranscriptPresentationModel.swift */; };
 		2D6EC45E77DF60DD637E99A4 /* BrowserHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428755E5B586F084930BCE41 /* BrowserHost.swift */; };
+		2D93010932A031AF365D76DE /* SessionCatalogModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3790702BA5D5AC1BD86AC2C /* SessionCatalogModelTests.swift */; };
 		2EAD3C52012BDCE207BFED7B /* InspectorBrowserTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3ACD7AD15138A194268B22 /* InspectorBrowserTab.swift */; };
 		2F30B3F6DF8AD2063BBAF9C9 /* BackendResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9203DFDC26CD5ADDAA0A8013 /* BackendResponses.swift */; };
 		2FD44DC8D5F09C734D00D51C /* GitStatusModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EA24EB82248151706E566E /* GitStatusModels.swift */; };
@@ -96,6 +98,7 @@
 		387433BAAF6C2B9D0277AD2F /* CompanionWireTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622AFAF0F2B7F699AB240371 /* CompanionWireTypes.swift */; };
 		3904FFCBA508404034843585 /* AppModel+PermissionsAndCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F1D91E4EBBD0BE7E4027FD /* AppModel+PermissionsAndCapabilities.swift */; };
 		3ADED25B5030F2CD34B36E35 /* AppModel+LandingFlowFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494AA2883078C54BAF0BF14C /* AppModel+LandingFlowFacade.swift */; };
+		3AEFFA65AC2FCC64061F9F9D /* SessionCatalogModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098BDBE9B53A4C18575502B4 /* SessionCatalogModel.swift */; };
 		3B8A090FB2704FB3B2908B2B /* AppModel+TeamRunLiveFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84873DD1B30B35462F4F21 /* AppModel+TeamRunLiveFacade.swift */; };
 		3B942BD1F1DF9E61D2994CCB /* BrowserAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70017AB3BFB7BC69CBD1CC85 /* BrowserAnnotationView.swift */; };
 		3BC92D0FBAF63A1831260CE5 /* CredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D427058C21A8F1993C532E8 /* CredentialStore.swift */; };
@@ -190,6 +193,7 @@
 		709506A38AE20076DCF1FA06 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E25B0D308D2D499E48D903 /* MarkdownRenderer.swift */; };
 		7161D1119A9B7183F6843C62 /* AgentTeamsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29912FD4FFA8E9056AD4FCA2 /* AgentTeamsSettingsView.swift */; };
 		721E997882A22C989DED3C01 /* AppModel+ActivityCenterFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16033E84DC973F0FD1BFA21 /* AppModel+ActivityCenterFacade.swift */; };
+		7432692999A8039E364E8475 /* TranscriptPresentationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0E76969AEB69AC1D510292 /* TranscriptPresentationModel.swift */; };
 		74A5BCF6953128864737A070 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D4CA41C622A34E45EF21F54 /* Assets.xcassets */; };
 		75FD85BD1189A435949FBFC0 /* SessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603951DA29612321B84516AE /* SessionModels.swift */; };
 		75FF0B7CA9E8580EE2585DE0 /* CodexComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111E527F52DFD9F5F6EC39D9 /* CodexComponentTests.swift */; };
@@ -216,6 +220,7 @@
 		829CBDBAFECC3D4B8558E27A /* VoiceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C05527F03B7D68A59343C4E /* VoiceModels.swift */; };
 		832B3EAC906F6E1C3A210D60 /* AppModel+SplitChatPanes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D16150F05480F3D9E417239 /* AppModel+SplitChatPanes.swift */; };
 		83AADDDF785F1C1B6E461820 /* WalletSignerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530DCDEFEDCBE87B25169CB8 /* WalletSignerProtocol.swift */; };
+		83EBDB8F13B284432B48E7AF /* SessionCatalogModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098BDBE9B53A4C18575502B4 /* SessionCatalogModel.swift */; };
 		8519267D24CCB11D4BDDDFB4 /* WalletProviderCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E1A0B244EB9A2F9852BA8A /* WalletProviderCoordinator.swift */; };
 		86FBF385C78D058DE267F94F /* WorkspaceFileViewerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DA82E9A9DD4E4C835FD984 /* WorkspaceFileViewerTests.swift */; };
 		873027C93A71AC0112D86F5B /* SettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC2E6FEB488D4F4DA5260EE /* SettingsModels.swift */; };
@@ -363,6 +368,7 @@
 		D73CE056DABC107BDDD4684B /* BrowserHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428755E5B586F084930BCE41 /* BrowserHost.swift */; };
 		D8873F086E1F5351BAB0FB2E /* WorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2CC3300CABBD87F954E4C63 /* WorkspaceView.swift */; };
 		D8DC0FBEAEBD19EC0480B363 /* SettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC2E6FEB488D4F4DA5260EE /* SettingsModels.swift */; };
+		D92AC7C3E35B7BA7A9613745 /* TranscriptPresentationModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54657DC67328D222A7D46AFF /* TranscriptPresentationModelTests.swift */; };
 		D9A99C280E55AEEAD1454B0E /* AppModel+Workspaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA1C6E1EB6781CFC36FD21F /* AppModel+Workspaces.swift */; };
 		DA2BBF3D75A06CF3177FEC09 /* DiffHunks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE116E00D831A9EE4433A893 /* DiffHunks.swift */; };
 		DA7A4D8766795F0B3E069A2E /* TranscriptSelectionGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418F31828D4EE1F1E605A01F /* TranscriptSelectionGeometry.swift */; };
@@ -496,6 +502,7 @@
 		06DD9A63C8FBDB42368F8A0C /* GitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitClient.swift; sourceTree = "<group>"; };
 		07B62C798D0E60793ED30FF0 /* CodexComponentInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexComponentInstaller.swift; sourceTree = "<group>"; };
 		08EBAE40DE85C2315DFA1510 /* AppModel+VoiceControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+VoiceControls.swift"; sourceTree = "<group>"; };
+		098BDBE9B53A4C18575502B4 /* SessionCatalogModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCatalogModel.swift; sourceTree = "<group>"; };
 		0AF5C1FAF2115086B439E46E /* AppModel+ProviderAccountsFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+ProviderAccountsFacade.swift"; sourceTree = "<group>"; };
 		0B46A04DBC2F15987A189E7A /* ThirdPartyNotices.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ThirdPartyNotices.md; sourceTree = "<group>"; };
 		0C16181F2E5716CD6DBEEE4D /* AppModel+ComposerAttachments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+ComposerAttachments.swift"; sourceTree = "<group>"; };
@@ -572,6 +579,7 @@
 		532B1372E8A5EE9DED6EAE97 /* AppModel+SessionActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+SessionActivity.swift"; sourceTree = "<group>"; };
 		535F3FB7D434799FB66DADAA /* PinnedSummaryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedSummaryModel.swift; sourceTree = "<group>"; };
 		53E5A0F19569788DA77F88B9 /* ContextPackLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextPackLoader.swift; sourceTree = "<group>"; };
+		54657DC67328D222A7D46AFF /* TranscriptPresentationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptPresentationModelTests.swift; sourceTree = "<group>"; };
 		569480B264D98967D6095A68 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		57D7A27ACF9B37EC8F79B9D7 /* BrowserBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserBridge.swift; sourceTree = "<group>"; };
 		592218F80C8625DB77665B98 /* BackgroundServicesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundServicesModelTests.swift; sourceTree = "<group>"; };
@@ -653,6 +661,7 @@
 		AD24095E0EA6433F8AF94214 /* ScheduleModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleModels.swift; sourceTree = "<group>"; };
 		AD57FF854E0D56B9953A1E92 /* AgentTeamsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTeamsModel.swift; sourceTree = "<group>"; };
 		ADFF6B3CE2F946B371F8A9EA /* CommandAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandAction.swift; sourceTree = "<group>"; };
+		AE0E76969AEB69AC1D510292 /* TranscriptPresentationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptPresentationModel.swift; sourceTree = "<group>"; };
 		AE116E00D831A9EE4433A893 /* DiffHunks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffHunks.swift; sourceTree = "<group>"; };
 		AEFB9A10F8784355D5344D95 /* Locus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Locus.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B082AFE6729F96D2D8606AC9 /* WorkspaceIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceIndex.swift; sourceTree = "<group>"; };
@@ -713,6 +722,7 @@
 		F07AB72AB3D46BF6E5B8EDC2 /* WalletRPCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletRPCClient.swift; sourceTree = "<group>"; };
 		F102DB59F958EF25F8E7F0B8 /* LocusMASUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LocusMASUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F234376C385182244FC1AA19 /* ScheduleModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleModel.swift; sourceTree = "<group>"; };
+		F3790702BA5D5AC1BD86AC2C /* SessionCatalogModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCatalogModelTests.swift; sourceTree = "<group>"; };
 		F3E3D606BE661E35AB2E9606 /* AppModel+OrchestrationRunsFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+OrchestrationRunsFacade.swift"; sourceTree = "<group>"; };
 		F6957EFEAE0E05AC5893C23F /* AppModel+SessionLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+SessionLifecycle.swift"; sourceTree = "<group>"; };
 		F7FCAE1E8B009CE43FD465A3 /* AppModel+ToastFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+ToastFacade.swift"; sourceTree = "<group>"; };
@@ -810,10 +820,12 @@
 				5E1CF6E34451F264F94F7E0D /* PinnedSummaryTests.swift */,
 				EA9331EF9C7239D1CD7BDA9A /* ProviderAccountsModelTests.swift */,
 				B9787D5738E48A61A52AD0C6 /* ScheduleModelTests.swift */,
+				F3790702BA5D5AC1BD86AC2C /* SessionCatalogModelTests.swift */,
 				3DDCC477A47A2FB0E5FF77D2 /* SessionOutputWatcherTests.swift */,
 				61DCAB1A0871266055F11C11 /* TeamRunLiveModelTests.swift */,
 				1BAF351A940527DD975AFC95 /* ToastCenterTests.swift */,
 				0C8D1A92D94F8102D312C79E /* TranscriptFollowTests.swift */,
+				54657DC67328D222A7D46AFF /* TranscriptPresentationModelTests.swift */,
 				B9803427C2F43062BF1C6A92 /* TranscriptRelayoutTests.swift */,
 				0E5439CB8E7839C8BC3DE3F7 /* TranscriptSearchModelTests.swift */,
 				C22A462B4342C2597DC23767 /* TranscriptSelectionTests.swift */,
@@ -990,6 +1002,7 @@
 				160A256D1C92F0937B961AB8 /* QuestionPromptView.swift */,
 				01EE3ED166C864419A854532 /* RemoteEndpointTester.swift */,
 				F234376C385182244FC1AA19 /* ScheduleModel.swift */,
+				098BDBE9B53A4C18575502B4 /* SessionCatalogModel.swift */,
 				CA812E808A560BC759B643F5 /* SessionOutputWatcher.swift */,
 				4414AFBD9717B5359B81CE8B /* SessionOverviewView.swift */,
 				00A37D5FE4583645B552296C /* SessionSidebarView.swift */,
@@ -1005,6 +1018,7 @@
 				0DB36421DC413C2F3F5BDA72 /* TextSelectionMenu.swift */,
 				0204C24A0102A8D20E3A23CE /* Theme.swift */,
 				5D3DF12677F019C6F0E4D853 /* ToastCenter.swift */,
+				AE0E76969AEB69AC1D510292 /* TranscriptPresentationModel.swift */,
 				8C8089379A9D8E1CAC5D5D1F /* TranscriptSearchModel.swift */,
 				418F31828D4EE1F1E605A01F /* TranscriptSelectionGeometry.swift */,
 				15FBD1A1C4963CEA3D54440E /* TranscriptSelectionStore.swift */,
@@ -1513,10 +1527,12 @@
 				D16940498B346B575CD0BD99 /* PinnedSummaryTests.swift in Sources */,
 				99269C98285C63BEAD6A3D7A /* ProviderAccountsModelTests.swift in Sources */,
 				1547863C4C10A77E87BE83B7 /* ScheduleModelTests.swift in Sources */,
+				2D93010932A031AF365D76DE /* SessionCatalogModelTests.swift in Sources */,
 				C8CE5CB81A94DF13254C7B14 /* SessionOutputWatcherTests.swift in Sources */,
 				BD91203025F291F9DE16135F /* TeamRunLiveModelTests.swift in Sources */,
 				0AA8C4C8F01F2872DFC7681E /* ToastCenterTests.swift in Sources */,
 				F5E2CC5C7F2D19C8380F41DF /* TranscriptFollowTests.swift in Sources */,
+				D92AC7C3E35B7BA7A9613745 /* TranscriptPresentationModelTests.swift in Sources */,
 				A2ABF63BAC7D91824652DBD2 /* TranscriptRelayoutTests.swift in Sources */,
 				F43AFCBB3DA51D3E9BA73F37 /* TranscriptSearchModelTests.swift in Sources */,
 				151503634B4BE07947B021B2 /* TranscriptSelectionTests.swift in Sources */,
@@ -1671,6 +1687,7 @@
 				4679DAB70FE7B88A97E3F6D9 /* RemoteEndpointTester.swift in Sources */,
 				948EA5ADF173355649913DB4 /* ScheduleModel.swift in Sources */,
 				7B2082B330CFAE2C2D8D51D1 /* ScheduleModels.swift in Sources */,
+				3AEFFA65AC2FCC64061F9F9D /* SessionCatalogModel.swift in Sources */,
 				75FD85BD1189A435949FBFC0 /* SessionModels.swift in Sources */,
 				DAA177BDA6203719C85C8481 /* SessionOutputWatcher.swift in Sources */,
 				C0F305A78BD17AAC4C3CE7F8 /* SessionOverviewView.swift in Sources */,
@@ -1689,6 +1706,7 @@
 				62A955375EBFA6E5A70A6C85 /* Theme.swift in Sources */,
 				951BD5076AF76B07C8B90A08 /* ToastCenter.swift in Sources */,
 				FC0B36C3B5F1E9FE34F908C1 /* TranscriptModels.swift in Sources */,
+				2D421BE291663B06A58C4C8F /* TranscriptPresentationModel.swift in Sources */,
 				9B809359453C0BE9E930B7D6 /* TranscriptSearchModel.swift in Sources */,
 				DA7A4D8766795F0B3E069A2E /* TranscriptSelectionGeometry.swift in Sources */,
 				6BDF0861929C613C6783F77F /* TranscriptSelectionStore.swift in Sources */,
@@ -1850,6 +1868,7 @@
 				CCE0C9F7DA04FE0F2ED8D51E /* RemoteEndpointTester.swift in Sources */,
 				BFDA43DEA4FD15631A0D8A54 /* ScheduleModel.swift in Sources */,
 				F931472E8E4FA66CB54043F5 /* ScheduleModels.swift in Sources */,
+				83EBDB8F13B284432B48E7AF /* SessionCatalogModel.swift in Sources */,
 				BA0CCBF4C4586CE85949BAAC /* SessionModels.swift in Sources */,
 				A1C511A92D7541CDB3C5B1FB /* SessionOutputWatcher.swift in Sources */,
 				214DE47BB80E06A2A0ABFEE3 /* SessionOverviewView.swift in Sources */,
@@ -1868,6 +1887,7 @@
 				473A0EEF2BC977577C962850 /* Theme.swift in Sources */,
 				D2E84B73D934050FA3FE623F /* ToastCenter.swift in Sources */,
 				CA3F741653786B222BA81179 /* TranscriptModels.swift in Sources */,
+				7432692999A8039E364E8475 /* TranscriptPresentationModel.swift in Sources */,
 				6C73699442C809810E8C8A70 /* TranscriptSearchModel.swift in Sources */,
 				BBDE84D324F6199CD80D6E0F /* TranscriptSelectionGeometry.swift in Sources */,
 				C5ACDAE5CF08E05BD60EFDD3 /* TranscriptSelectionStore.swift in Sources */,

--- a/Locus/AppModel+BackendEvents.swift
+++ b/Locus/AppModel+BackendEvents.swift
@@ -135,7 +135,9 @@ extension AppModel {
                 ? (event["sections"] as? [String] ?? [])
                 : nil
             if let phase = event["phase"] as? String, kind == "message" {
-                blocks[index].assistantPhase = AssistantPhase.resolved(phase)
+                updateTranscriptBlocks {
+                    $0[index].assistantPhase = AssistantPhase.resolved(phase)
+                }
             }
             if blocks[index].id == streamingAssistantID {
                 commitStreamingReply(
@@ -146,12 +148,18 @@ extension AppModel {
                 )
                 streamingAssistantID = nil
             } else {
-                if let authoritativeText { blocks[index].text = authoritativeText }
-                if let sections {
-                    blocks[index].reasoningSections = sections.isEmpty ? nil : sections
-                    blocks[index].reasoningText = sections.joined(separator: "\n\n").nilIfEmpty
+                updateTranscriptBlocks { transcriptBlocks in
+                    if let authoritativeText {
+                        transcriptBlocks[index].text = authoritativeText
+                    }
+                    if let sections {
+                        transcriptBlocks[index].reasoningSections = sections.isEmpty ? nil : sections
+                        transcriptBlocks[index].reasoningText = sections
+                            .joined(separator: "\n\n")
+                            .nilIfEmpty
+                    }
+                    transcriptBlocks[index].isStreaming = false
                 }
-                blocks[index].isStreaming = false
             }
             if wasStreaming, let runtime = taskWorkers[currentSessionID] {
                 runtime.streamingBlockID = nil
@@ -217,16 +225,20 @@ extension AppModel {
                 let explanation = "The agent sent a permission request the app cannot answer"
                     + " (missing request id). Stop the run if it does not continue."
                 if let index = blocks.lastIndex(where: { $0.tool?.toolID == toolID }), !toolID.isEmpty {
-                    blocks[index].tool?.status = .error
-                    blocks[index].tool?.result = explanation
+                    updateTranscriptBlocks {
+                        $0[index].tool?.status = .error
+                        $0[index].tool?.result = explanation
+                    }
                 } else {
                     blocks.append(ChatBlock(kind: .error, text: explanation))
                 }
                 return
             }
             if let index = blocks.lastIndex(where: { $0.tool?.toolID == toolID }), !toolID.isEmpty {
-                blocks[index].tool?.status = .awaitingPermission
-                blocks[index].tool?.requestID = requestID
+                updateTranscriptBlocks {
+                    $0[index].tool?.status = .awaitingPermission
+                    $0[index].tool?.requestID = requestID
+                }
                 // Publish the in-place tool-card upgrade even though the
                 // block count did not change. The native scroll coordinator
                 // decides independently whether the viewport should follow.
@@ -261,8 +273,10 @@ extension AppModel {
             let denied = event["denied"] as? Bool == true
             let ok = event["ok"] as? Bool == true
             if let index = blocks.firstIndex(where: { $0.tool?.toolID == toolID }) {
-                blocks[index].tool?.status = denied ? .denied : ok ? .done : .error
-                blocks[index].tool?.result = event["result"] as? String
+                updateTranscriptBlocks {
+                    $0[index].tool?.status = denied ? .denied : ok ? .done : .error
+                    $0[index].tool?.result = event["result"] as? String
+                }
             } else {
                 // Never drop a result: without a matching card the outcome of
                 // a tool the user approved would vanish silently.
@@ -960,8 +974,10 @@ extension AppModel {
         if let id = streamingAssistantID {
             commitStreamingReply(id, finished: true)
         }
-        for index in blocks.indices where blocks[index].isStreaming {
-            blocks[index].isStreaming = false
+        updateTranscriptBlocks { transcriptBlocks in
+            for index in transcriptBlocks.indices where transcriptBlocks[index].isStreaming {
+                transcriptBlocks[index].isStreaming = false
+            }
         }
     }
 
@@ -978,12 +994,14 @@ extension AppModel {
         ),
               let index = blocks.firstIndex(where: { $0.id == id })
         else { return }
-        blocks[index].text = snapshot.text
-        blocks[index].reasoningText = snapshot.reasoning.nilIfEmpty
-        blocks[index].reasoningSections = snapshot.reasoningSections.isEmpty
-            ? nil
-            : snapshot.reasoningSections
-        if finished { blocks[index].isStreaming = false }
+        updateTranscriptBlocks {
+            $0[index].text = snapshot.text
+            $0[index].reasoningText = snapshot.reasoning.nilIfEmpty
+            $0[index].reasoningSections = snapshot.reasoningSections.isEmpty
+                ? nil
+                : snapshot.reasoningSections
+            if finished { $0[index].isStreaming = false }
+        }
     }
 
     /// A normally completed Build turn is authoritative evidence that the
@@ -1031,9 +1049,13 @@ extension AppModel {
     /// longer matter, and a stuck awaiting card would disable send and
     /// clear-chat forever.
     private func resolveDanglingPermissions() {
-        for index in blocks.indices where blocks[index].tool?.status == .awaitingPermission {
-            blocks[index].tool?.status = .error
-            blocks[index].tool?.result = "The turn ended before this request was answered."
+        updateTranscriptBlocks { transcriptBlocks in
+            for index in transcriptBlocks.indices
+            where transcriptBlocks[index].tool?.status == .awaitingPermission {
+                transcriptBlocks[index].tool?.status = .error
+                transcriptBlocks[index].tool?.result =
+                    "The turn ended before this request was answered."
+            }
         }
     }
 
@@ -1060,11 +1082,15 @@ extension AppModel {
         pendingCheckpointRestore = nil
         pendingRewindDraft = nil
         sessionResetWatchdog?.cancel()
-        for index in blocks.indices where blocks[index].tool?.status == .awaitingPermission
-            || blocks[index].tool?.status == .running
-        {
-            blocks[index].tool?.status = .error
-            blocks[index].tool?.result = "The connection to the local agent was lost before this finished."
+        updateTranscriptBlocks { transcriptBlocks in
+            for index in transcriptBlocks.indices
+            where transcriptBlocks[index].tool?.status == .awaitingPermission
+                || transcriptBlocks[index].tool?.status == .running
+            {
+                transcriptBlocks[index].tool?.status = .error
+                transcriptBlocks[index].tool?.result =
+                    "The connection to the local agent was lost before this finished."
+            }
         }
     }
 

--- a/Locus/AppModel+ChatOrganization.swift
+++ b/Locus/AppModel+ChatOrganization.swift
@@ -183,8 +183,8 @@ extension AppModel {
     }
 
     var expandedChatFolderIDs: Set<String> {
-        get { Set(UserDefaults.standard.stringArray(forKey: "Locus.expandedChatFolders") ?? []) }
-        set { UserDefaults.standard.set(Array(newValue).sorted(), forKey: "Locus.expandedChatFolders") }
+        get { sessionCatalog.snapshot.expandedChatFolderIDs }
+        set { sessionCatalog.replaceExpandedChatFolderIDs(newValue) }
     }
 
     func isChatFolderExpanded(_ id: String) -> Bool {
@@ -192,27 +192,28 @@ extension AppModel {
     }
 
     func setChatFolderExpanded(_ id: String, expanded: Bool) {
-        var values = expandedChatFolderIDs
-        if expanded { values.insert(id) } else { values.remove(id) }
-        expandedChatFolderIDs = values
+        sessionCatalog.setChatFolderExpanded(id, expanded: expanded)
     }
 
     private func persistExpandedChatFolders() {
-        expandedChatFolderIDs = expandedChatFolderIDs
+        sessionCatalog.persistExpansionState()
     }
 
     private func refreshChatOrganization() async {
-        if let response = try? await backend.get(
+        let folders = try? await backend.get(
             "/api/chat-folders", as: ChatFoldersResponse.self
-        ) {
-            chatFolders = response.folders
-        }
+        )
         let suffix = showArchivedSessions ? "?include_archived=true&limit=500" : "?limit=500"
         if let response = try? await backend.get(
             "/api/sessions\(suffix)", as: SessionsResponse.self
         ) {
-            sessions = response.sessions
+            sessionCatalog.replaceRemoteCatalog(
+                sessions: response.sessions,
+                chatFolders: folders?.folders
+            )
             reconcileChatSplitRestoration()
+        } else if let folders {
+            chatFolders = folders.folders
         }
     }
 

--- a/Locus/AppModel+RuntimeAndLifecycle.swift
+++ b/Locus/AppModel+RuntimeAndLifecycle.swift
@@ -514,12 +514,13 @@ extension AppModel {
                 ? "?include_archived=true&limit=500"
                 : "?limit=500"
             let response = try await backend.get("/api/sessions\(suffix)", as: SessionsResponse.self)
-            sessions = response.sessions
-            if let folders = try? await backend.get(
+            let folders = try? await backend.get(
                 "/api/chat-folders", as: ChatFoldersResponse.self
-            ) {
-                chatFolders = folders.folders
-            }
+            )
+            sessionCatalog.replaceRemoteCatalog(
+                sessions: response.sessions,
+                chatFolders: folders?.folders
+            )
             if taskWorkers[currentSessionID] == nil {
                 currentSessionID = response.current
             }

--- a/Locus/AppModel+SessionActivity.swift
+++ b/Locus/AppModel+SessionActivity.swift
@@ -324,7 +324,7 @@ extension AppModel {
         fileCaptureUntil = .max
         sessionOutputWatchTeardown?.cancel()
         sessionOutputWatchTeardown = nil
-        guard !isUITesting else { return }
+        guard persistenceEnabled else { return }
         let started = Date()
         let root = workspacePath
         sessionOutputWatcher.start(path: root, since: started) { [weak self] changes in

--- a/Locus/AppModel+UITestFixtures.swift
+++ b/Locus/AppModel+UITestFixtures.swift
@@ -907,8 +907,10 @@ extension AppModel {
             exportAttempts: 0
         )
         if let requestIndex = blocks.firstIndex(where: { $0.kind == .user }) {
-            blocks[requestIndex].text = run.request
-            blocks[requestIndex].runID = run.id
+            updateTranscriptBlocks {
+                $0[requestIndex].text = run.request
+                $0[requestIndex].runID = run.id
+            }
         }
         orchestrationRuns = [run]
         selectedOrchestrationRun = run

--- a/Locus/AppModel+WorkspaceProfiles.swift
+++ b/Locus/AppModel+WorkspaceProfiles.swift
@@ -229,11 +229,7 @@ extension AppModel {
     }
 
     func persistExpandedWorkspaces() {
-        guard persistenceEnabled else { return }
-        UserDefaults.standard.set(
-            expandedWorkspaceIDs.sorted(),
-            forKey: "Locus.expandedWorkspaces"
-        )
+        sessionCatalog.persistExpansionState()
     }
 
     func persistSettings() {

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -91,8 +91,16 @@ final class AppModel: ObservableObject {
     private var backgroundServicesBridge: AnyCancellable?
     let extensionsModel = ExtensionsModel()
     private var extensionsBridge: AnyCancellable?
-    @Published var sessions: [SessionSummary] = []
-    @Published var chatFolders: [ChatFolderRecord] = []
+    let sessionCatalog = SessionCatalogModel()
+    let transcriptPresentation = TranscriptPresentationModel()
+    var sessions: [SessionSummary] {
+        get { sessionCatalog.snapshot.sessions }
+        set { sessionCatalog.replaceSessions(newValue) }
+    }
+    var chatFolders: [ChatFolderRecord] {
+        get { sessionCatalog.snapshot.chatFolders }
+        set { sessionCatalog.replaceChatFolders(newValue) }
+    }
     @Published var currentSessionID = ""
     @Published var chatSplitRestoration = ChatSplitRestoration.empty  // internal(for: AppModel extension files)
     let primaryChatPaneState = ChatPaneState(id: .primary)
@@ -111,6 +119,11 @@ final class AppModel: ObservableObject {
             // Session changes must retarget the app-owned PTY even when its
             // inspector tab is hidden. Ignore a transient nil while the local
             // backend reconnects so the shell survives agent restarts.
+            if let cwd = sessionInfo?.cwd, !cwd.isEmpty {
+                sessionCatalog.setActiveWorkspacePath(cwd)
+            } else if let initialWorkspacePath {
+                sessionCatalog.setActiveWorkspacePath(initialWorkspacePath)
+            }
             guard let cwd = sessionInfo?.cwd, !cwd.isEmpty else { return }
             terminal.configure(
                 workspacePath: cwd,
@@ -123,9 +136,18 @@ final class AppModel: ObservableObject {
             )
         }
     }
-    @Published var blocks: [ChatBlock] = []
+    var blocks: [ChatBlock] {
+        get { transcriptPresentation.snapshot.blocks }
+        set { transcriptPresentation.replaceBlocks(newValue) }
+    }
+
+    func updateTranscriptBlocks(_ update: (inout [ChatBlock]) -> Void) {
+        transcriptPresentation.updateBlocks(update)
+    }
+
     @Published var todos: [TodoItem] = []
     @Published var isBusy = false
+    @Published private(set) var hasPendingPermission = false
     /// A short, truthful description of where an in-flight steering request
     /// is waiting. It is cleared when the direction joins the active turn.
     @Published var steeringState: String?  // internal(for: AppModel extension files)
@@ -219,7 +241,10 @@ final class AppModel: ObservableObject {
     /// memory; reconnects and app relaunches require a fresh scoped consent.
     @Published var liveApplicationTargets: [String: ApplicationTarget] = [:]  // internal(for: AppModel extension files)
     @Published var checkpoints: [SessionCheckpoint] = []
-    @Published var workspaceProfiles: [WorkspaceProfile] = []
+    var workspaceProfiles: [WorkspaceProfile] {
+        get { sessionCatalog.snapshot.workspaceProfiles }
+        set { sessionCatalog.replaceWorkspaceProfiles(newValue) }
+    }
     @Published var draftText = "" {
         didSet {
             resetHistoryCursorIfEdited()
@@ -237,6 +262,10 @@ final class AppModel: ObservableObject {
     }
     @Published var settings: AppSettings {
         didSet {
+            transcriptPresentation.setPresentationVisibility(
+                toolActivity: settings.resolvedToolActivityVisibility,
+                thinking: settings.resolvedThinkingVisibility
+            )
             scheduleWorkspacePersistence()
             // Without this, anything a view writes into `settings` is lost on
             // relaunch: the only other writer is applySettings(), so the
@@ -279,18 +308,27 @@ final class AppModel: ObservableObject {
     @Published var clearChatConfirmationPresented = false
     @Published var clearSessionsConfirmationPresented = false
     @Published var isClearingSessions = false
-    @Published var showArchivedSessions = false
-    @Published var searchQuery = "" {
-        didSet { transcriptSearch.scheduleHitSearch(query: searchQuery) }
+    var showArchivedSessions: Bool {
+        get { sessionCatalog.snapshot.showArchivedSessions }
+        set { sessionCatalog.setShowArchivedSessions(newValue) }
+    }
+    var searchQuery: String {
+        get { sessionCatalog.snapshot.searchQuery }
+        set { sessionCatalog.setSearchQuery(newValue) }
     }
     let transcriptSearch = TranscriptSearchModel()
-    private var transcriptSearchBridge: AnyCancellable?
-    @Published var sidebarSearchFocusToken = UUID()
+    var sidebarSearchFocusToken: UUID {
+        get { sessionCatalog.snapshot.sidebarSearchFocusToken }
+        set { sessionCatalog.replaceSidebarSearchFocusToken(newValue) }
+    }
     @Published var globalNewFolderPresented = false
     @Published var globalNewFolderName = ""
     @Published var composerFocusToken = UUID()
     private var pendingSearchHit: TranscriptSearchHit?
-    @Published var expandedWorkspaceIDs: Set<String> = []
+    var expandedWorkspaceIDs: Set<String> {
+        get { sessionCatalog.snapshot.expandedWorkspaceIDs }
+        set { sessionCatalog.replaceExpandedWorkspaceIDs(newValue) }
+    }
     @Published var transcriptSearchPresented = false
     @Published var transcriptSearchQuery = "" {
         didSet { transcriptSearchSelection = 0 }
@@ -665,12 +703,13 @@ final class AppModel: ObservableObject {
         {
             checkpoints = saved
         }
+        var restoredWorkspaceProfiles: [WorkspaceProfile] = []
         var restoredWorkspacePaths: [String] = []
         if !isUITesting,
            let data = defaults.data(forKey: "Locus.workspaceProfiles"),
            let saved = try? JSONDecoder().decode([WorkspaceProfile].self, from: data)
         {
-            var recent = saved.sorted { $0.lastOpened > $1.lastOpened }
+            let recent = saved.sorted { $0.lastOpened > $1.lastOpened }
             if migrateLegacyBuildMode {
                 if persistenceEnabled,
                    let migratedData = try? JSONEncoder().encode(recent)
@@ -678,13 +717,8 @@ final class AppModel: ObservableObject {
                     defaults.set(migratedData, forKey: "Locus.workspaceProfiles")
                 }
             }
-            workspaceProfiles = recent
+            restoredWorkspaceProfiles = recent
             restoredWorkspacePaths = recent.map(\.path)
-        }
-        if !isUITesting, persistenceEnabled {
-            expandedWorkspaceIDs = Set(
-                defaults.stringArray(forKey: "Locus.expandedWorkspaces") ?? []
-            )
         }
         let access = WorkspaceAccess(defaults: defaults)
         workspaceAccess = access
@@ -708,6 +742,24 @@ final class AppModel: ObservableObject {
 
         backend = backendOverride ?? BackendService(
             baseURL: URL(string: loadedSettings.backendURL) ?? URL(string: "http://127.0.0.1:8791")!
+        )
+        sessionCatalog.configure(
+            persistenceEnabled: !isUITesting && persistenceEnabled,
+            defaults: defaults,
+            searchQueryDidChange: { [weak self] query in
+                self?.transcriptSearch.scheduleHitSearch(query: query)
+            }
+        )
+        sessionCatalog.replaceWorkspaceProfiles(restoredWorkspaceProfiles)
+        sessionCatalog.setActiveWorkspacePath(
+            initialWorkspacePath ?? FileManager.default.homeDirectoryForCurrentUser.path
+        )
+        transcriptPresentation.configure(
+            toolActivityVisibility: loadedSettings.resolvedToolActivityVisibility,
+            thinkingVisibility: loadedSettings.resolvedThinkingVisibility,
+            pendingPermissionDidChange: { [weak self] value in
+                self?.hasPendingPermission = value
+            }
         )
         providerAccountsModel.providerAccounts = restoredProviderAccounts
         gitWorkspace.configure(
@@ -862,9 +914,6 @@ final class AppModel: ObservableObject {
             self?.objectWillChange.send()
         }
         transcriptSearch.configure(backend: backend)
-        transcriptSearchBridge = transcriptSearch.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         schedule.configure(
             backend: backend,
             persistenceEnabled: persistenceEnabled,
@@ -1335,32 +1384,10 @@ final class AppModel: ObservableObject {
     }
 
     var filteredSessions: [SessionSummary] {
-        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let filtered = sessions
-            .filter { showArchivedSessions || !$0.isArchived }
-            .sorted { lhs, rhs in
-                if lhs.isPinned != rhs.isPinned { return lhs.isPinned }
-                return lhs.mtime > rhs.mtime
-            }
-        guard !query.isEmpty else { return filtered }
-        let directlyMatchingFolders = Set(chatFolders.filter {
-            $0.name.lowercased().contains(query)
-        }.map(\.id))
-        var matchingFolderTree = directlyMatchingFolders
-        var changed = true
-        while changed {
-            changed = false
-            for folder in chatFolders where folder.parentID.map(matchingFolderTree.contains) == true {
-                if matchingFolderTree.insert(folder.id).inserted { changed = true }
-            }
-        }
-        return filtered.filter {
-            "\($0.displayTitle) \($0.name)".lowercased().contains(query)
-                || $0.folderID.map(matchingFolderTree.contains) == true
-        }
+        sessionCatalog.snapshot.filteredSessions
     }
 
-    static let otherWorkspaceID = "locus.other-chats"
+    static let otherWorkspaceID = SessionCatalogModel.otherWorkspaceID
 
     var activeWorkspaceID: String {
         SessionSummary.canonicalWorkspacePath(workspacePath)
@@ -1373,112 +1400,37 @@ final class AppModel: ObservableObject {
     /// Folder-backed workspace sections plus a compatibility bucket for old
     /// transcripts whose meta record predates cwd provenance.
     var workspaceChatGroups: [WorkspaceChatGroup] {
-        let queryActive = !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let chats = filteredSessions
-        var chatsByPath = Dictionary(grouping: chats.compactMap { session -> (String, SessionSummary)? in
-            guard let path = session.workspacePath else { return nil }
-            return (path, session)
-        }, by: \.0).mapValues { $0.map(\.1) }
-
-        var profilesByPath: [String: WorkspaceProfile] = [:]
-        for profile in workspaceProfiles {
-            let path = SessionSummary.canonicalWorkspacePath(profile.path)
-            if let existing = profilesByPath[path], existing.lastOpened >= profile.lastOpened {
-                continue
-            }
-            profilesByPath[path] = profile
-        }
-
-        var paths = Set(profilesByPath.keys)
-        paths.formUnion(chatsByPath.keys)
-        paths.insert(activeWorkspaceID)
-
-        var groups = paths.compactMap { path -> WorkspaceChatGroup? in
-            let groupChats = (chatsByPath.removeValue(forKey: path) ?? []).sorted(by: Self.sessionSort)
-            let folderMatches = queryActive && chatFolders.contains { folder in
-                SessionSummary.canonicalWorkspacePath(folder.workspace) == path
-                    && folder.name.localizedCaseInsensitiveContains(
-                        searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-                    )
-            }
-            if queryActive && groupChats.isEmpty && !folderMatches { return nil }
-            let profile = profilesByPath[path]
-            let chatDate = groupChats.map(\.date).max() ?? .distantPast
-            let lastOpened = max(profile?.lastOpened ?? .distantPast, chatDate)
-            return WorkspaceChatGroup(
-                id: path,
-                path: path,
-                title: URL(fileURLWithPath: path).lastPathComponent,
-                chats: groupChats,
-                lastOpened: lastOpened,
-                isAvailable: FileManager.default.fileExists(atPath: path),
-                isOther: false
-            )
-        }
-        groups.sort { lhs, rhs in
-            if lhs.id == activeWorkspaceID { return true }
-            if rhs.id == activeWorkspaceID { return false }
-            return lhs.lastOpened > rhs.lastOpened
-        }
-
-        let otherChats = chats.filter { $0.workspacePath == nil }.sorted(by: Self.sessionSort)
-        if !otherChats.isEmpty {
-            groups.append(
-                WorkspaceChatGroup(
-                    id: Self.otherWorkspaceID,
-                    path: nil,
-                    title: "Other Chats",
-                    chats: otherChats,
-                    lastOpened: otherChats.map(\.date).max() ?? .distantPast,
-                    isAvailable: true,
-                    isOther: true
-                )
-            )
-        }
-        return groups
+        sessionCatalog.snapshot.sidebarGroups.map(\.group)
     }
 
     func folders(in group: WorkspaceChatGroup, parentID: String? = nil) -> [ChatFolderRecord] {
-        guard let path = group.path else { return [] }
-        let canonical = SessionSummary.canonicalWorkspacePath(path)
-        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return chatFolders
-            .filter { folder in
-                SessionSummary.canonicalWorkspacePath(folder.workspace) == canonical
-                    && folder.parentID == parentID
-                    && (query.isEmpty || folderMatchesSearch(folder, query: query, group: group))
-            }
-            .sorted { lhs, rhs in
-                if lhs.order != rhs.order { return lhs.order < rhs.order }
-                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
-            }
+        guard let sidebarGroup = sessionCatalog.snapshot.sidebarGroups.first(where: {
+            $0.id == group.id
+        }) else { return [] }
+        if let parentID {
+            return Self.folderNode(id: parentID, in: sidebarGroup.rootFolders)?
+                .children.map(\.folder) ?? []
+        }
+        return sidebarGroup.rootFolders.map(\.folder)
     }
 
     func chats(in group: WorkspaceChatGroup, folderID: String?) -> [SessionSummary] {
-        group.chats
-            .filter { $0.folderID == folderID }
-            .sorted { lhs, rhs in
-                if lhs.isPinned != rhs.isPinned { return lhs.isPinned }
-                if lhs.sortOrder != rhs.sortOrder {
-                    return (lhs.sortOrder ?? .max) < (rhs.sortOrder ?? .max)
-                }
-                return lhs.mtime > rhs.mtime
-            }
+        guard let sidebarGroup = sessionCatalog.snapshot.sidebarGroups.first(where: {
+            $0.id == group.id
+        }) else { return [] }
+        guard let folderID else { return sidebarGroup.unfiledChats }
+        return Self.folderNode(id: folderID, in: sidebarGroup.rootFolders)?.chats ?? []
     }
 
-    private func folderMatchesSearch(
-        _ folder: ChatFolderRecord, query: String, group: WorkspaceChatGroup
-    ) -> Bool {
-        if folder.name.lowercased().contains(query) { return true }
-        if group.chats.contains(where: { $0.folderID == folder.id }) { return true }
-        return chatFolders.contains { child in
-            child.parentID == folder.id && folderMatchesSearch(child, query: query, group: group)
+    private static func folderNode(
+        id: String,
+        in nodes: [SessionSidebarFolderSnapshot]
+    ) -> SessionSidebarFolderSnapshot? {
+        for node in nodes {
+            if node.id == id { return node }
+            if let match = folderNode(id: id, in: node.children) { return match }
         }
-    }
-
-    private static func sessionSort(_ lhs: SessionSummary, _ rhs: SessionSummary) -> Bool {
-        if lhs.isPinned != rhs.isPinned { return lhs.isPinned }
-        return lhs.mtime > rhs.mtime
+        return nil
     }
 
     func teamRunState(for session: SessionSummary) -> TeamRunState? {
@@ -1502,16 +1454,11 @@ final class AppModel: ObservableObject {
     }
 
     func isWorkspaceExpanded(_ id: String) -> Bool {
-        expandedWorkspaceIDs.contains(id)
+        sessionCatalog.snapshot.expandedWorkspaceIDs.contains(id)
     }
 
     func setWorkspaceExpanded(_ id: String, expanded: Bool) {
-        if expanded {
-            expandedWorkspaceIDs.insert(id)
-        } else {
-            expandedWorkspaceIDs.remove(id)
-        }
-        persistExpandedWorkspaces()
+        sessionCatalog.setWorkspaceExpanded(id, expanded: expanded)
     }
 
     var includedContextTokens: Int {
@@ -1534,10 +1481,6 @@ final class AppModel: ObservableObject {
 
     var contextBudgetTokens: Int {
         Int(Double(contextWindowTokens ?? Self.assumedContextWindowTokens) * 0.60)
-    }
-
-    var hasPendingPermission: Bool {
-        blocks.contains { $0.tool?.status == .awaitingPermission }
     }
 
     /// Bridged into settings so the choice persists; views observe it through

--- a/Locus/InspectorRail.swift
+++ b/Locus/InspectorRail.swift
@@ -195,6 +195,7 @@ struct InspectorRail: View {
 /// header. This keeps them separate from the inspector's panel picker.
 struct WorkspaceActionsMenu: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var sessionCatalog: SessionCatalogModel
     @State private var createBranchPresented = false
     @State private var branchName = ""
 
@@ -254,7 +255,7 @@ struct WorkspaceActionsMenu: View {
                     Button("\(format.title)…") { model.exportCurrentSession(format: format) }
                 }
             }
-            .disabled(!model.sessions.contains { $0.id == model.currentSessionID })
+            .disabled(sessionCatalog.snapshot.sessionsByID[model.currentSessionID] == nil)
             .accessibilityIdentifier("workspace.actions.export")
             Divider()
             Picker("Tool activity", selection: Binding(

--- a/Locus/LocusApp.swift
+++ b/Locus/LocusApp.swift
@@ -61,6 +61,8 @@ struct LocusApp: App {
         Window("Locus", id: "main") {
             sceneContent
                 .environmentObject(model)
+                .environmentObject(model.sessionCatalog)
+                .environmentObject(model.transcriptPresentation)
                 .environmentObject(updates)
                 .onAppear {
                     appDelegate.model = model
@@ -115,9 +117,10 @@ struct LocusApp: App {
             CommandMenu("Locus") {
                 Button("Command Palette") { model.commandPalettePresented = true }
                     .keyboardShortcut("k", modifiers: .command)
-                Button("Find in Conversation") { model.openTranscriptSearch() }
-                    .keyboardShortcut("f", modifiers: .command)
-                    .disabled(model.blocks.isEmpty)
+                FindInConversationCommand(
+                    transcriptPresentation: model.transcriptPresentation,
+                    open: model.openTranscriptSearch
+                )
                 Button("Search All Conversations") {
                     if model.sidebarCollapsed { model.toggleSidebar() }
                     model.sidebarSearchFocusToken = UUID()
@@ -205,6 +208,8 @@ struct LocusApp: App {
         Settings {
             SettingsView(presentationContext: .settingsWindow)
                 .environmentObject(model)
+                .environmentObject(model.sessionCatalog)
+                .environmentObject(model.transcriptPresentation)
                 .environmentObject(updates)
                 .preferredColorScheme(model.effectiveAppearance.colorScheme)
                 .accentColor(model.accentActionColor)
@@ -215,6 +220,8 @@ struct LocusApp: App {
         MenuBarExtra {
             LocusMenuBarView(presenter: mainWindowPresenter)
                 .environmentObject(model)
+                .environmentObject(model.sessionCatalog)
+                .environmentObject(model.transcriptPresentation)
         } label: {
             Image("MenuBarIcon")
                 .renderingMode(.template)
@@ -330,6 +337,19 @@ struct LocusApp: App {
         default:
             RootView()
         }
+    }
+}
+
+/// Observes only transcript availability for the menu item whose enabled
+/// state depends on it. The app scene remains free of transcript publications.
+private struct FindInConversationCommand: View {
+    @ObservedObject var transcriptPresentation: TranscriptPresentationModel
+    let open: () -> Void
+
+    var body: some View {
+        Button("Find in Conversation", action: open)
+            .keyboardShortcut("f", modifiers: .command)
+            .disabled(transcriptPresentation.snapshot.isEmpty)
     }
 }
 

--- a/Locus/PlanApprovalPromptView.swift
+++ b/Locus/PlanApprovalPromptView.swift
@@ -518,6 +518,7 @@ struct TeamRunBoardView: View {
 /// diagnostics without presenting provider reasoning or raw structured output.
 struct TeamDispatchProgressView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var transcriptPresentation: TranscriptPresentationModel
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 1)) { timeline in
@@ -695,7 +696,7 @@ struct TeamDispatchProgressView: View {
         if let request = model.runs.selectedOrchestrationRun?.request, !request.isEmpty {
             return request
         }
-        return model.blocks.last(where: { $0.kind == .user })?.text ?? ""
+        return transcriptPresentation.snapshot.blocks.last(where: { $0.kind == .user })?.text ?? ""
     }
 
     private func duration(_ seconds: TimeInterval) -> String {

--- a/Locus/SessionCatalogModel.swift
+++ b/Locus/SessionCatalogModel.swift
@@ -1,0 +1,491 @@
+import Combine
+import Foundation
+import os
+
+struct SessionSidebarFolderSnapshot: Identifiable, Equatable {
+    let folder: ChatFolderRecord
+    let children: [SessionSidebarFolderSnapshot]
+    let chats: [SessionSummary]
+
+    var id: String { folder.id }
+}
+
+struct SessionSidebarGroupSnapshot: Identifiable, Equatable {
+    let group: WorkspaceChatGroup
+    let rootFolders: [SessionSidebarFolderSnapshot]
+    let unfiledChats: [SessionSummary]
+
+    var id: String { group.id }
+}
+
+struct SessionCatalogSnapshot: Equatable {
+    let sessions: [SessionSummary]
+    let chatFolders: [ChatFolderRecord]
+    let workspaceProfiles: [WorkspaceProfile]
+    let sessionsByID: [String: SessionSummary]
+    let foldersByID: [String: ChatFolderRecord]
+    let workspaceIDBySessionID: [String: String]
+    let foldersByWorkspaceID: [String: [ChatFolderRecord]]
+    let folderMoveTargetsByFolderID: [String: [ChatFolderRecord]]
+    let recentWorkspaceProfiles: [WorkspaceProfile]
+    let availableWorkspaceIDs: Set<String>
+    let workspaceAvailabilityByProfileID: [String: Bool]
+    let availableExecutionSessionIDs: Set<String>
+    let filteredSessions: [SessionSummary]
+    let sidebarGroups: [SessionSidebarGroupSnapshot]
+    let activeWorkspaceID: String
+    let showArchivedSessions: Bool
+    let searchQuery: String
+    let expandedWorkspaceIDs: Set<String>
+    let expandedChatFolderIDs: Set<String>
+    let sidebarSearchFocusToken: UUID
+
+    static let empty = SessionCatalogSnapshot(
+        sessions: [],
+        chatFolders: [],
+        workspaceProfiles: [],
+        sessionsByID: [:],
+        foldersByID: [:],
+        workspaceIDBySessionID: [:],
+        foldersByWorkspaceID: [:],
+        folderMoveTargetsByFolderID: [:],
+        recentWorkspaceProfiles: [],
+        availableWorkspaceIDs: [],
+        workspaceAvailabilityByProfileID: [:],
+        availableExecutionSessionIDs: [],
+        filteredSessions: [],
+        sidebarGroups: [],
+        activeWorkspaceID: "",
+        showArchivedSessions: false,
+        searchQuery: "",
+        expandedWorkspaceIDs: [],
+        expandedChatFolderIDs: [],
+        sidebarSearchFocusToken: UUID()
+    )
+}
+
+/// Authoritative session/sidebar state. It publishes one complete, immutable
+/// snapshot only when catalog inputs change, so SwiftUI never rebuilds the
+/// workspace hierarchy while evaluating an unrelated AppModel publication.
+@MainActor
+final class SessionCatalogModel: ObservableObject {
+    typealias FileExists = (String) -> Bool
+    static let otherWorkspaceID = "locus.other-chats"
+
+    private struct State: Equatable {
+        var sessions: [SessionSummary] = []
+        var chatFolders: [ChatFolderRecord] = []
+        var workspaceProfiles: [WorkspaceProfile] = []
+        var activeWorkspaceID = ""
+        var showArchivedSessions = false
+        var searchQuery = ""
+        var expandedWorkspaceIDs: Set<String> = []
+        var expandedChatFolderIDs: Set<String> = []
+        var sidebarSearchFocusToken = UUID()
+    }
+
+    private static let signposter = OSSignposter(
+        subsystem: Bundle.main.bundleIdentifier ?? "io.sparktales.locus",
+        category: "Session Catalog"
+    )
+
+    @Published private(set) var snapshot = SessionCatalogSnapshot.empty
+
+    /// Deterministic structural metric used by tests. Timings stay advisory;
+    /// this counter is the CI gate for accidental rebuilds.
+#if DEBUG
+    private(set) var snapshotBuildCountForTesting = 0
+#endif
+
+    private var state = State()
+    private let fileExists: FileExists
+    private var persistenceEnabled = false
+    private var defaults: UserDefaults = .standard
+    private var searchQueryDidChange: (String) -> Void = { _ in }
+
+    init(fileExists: @escaping FileExists = { FileManager.default.fileExists(atPath: $0) }) {
+        self.fileExists = fileExists
+        rebuildSnapshot()
+    }
+
+    func configure(
+        persistenceEnabled: Bool,
+        defaults: UserDefaults = .standard,
+        searchQueryDidChange: @escaping (String) -> Void
+    ) {
+        self.persistenceEnabled = persistenceEnabled
+        self.defaults = defaults
+        self.searchQueryDidChange = searchQueryDidChange
+        guard persistenceEnabled else { return }
+        commit { state in
+            state.expandedWorkspaceIDs = Set(
+                defaults.stringArray(forKey: "Locus.expandedWorkspaces") ?? []
+            )
+            state.expandedChatFolderIDs = Set(
+                defaults.stringArray(forKey: "Locus.expandedChatFolders") ?? []
+            )
+        }
+    }
+
+    func replaceRemoteCatalog(
+        sessions: [SessionSummary],
+        chatFolders: [ChatFolderRecord]?
+    ) {
+        commit { state in
+            state.sessions = sessions
+            if let chatFolders { state.chatFolders = chatFolders }
+        }
+    }
+
+    func replaceSessions(_ sessions: [SessionSummary]) {
+        commit { $0.sessions = sessions }
+    }
+
+    func replaceChatFolders(_ folders: [ChatFolderRecord]) {
+        commit { $0.chatFolders = folders }
+    }
+
+    func replaceWorkspaceProfiles(_ profiles: [WorkspaceProfile]) {
+        commit { $0.workspaceProfiles = profiles }
+    }
+
+    func replaceExpandedWorkspaceIDs(_ ids: Set<String>) {
+        commit { $0.expandedWorkspaceIDs = ids }
+    }
+
+    func replaceExpandedChatFolderIDs(_ ids: Set<String>) {
+        commit { $0.expandedChatFolderIDs = ids }
+    }
+
+    func setActiveWorkspacePath(_ path: String) {
+        let canonical = path.isEmpty ? "" : SessionSummary.canonicalWorkspacePath(path)
+        commit { $0.activeWorkspaceID = canonical }
+    }
+
+    func setShowArchivedSessions(_ value: Bool) {
+        commit { $0.showArchivedSessions = value }
+    }
+
+    func setSearchQuery(_ value: String) {
+        let previous = state.searchQuery
+        commit { $0.searchQuery = value }
+        if value != previous { searchQueryDidChange(value) }
+    }
+
+    func requestSearchFocus() {
+        commit { $0.sidebarSearchFocusToken = UUID() }
+    }
+
+    func replaceSidebarSearchFocusToken(_ token: UUID) {
+        commit { $0.sidebarSearchFocusToken = token }
+    }
+
+    func setWorkspaceExpanded(_ id: String, expanded: Bool) {
+        let changed = commit { state in
+            if expanded {
+                state.expandedWorkspaceIDs.insert(id)
+            } else {
+                state.expandedWorkspaceIDs.remove(id)
+            }
+        }
+        if changed { persistExpansionState() }
+    }
+
+    func setChatFolderExpanded(_ id: String, expanded: Bool) {
+        let changed = commit { state in
+            if expanded {
+                state.expandedChatFolderIDs.insert(id)
+            } else {
+                state.expandedChatFolderIDs.remove(id)
+            }
+        }
+        if changed { persistExpansionState() }
+    }
+
+    func persistExpansionState() {
+        guard persistenceEnabled else { return }
+        defaults.set(
+            Array(state.expandedWorkspaceIDs).sorted(),
+            forKey: "Locus.expandedWorkspaces"
+        )
+        defaults.set(
+            Array(state.expandedChatFolderIDs).sorted(),
+            forKey: "Locus.expandedChatFolders"
+        )
+    }
+
+    @discardableResult
+    private func commit(_ update: (inout State) -> Void) -> Bool {
+        let previous = state
+        update(&state)
+        guard state != previous else { return false }
+        rebuildSnapshot()
+        return true
+    }
+
+    private func rebuildSnapshot() {
+        let signpostID = Self.signposter.makeSignpostID()
+        let interval = Self.signposter.beginInterval(
+            "Build Sidebar Snapshot",
+            id: signpostID,
+            "sessions=\(self.state.sessions.count) folders=\(self.state.chatFolders.count)"
+        )
+        defer { Self.signposter.endInterval("Build Sidebar Snapshot", interval) }
+
+#if DEBUG
+        snapshotBuildCountForTesting += 1
+#endif
+        snapshot = Self.makeSnapshot(state: state, fileExists: fileExists)
+    }
+
+    private static func makeSnapshot(
+        state: State,
+        fileExists: FileExists
+    ) -> SessionCatalogSnapshot {
+        let query = state.searchQuery
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let archiveFiltered = state.sessions
+            .filter { state.showArchivedSessions || !$0.isArchived }
+            .sorted(by: sessionSort)
+
+        let filteredSessions: [SessionSummary]
+        if query.isEmpty {
+            filteredSessions = archiveFiltered
+        } else {
+            let directlyMatchingFolders = Set(state.chatFolders.filter {
+                $0.name.lowercased().contains(query)
+            }.map(\.id))
+            var matchingFolderTree = directlyMatchingFolders
+            var changed = true
+            while changed {
+                changed = false
+                for folder in state.chatFolders
+                where folder.parentID.map(matchingFolderTree.contains) == true {
+                    if matchingFolderTree.insert(folder.id).inserted { changed = true }
+                }
+            }
+            filteredSessions = archiveFiltered.filter {
+                "\($0.displayTitle) \($0.name)".lowercased().contains(query)
+                    || $0.folderID.map(matchingFolderTree.contains) == true
+            }
+        }
+
+        let workspaceIDBySessionID = Dictionary(
+            state.sessions.compactMap { session in
+                session.workspacePath.map { (session.id, $0) }
+            },
+            uniquingKeysWith: { existing, _ in existing }
+        )
+        var chatsByPath = Dictionary(
+            grouping: filteredSessions.compactMap { session -> (String, SessionSummary)? in
+                guard let path = workspaceIDBySessionID[session.id] else { return nil }
+                return (path, session)
+            },
+            by: \.0
+        ).mapValues { $0.map(\.1) }
+
+        var profilesByPath: [String: WorkspaceProfile] = [:]
+        for profile in state.workspaceProfiles {
+            let path = SessionSummary.canonicalWorkspacePath(profile.path)
+            if let existing = profilesByPath[path], existing.lastOpened >= profile.lastOpened {
+                continue
+            }
+            profilesByPath[path] = profile
+        }
+        let foldersByID = Dictionary(
+            state.chatFolders.map { ($0.id, $0) },
+            uniquingKeysWith: { existing, _ in existing }
+        )
+        let foldersByWorkspaceID = Dictionary(
+            grouping: state.chatFolders,
+            by: { SessionSummary.canonicalWorkspacePath($0.workspace) }
+        ).mapValues { folders in
+            folders.sorted {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+        }
+        var folderMoveTargetsByFolderID: [String: [ChatFolderRecord]] = [:]
+        for folder in state.chatFolders {
+            let workspaceID = SessionSummary.canonicalWorkspacePath(folder.workspace)
+            folderMoveTargetsByFolderID[folder.id] = (foldersByWorkspaceID[workspaceID] ?? [])
+                .filter {
+                    canMoveFolder(folder, into: $0, foldersByID: foldersByID)
+                }
+        }
+        let availableExecutionSessionIDs: Set<String> = Set(
+            state.sessions.compactMap { session -> String? in
+                guard session.executionEnvironment == .worktree,
+                      let task = session.task,
+                      fileExists(task.executionPath)
+                else { return nil }
+                return session.id
+            }
+        )
+
+        var paths = Set(profilesByPath.keys)
+        paths.formUnion(chatsByPath.keys)
+        if !state.activeWorkspaceID.isEmpty { paths.insert(state.activeWorkspaceID) }
+
+        let availableWorkspaceIDs = Set(paths.filter(fileExists))
+        var sidebarGroups = paths.compactMap { path -> SessionSidebarGroupSnapshot? in
+            let chats = (chatsByPath.removeValue(forKey: path) ?? []).sorted(by: sessionSort)
+            let workspaceFolders = foldersByWorkspaceID[path] ?? []
+            let folderNameMatches = !query.isEmpty && workspaceFolders.contains {
+                $0.name.localizedCaseInsensitiveContains(query)
+            }
+            if !query.isEmpty && chats.isEmpty && !folderNameMatches { return nil }
+
+            let profile = profilesByPath[path]
+            let chatDate = chats.map(\.date).max() ?? .distantPast
+            let isAvailable = availableWorkspaceIDs.contains(path)
+            let group = WorkspaceChatGroup(
+                id: path,
+                path: path,
+                title: URL(fileURLWithPath: path).lastPathComponent,
+                chats: chats,
+                lastOpened: max(profile?.lastOpened ?? .distantPast, chatDate),
+                isAvailable: isAvailable,
+                isOther: false
+            )
+            return SessionSidebarGroupSnapshot(
+                group: group,
+                rootFolders: folderTree(
+                    folders: workspaceFolders,
+                    chats: chats,
+                    parentID: nil,
+                    query: query
+                ),
+                unfiledChats: sortedChats(chats.filter { $0.folderID == nil })
+            )
+        }
+        sidebarGroups.sort { lhs, rhs in
+            if lhs.id == state.activeWorkspaceID { return true }
+            if rhs.id == state.activeWorkspaceID { return false }
+            return lhs.group.lastOpened > rhs.group.lastOpened
+        }
+
+        let otherChats = filteredSessions
+            .filter { workspaceIDBySessionID[$0.id] == nil }
+            .sorted(by: sessionSort)
+        if !otherChats.isEmpty {
+            let group = WorkspaceChatGroup(
+                id: otherWorkspaceID,
+                path: nil,
+                title: "Other Chats",
+                chats: otherChats,
+                lastOpened: otherChats.map(\.date).max() ?? .distantPast,
+                isAvailable: true,
+                isOther: true
+            )
+            sidebarGroups.append(SessionSidebarGroupSnapshot(
+                group: group,
+                rootFolders: [],
+                unfiledChats: sortedChats(otherChats)
+            ))
+        }
+
+        let workspaceAvailabilityByProfileID = Dictionary(
+            state.workspaceProfiles.map { profile in
+                let workspaceID = SessionSummary.canonicalWorkspacePath(profile.path)
+                return (profile.id, availableWorkspaceIDs.contains(workspaceID))
+            },
+            uniquingKeysWith: { existing, _ in existing }
+        )
+        return SessionCatalogSnapshot(
+            sessions: state.sessions,
+            chatFolders: state.chatFolders,
+            workspaceProfiles: state.workspaceProfiles,
+            sessionsByID: Dictionary(
+                state.sessions.map { ($0.id, $0) },
+                uniquingKeysWith: { existing, _ in existing }
+            ),
+            foldersByID: foldersByID,
+            workspaceIDBySessionID: workspaceIDBySessionID,
+            foldersByWorkspaceID: foldersByWorkspaceID,
+            folderMoveTargetsByFolderID: folderMoveTargetsByFolderID,
+            recentWorkspaceProfiles: Array(
+                state.workspaceProfiles.sorted { $0.lastOpened > $1.lastOpened }.prefix(8)
+            ),
+            availableWorkspaceIDs: availableWorkspaceIDs,
+            workspaceAvailabilityByProfileID: workspaceAvailabilityByProfileID,
+            availableExecutionSessionIDs: availableExecutionSessionIDs,
+            filteredSessions: filteredSessions,
+            sidebarGroups: sidebarGroups,
+            activeWorkspaceID: state.activeWorkspaceID,
+            showArchivedSessions: state.showArchivedSessions,
+            searchQuery: state.searchQuery,
+            expandedWorkspaceIDs: state.expandedWorkspaceIDs,
+            expandedChatFolderIDs: state.expandedChatFolderIDs,
+            sidebarSearchFocusToken: state.sidebarSearchFocusToken
+        )
+    }
+
+    private static func folderTree(
+        folders: [ChatFolderRecord],
+        chats: [SessionSummary],
+        parentID: String?,
+        query: String
+    ) -> [SessionSidebarFolderSnapshot] {
+        folders
+            .filter { $0.parentID == parentID }
+            .sorted(by: folderSort)
+            .compactMap { folder in
+                let children = folderTree(
+                    folders: folders,
+                    chats: chats,
+                    parentID: folder.id,
+                    query: query
+                )
+                let folderChats = sortedChats(chats.filter { $0.folderID == folder.id })
+                guard query.isEmpty
+                        || folder.name.lowercased().contains(query)
+                        || !children.isEmpty
+                        || !folderChats.isEmpty
+                else { return nil }
+                return SessionSidebarFolderSnapshot(
+                    folder: folder,
+                    children: children,
+                    chats: folderChats
+                )
+            }
+    }
+
+    private static func sessionSort(_ lhs: SessionSummary, _ rhs: SessionSummary) -> Bool {
+        if lhs.isPinned != rhs.isPinned { return lhs.isPinned }
+        return lhs.mtime > rhs.mtime
+    }
+
+    private static func sortedChats(_ chats: [SessionSummary]) -> [SessionSummary] {
+        chats.sorted { lhs, rhs in
+            if lhs.isPinned != rhs.isPinned { return lhs.isPinned }
+            if lhs.sortOrder != rhs.sortOrder {
+                return (lhs.sortOrder ?? .max) < (rhs.sortOrder ?? .max)
+            }
+            return lhs.mtime > rhs.mtime
+        }
+    }
+
+    private static func folderSort(_ lhs: ChatFolderRecord, _ rhs: ChatFolderRecord) -> Bool {
+        if lhs.order != rhs.order { return lhs.order < rhs.order }
+        return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+    }
+
+    private static func canMoveFolder(
+        _ folder: ChatFolderRecord,
+        into target: ChatFolderRecord,
+        foldersByID: [String: ChatFolderRecord]
+    ) -> Bool {
+        guard folder.id != target.id,
+              SessionSummary.canonicalWorkspacePath(folder.workspace)
+                == SessionSummary.canonicalWorkspacePath(target.workspace)
+        else { return false }
+        var cursor: ChatFolderRecord? = target
+        var visited: Set<String> = []
+        while let current = cursor, visited.insert(current.id).inserted {
+            if current.id == folder.id { return false }
+            cursor = current.parentID.flatMap { foldersByID[$0] }
+        }
+        return true
+    }
+}

--- a/Locus/SessionSidebarView.swift
+++ b/Locus/SessionSidebarView.swift
@@ -11,6 +11,102 @@ private struct ChatFolderEditorRequest: Identifiable {
     var title: String { folder == nil ? "New Chat Folder" : "Rename Chat Folder" }
 }
 
+/// Cross-session transcript results observe their child model at the smallest
+/// owning boundary, so result updates do not invalidate the whole sidebar or AppModel.
+private struct TranscriptHitsSection: View {
+    let snapshot: SessionCatalogSnapshot
+    @ObservedObject var transcriptSearch: TranscriptSearchModel
+    let navigationDisabled: Bool
+    let onOpen: (TranscriptSearchHit) -> Void
+
+    @ViewBuilder
+    var body: some View {
+        let query = snapshot.searchQuery
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if query.count >= 2 {
+            SectionLabel("In conversations")
+                .padding(.top, 8)
+            if transcriptSearch.isSearchingTranscripts || transcriptSearch.transcriptSearchIndexing {
+                HStack(spacing: 7) {
+                    ProgressView()
+                        .controlSize(.mini)
+                    Text(transcriptSearch.transcriptSearchIndexing
+                        ? "Indexing conversations…" : "Searching…")
+                        .font(.locus(size: 9))
+                        .foregroundStyle(LocusTheme.muted)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, SidebarMetrics.rowInset)
+                .padding(.vertical, 6)
+                .accessibilityIdentifier("sidebar.search.progress")
+            }
+            if transcriptSearch.transcriptHits.isEmpty,
+               !transcriptSearch.isSearchingTranscripts,
+               !transcriptSearch.transcriptSearchIndexing {
+                Text("No matching messages")
+                    .font(.locus(size: 9))
+                    .foregroundStyle(LocusTheme.muted)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, SidebarMetrics.rowInset)
+                    .padding(.vertical, 6)
+            }
+            ForEach(transcriptSearch.transcriptHits) { hit in
+                transcriptHitRow(hit)
+            }
+        }
+    }
+
+    private func transcriptHitRow(_ hit: TranscriptSearchHit) -> some View {
+        Button { onOpen(hit) } label: {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 5) {
+                    Image(systemName: hit.role == "user" ? "person" : "sparkle")
+                        .font(.locus(size: 8))
+                        .foregroundStyle(LocusTheme.muted)
+                    Text(hit.title?.nilIfEmpty ?? "Untitled chat")
+                        .font(.locus(size: 9, weight: .semibold))
+                        .lineLimit(1)
+                    Spacer()
+                    Text(
+                        Date(timeIntervalSince1970: hit.mtime)
+                            .formatted(.relative(presentation: .named))
+                    )
+                    .font(.locus(size: 7))
+                    .foregroundStyle(LocusTheme.muted)
+                }
+                Text(highlightedSnippet(hit))
+                    .font(.locus(size: 9))
+                    .foregroundStyle(LocusTheme.muted)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+            .padding(.horizontal, SidebarMetrics.rowInset)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.white.opacity(0.001))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.locus())
+        .disabled(navigationDisabled)
+        .accessibilityIdentifier("sidebar.hit.\(hit.id)")
+    }
+
+    private func highlightedSnippet(_ hit: TranscriptSearchHit) -> AttributedString {
+        var text = AttributedString(hit.snippet)
+        for highlight in hit.highlights {
+            // Offsets are Unicode scalars (Python str positions); the hit
+            // converts them on the string, then the range maps across.
+            guard let stringRange = hit.stringRange(of: highlight),
+                  let range = Range(stringRange, in: text)
+            else { continue }
+            text[range].font = .system(size: 9, weight: .bold)
+            text[range].foregroundColor = LocusTheme.signalDeep
+        }
+        return text
+    }
+}
+
 /// The sidebar's shared rail. Every leading glyph — plus, magnifying glass,
 /// bell, and the nav rows above them — is drawn in a fixed-width column at
 /// the same inset, so they line up down the edge whatever each symbol's own
@@ -35,6 +131,7 @@ enum SidebarIconMetrics {
 
 struct SessionSidebarView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var sessionCatalog: SessionCatalogModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var sessionToRename: SessionSummary?
     @State private var renameText = ""
@@ -46,30 +143,32 @@ struct SessionSidebarView: View {
     @FocusState private var searchFocused: Bool
 
     var body: some View {
+        let snapshot = sessionCatalog.snapshot
         VStack(spacing: 0) {
             header
             controls
 
             ScrollView {
                 LazyVStack(spacing: 2) {
-                    workspacesHeader
+                    workspacesHeader(snapshot: snapshot)
                     if searchExpanded {
-                        searchField
+                        searchField(snapshot: snapshot)
                             .transition(LocusMotion.transition(edge: .top, reduceMotion: reduceMotion))
                     }
-                    if model.workspaceChatGroups.isEmpty {
-                        emptyState
+                    if snapshot.sidebarGroups.isEmpty {
+                        emptyState(snapshot: snapshot)
                     } else {
-                        ForEach(model.workspaceChatGroups) { group in
+                        ForEach(snapshot.sidebarGroups) { sidebarGroup in
+                            let group = sidebarGroup.group
                             WorkspaceGroupRow(
                                 group: group,
-                                expanded: model.isWorkspaceExpanded(group.id),
-                                active: group.id == model.activeWorkspaceID,
+                                expanded: snapshot.expandedWorkspaceIDs.contains(group.id),
+                                active: group.id == snapshot.activeWorkspaceID,
                                 actionsDisabled: model.chatNavigationDisabled,
                                 onToggle: {
                                     model.setWorkspaceExpanded(
                                         group.id,
-                                        expanded: !model.isWorkspaceExpanded(group.id)
+                                        expanded: !snapshot.expandedWorkspaceIDs.contains(group.id)
                                     )
                                 },
                                 onOpen: { model.openWorkspace(group) },
@@ -88,7 +187,7 @@ struct SessionSidebarView: View {
                                         requestWorkspaceRemoval(group)
                                     }
                                     .disabled(
-                                        group.id == model.activeWorkspaceID
+                                        group.id == snapshot.activeWorkspaceID
                                             || model.workspaceHasActiveRun(group)
                                     )
                                     .accessibilityIdentifier("workspace.group.\(group.id).remove")
@@ -99,8 +198,8 @@ struct SessionSidebarView: View {
                                 index: nil,
                                 targetWorkspace: group.path
                             ))
-                            if model.isWorkspaceExpanded(group.id) {
-                                if group.chats.isEmpty && model.folders(in: group).isEmpty {
+                            if snapshot.expandedWorkspaceIDs.contains(group.id) {
+                                if group.chats.isEmpty && sidebarGroup.rootFolders.isEmpty {
                                     Text("No chats yet")
                                         .font(.locus(size: 9))
                                         .foregroundStyle(LocusTheme.muted)
@@ -108,10 +207,9 @@ struct SessionSidebarView: View {
                                         .padding(.leading, 42)
                                         .padding(.vertical, 7)
                                 } else {
-                                    ForEach(model.folders(in: group)) { folder in
+                                    ForEach(sidebarGroup.rootFolders) { folderNode in
                                         ChatFolderBranchView(
-                                            group: group,
-                                            folder: folder,
+                                            node: folderNode,
                                             depth: 0,
                                             onCreateFolder: { workspace, parentID in
                                                 requestFolderEditor(
@@ -128,20 +226,25 @@ struct SessionSidebarView: View {
                                             },
                                             onDeleteFolder: { folderToDelete = $0 },
                                             sessionContent: { session in
-                                                AnyView(sessionRow(session))
+                                                AnyView(sessionRow(session, snapshot: snapshot))
                                             }
                                         )
                                         .environmentObject(model)
                                     }
-                                    ForEach(model.chats(in: group, folderID: nil)) { session in
-                                        sessionRow(session)
+                                    ForEach(sidebarGroup.unfiledChats) { session in
+                                        sessionRow(session, snapshot: snapshot)
                                             .padding(.leading, 18)
                                     }
                                 }
                             }
                         }
                     }
-                    transcriptHitsSection
+                    TranscriptHitsSection(
+                        snapshot: snapshot,
+                        transcriptSearch: model.transcriptSearch,
+                        navigationDisabled: model.chatNavigationDisabled,
+                        onOpen: model.openSearchHit
+                    )
                 }
                 .accessibilityElement(children: .contain)
                 .accessibilityLabel("Workspaces and chats")
@@ -150,7 +253,7 @@ struct SessionSidebarView: View {
             }
             .frame(maxHeight: .infinity)
 
-            footer
+            footer(snapshot: snapshot)
         }
         .frame(maxHeight: .infinity)
         .locusSurface(.structural)
@@ -166,7 +269,7 @@ struct SessionSidebarView: View {
                 // column boundary should meet the top of the window chrome.
                 .ignoresSafeArea(.container, edges: .top)
         }
-        .onChange(of: model.sidebarSearchFocusToken) {
+        .onChange(of: snapshot.sidebarSearchFocusToken) {
             withAnimation(LocusMotion.spatial) { searchExpanded = true }
             // The field is created by this same update, so focus has to wait
             // one main-actor turn for it to exist.
@@ -495,12 +598,14 @@ struct SessionSidebarView: View {
 
     /// Search is a section control now: the glyph beside WORKSPACES reveals
     /// the field, so an unused search box no longer occupies the sidebar.
-    private var workspacesHeader: some View {
+    private func workspacesHeader(snapshot: SessionCatalogSnapshot) -> some View {
         HStack(spacing: 0) {
-            SectionLabel(model.showArchivedSessions ? "All Workspaces" : "Workspaces")
+            SectionLabel(
+                snapshot.showArchivedSessions ? "All Workspaces" : "Workspaces"
+            )
             Button {
                 withAnimation(LocusMotion.spatial) {
-                    if searchExpanded, model.searchQuery.isEmpty {
+                    if searchExpanded, snapshot.searchQuery.isEmpty {
                         searchExpanded = false
                     } else {
                         searchExpanded = true
@@ -520,7 +625,10 @@ struct SessionSidebarView: View {
             .accessibilityValue(searchExpanded ? "Shown" : "Hidden")
             .accessibilityIdentifier("sidebar.search.toggle")
             Button {
-                requestFolderEditor(workspace: model.activeWorkspaceID, parentID: nil)
+                requestFolderEditor(
+                    workspace: snapshot.activeWorkspaceID,
+                    parentID: nil
+                )
             } label: {
                 Image(systemName: "folder.badge.plus")
                     .font(.locus(size: 10, weight: .semibold))
@@ -536,19 +644,22 @@ struct SessionSidebarView: View {
         .padding(.trailing, 6)
     }
 
-    private var searchField: some View {
+    private func searchField(snapshot: SessionCatalogSnapshot) -> some View {
         HStack(spacing: SidebarMetrics.iconGap) {
             Image(systemName: "magnifyingglass")
                 .font(.locus(size: 11, weight: .medium))
                 .frame(width: SidebarMetrics.iconColumn)
                 .foregroundStyle(LocusTheme.muted)
-            TextField("Search sessions", text: $model.searchQuery)
+            TextField("Search sessions", text: Binding(
+                get: { snapshot.searchQuery },
+                set: { sessionCatalog.setSearchQuery($0) }
+            ))
                 .textFieldStyle(.plain)
                 .font(.locus(size: 11))
                 .focused($searchFocused)
-            if !model.searchQuery.isEmpty {
+            if !snapshot.searchQuery.isEmpty {
                 Button {
-                    model.searchQuery = ""
+                    sessionCatalog.setSearchQuery("")
                     searchFocused = true
                 } label: {
                     Image(systemName: "xmark.circle.fill")
@@ -571,14 +682,17 @@ struct SessionSidebarView: View {
         .padding(.bottom, 4)
         // Escape leaves the way it arrived: empty query, field put away.
         .onExitCommand {
-            model.searchQuery = ""
+            sessionCatalog.setSearchQuery("")
             withAnimation(LocusMotion.spatial) { searchExpanded = false }
         }
         .accessibilityIdentifier("sidebar.search")
     }
 
     @ViewBuilder
-    private func sessionRow(_ session: SessionSummary) -> some View {
+    private func sessionRow(
+        _ session: SessionSummary,
+        snapshot: SessionCatalogSnapshot
+    ) -> some View {
         SessionRow(
             session: session,
             isActive: session.id == model.currentSessionID,
@@ -614,24 +728,19 @@ struct SessionSidebarView: View {
                 }
                 .disabled(
                     session.isArchived || model.chatHasActiveRun(session)
-                        || session.task.map {
-                            !FileManager.default.fileExists(atPath: $0.executionPath)
-                        } ?? true
+                        || !snapshot.availableExecutionSessionIDs.contains(session.id)
                 )
                 .accessibilityIdentifier("session.\(session.id).duplicateWorktree")
             }
             Menu("Move to Folder") {
                 Button("Workspace Root") { model.moveChat(session, to: nil) }
                     .disabled(session.folderID == nil)
-                let workspace = session.workspacePath
-                ForEach(
-                    model.chatFolders.filter {
-                        SessionSummary.canonicalWorkspacePath($0.workspace) == workspace
-                    }.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                ) { folder in
+                let workspace = snapshot.workspaceIDBySessionID[session.id]
+                let folderTargets = workspace.flatMap { snapshot.foldersByWorkspaceID[$0] } ?? []
+                ForEach(folderTargets) { folder in
                     Button(folder.name) { model.moveChat(session, to: folder.id) }
                         .disabled(session.folderID == folder.id)
-                    }
+                }
             }
             Button("Move Earlier") { model.reorderChat(session, offset: -1) }
                 .accessibilityIdentifier("session.\(session.id).moveEarlier")
@@ -653,8 +762,8 @@ struct SessionSidebarView: View {
                 session.id == model.currentSessionID || model.chatHasActiveRun(session)
             )
             .accessibilityIdentifier("session.\(session.id).archive")
-            if let task = session.task,
-               !FileManager.default.fileExists(atPath: task.executionPath) {
+            if session.task != nil,
+               !snapshot.availableExecutionSessionIDs.contains(session.id) {
                 Button("Restore Worktree") { model.restoreWorktree(for: session) }
                     .accessibilityIdentifier("session.\(session.id).restoreWorktree")
             }
@@ -673,7 +782,7 @@ struct SessionSidebarView: View {
         .modifier(ChatSidebarDropTarget(
             targetFolderID: session.folderID,
             index: session.sortOrder,
-            targetWorkspace: session.workspacePath
+            targetWorkspace: snapshot.workspaceIDBySessionID[session.id]
         ))
         .accessibilityAction(named: "Move Earlier") {
             model.reorderChat(session, offset: -1)
@@ -683,103 +792,15 @@ struct SessionSidebarView: View {
         }
     }
 
-    /// Cross-session transcript hits under the title matches. Rendered only
-    /// while the search has enough characters to have queried the index.
-    @ViewBuilder
-    private var transcriptHitsSection: some View {
-        let query = model.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        if query.count >= 2 {
-            SectionLabel("In conversations")
-                .padding(.top, 8)
-            if model.transcriptSearch.isSearchingTranscripts || model.transcriptSearch.transcriptSearchIndexing {
-                HStack(spacing: 7) {
-                    ProgressView()
-                        .controlSize(.mini)
-                    Text(model.transcriptSearch.transcriptSearchIndexing
-                        ? "Indexing conversations…" : "Searching…")
-                        .font(.locus(size: 9))
-                        .foregroundStyle(LocusTheme.muted)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, SidebarMetrics.rowInset)
-                .padding(.vertical, 6)
-                .accessibilityIdentifier("sidebar.search.progress")
-            }
-            if model.transcriptSearch.transcriptHits.isEmpty,
-               !model.transcriptSearch.isSearchingTranscripts, !model.transcriptSearch.transcriptSearchIndexing {
-                Text("No matching messages")
-                    .font(.locus(size: 9))
-                    .foregroundStyle(LocusTheme.muted)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, SidebarMetrics.rowInset)
-                    .padding(.vertical, 6)
-            }
-            ForEach(model.transcriptSearch.transcriptHits) { hit in
-                transcriptHitRow(hit)
-            }
-        }
-    }
-
-    private func transcriptHitRow(_ hit: TranscriptSearchHit) -> some View {
-        Button {
-            model.openSearchHit(hit)
-        } label: {
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 5) {
-                    Image(systemName: hit.role == "user" ? "person" : "sparkle")
-                        .font(.locus(size: 8))
-                        .foregroundStyle(LocusTheme.muted)
-                    Text(hit.title?.nilIfEmpty ?? "Untitled chat")
-                        .font(.locus(size: 9, weight: .semibold))
-                        .lineLimit(1)
-                    Spacer()
-                    Text(
-                        Date(timeIntervalSince1970: hit.mtime)
-                            .formatted(.relative(presentation: .named))
-                    )
-                    .font(.locus(size: 7))
-                    .foregroundStyle(LocusTheme.muted)
-                }
-                Text(highlightedSnippet(hit))
-                    .font(.locus(size: 9))
-                    .foregroundStyle(LocusTheme.muted)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
-            }
-            .padding(.horizontal, SidebarMetrics.rowInset)
-            .padding(.vertical, 6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.white.opacity(0.001))
-            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.locus())
-        .disabled(model.chatNavigationDisabled)
-        .accessibilityIdentifier("sidebar.hit.\(hit.id)")
-    }
-
-    private func highlightedSnippet(_ hit: TranscriptSearchHit) -> AttributedString {
-        var text = AttributedString(hit.snippet)
-        for highlight in hit.highlights {
-            // Offsets are Unicode scalars (Python str positions); the hit
-            // converts them on the string, then the range maps across.
-            guard let stringRange = hit.stringRange(of: highlight),
-                  let range = Range(stringRange, in: text)
-            else { continue }
-            text[range].font = .system(size: 9, weight: .bold)
-            text[range].foregroundColor = LocusTheme.signalDeep
-        }
-        return text
-    }
-
-    private var emptyState: some View {
+    private func emptyState(snapshot: SessionCatalogSnapshot) -> some View {
         VStack(spacing: 9) {
             Image(systemName: "bubble.left")
                 .font(.locus(size: 18))
                 .foregroundStyle(LocusTheme.muted)
-            Text(model.searchQuery.isEmpty ? "No saved sessions yet" : "No matching sessions")
+            Text(snapshot.searchQuery.isEmpty
+                ? "No saved sessions yet" : "No matching sessions")
                 .font(.locus(size: 10, weight: .semibold))
-            if model.searchQuery.isEmpty {
+            if snapshot.searchQuery.isEmpty {
                 Text("Start a conversation and it will appear here.")
                     .font(.locus(size: 9))
                     .foregroundStyle(LocusTheme.muted)
@@ -796,14 +817,14 @@ struct SessionSidebarView: View {
     /// The service indicators live with the composer, where they remain fixed
     /// as panels resize. The sidebar footer only owns workspace and app-wide
     /// controls now.
-    private var footer: some View {
+    private func footer(snapshot: SessionCatalogSnapshot) -> some View {
         VStack(spacing: 8) {
-            workspaceMenu
+            workspaceMenu(snapshot: snapshot)
 
             HStack {
                 agentStatus
                 Spacer()
-                settingsMenu
+                settingsMenu(snapshot: snapshot)
             }
         }
         .padding(.horizontal, SidebarMetrics.gutter)
@@ -814,7 +835,7 @@ struct SessionSidebarView: View {
         }
     }
 
-    private var settingsMenu: some View {
+    private func settingsMenu(snapshot: SessionCatalogSnapshot) -> some View {
         Menu {
             Button("Settings…") { model.presentSettings() }
                 .accessibilityIdentifier("sidebar.settings")
@@ -826,9 +847,11 @@ struct SessionSidebarView: View {
                 .accessibilityIdentifier("sidebar.notebook")
             Divider()
             Button("Archived Sessions") {
-                model.setShowArchived(!model.showArchivedSessions)
+                model.setShowArchived(!snapshot.showArchivedSessions)
             }
-            .accessibilityValue(model.showArchivedSessions ? "Shown" : "Hidden")
+            .accessibilityValue(
+                snapshot.showArchivedSessions ? "Shown" : "Hidden"
+            )
             .accessibilityIdentifier("sidebar.showArchived")
             Button(model.isClearingSessions ? "Clearing Saved Sessions…" : "Clear Saved Sessions…") {
                 model.requestClearSavedSessions()
@@ -855,31 +878,37 @@ struct SessionSidebarView: View {
         .accessibilityIdentifier("sidebar.more")
     }
 
-    private var workspaceMenu: some View {
+    private func workspaceMenu(snapshot: SessionCatalogSnapshot) -> some View {
         Menu {
             Button("Choose Workspace…") { model.chooseWorkspace() }
             Button("New Workspace…") { model.createWorkspace() }
                 .accessibilityIdentifier("workspace.new")
             Button("Reveal in Finder") { model.openWorkspaceInFinder() }
-            if !model.recentWorkspaceProfiles.isEmpty {
+            if !snapshot.recentWorkspaceProfiles.isEmpty {
                 Divider()
                 Section("Recent Workspaces") {
-                    ForEach(model.recentWorkspaceProfiles) { profile in
+                    ForEach(snapshot.recentWorkspaceProfiles) { profile in
+                        let isAvailable = snapshot.workspaceAvailabilityByProfileID[profile.id]
+                            == true
                         Button {
                             model.switchWorkspace(to: profile.path)
                         } label: {
                             Label(
                                 profile.displayName,
-                                systemImage: profile.isAvailable ? "folder" : "exclamationmark.triangle"
+                                systemImage: isAvailable ? "folder" : "exclamationmark.triangle"
                             )
                         }
-                        .disabled(!profile.isAvailable)
+                        .disabled(!isAvailable)
                         .accessibilityIdentifier("workspace.profile.\(profile.path)")
                     }
                 }
-                if model.recentWorkspaceProfiles.contains(where: { !$0.isAvailable }) {
+                if snapshot.recentWorkspaceProfiles.contains(where: {
+                    snapshot.workspaceAvailabilityByProfileID[$0.id] != true
+                }) {
                     Button("Remove Missing Entries") {
-                        for profile in model.recentWorkspaceProfiles where !profile.isAvailable {
+                        for profile in snapshot.recentWorkspaceProfiles where
+                            snapshot.workspaceAvailabilityByProfileID[profile.id] != true
+                        {
                             model.removeWorkspaceProfile(profile.path)
                         }
                     }
@@ -1425,9 +1454,9 @@ private struct ChatSidebarDropTarget: ViewModifier {
 
 private struct ChatFolderBranchView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var sessionCatalog: SessionCatalogModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    let group: WorkspaceChatGroup
-    let folder: ChatFolderRecord
+    let node: SessionSidebarFolderSnapshot
     let depth: Int
     let onCreateFolder: (String, String?) -> Void
     let onRenameFolder: (ChatFolderRecord) -> Void
@@ -1436,12 +1465,13 @@ private struct ChatFolderBranchView: View {
     @State private var isDropTarget = false
     @State private var hoverExpansion: Task<Void, Never>?
 
-    private var expanded: Bool {
-        !model.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            || model.isChatFolderExpanded(folder.id)
-    }
+    private var folder: ChatFolderRecord { node.folder }
 
     var body: some View {
+        let snapshot = sessionCatalog.snapshot
+        let expanded = !snapshot.searchQuery
+            .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || snapshot.expandedChatFolderIDs.contains(folder.id)
         VStack(spacing: 2) {
             Button {
                 withAnimation(reduceMotion ? nil : LocusMotion.spatial) {
@@ -1459,7 +1489,7 @@ private struct ChatFolderBranchView: View {
                         .font(.locus(size: 10, weight: .semibold))
                         .lineLimit(1)
                     Spacer(minLength: 4)
-                    Text("\(model.chats(in: group, folderID: folder.id).count)")
+                    Text("\(node.chats.count)")
                         .font(.locus(size: 8, design: .monospaced))
                         .foregroundStyle(LocusTheme.muted)
                 }
@@ -1478,11 +1508,7 @@ private struct ChatFolderBranchView: View {
                 Menu("Move to Folder") {
                     Button("Workspace Root") { model.moveChatFolder(folder, to: nil) }
                         .disabled(folder.parentID == nil)
-                    ForEach(model.chatFolders.filter {
-                        model.canMoveChatFolder(folder, into: $0)
-                    }.sorted {
-                        $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-                    }) { target in
+                    ForEach(snapshot.folderMoveTargetsByFolderID[folder.id] ?? []) { target in
                         Button(target.name) { model.moveChatFolder(folder, to: target.id) }
                             .disabled(folder.parentID == target.id)
                     }
@@ -1535,10 +1561,9 @@ private struct ChatFolderBranchView: View {
             }
 
             if expanded {
-                ForEach(model.folders(in: group, parentID: folder.id)) { child in
+                ForEach(node.children) { child in
                     ChatFolderBranchView(
-                        group: group,
-                        folder: child,
+                        node: child,
                         depth: depth + 1,
                         onCreateFolder: onCreateFolder,
                         onRenameFolder: onRenameFolder,
@@ -1547,7 +1572,7 @@ private struct ChatFolderBranchView: View {
                     )
                     .environmentObject(model)
                 }
-                ForEach(model.chats(in: group, folderID: folder.id)) { session in
+                ForEach(node.chats) { session in
                     sessionContent(session)
                         .padding(.leading, 32 + CGFloat(depth) * 14)
                 }

--- a/Locus/TranscriptPresentationModel.swift
+++ b/Locus/TranscriptPresentationModel.swift
@@ -1,0 +1,140 @@
+import Combine
+import Foundation
+import os
+
+struct TranscriptPresentationSnapshot: Equatable {
+    let blocks: [ChatBlock]
+    let blocksByID: [UUID: ChatBlock]
+    let items: [TranscriptPresentationItem]
+    let assistantMarkerItemIDs: Set<TranscriptPresentationItem.ID>
+    let assistantActionItemIDs: Set<TranscriptPresentationItem.ID>
+    let toolActivityVisibility: ToolActivityVisibility
+    let thinkingVisibility: ThinkingVisibility
+    let hasPendingPermission: Bool
+
+    var isEmpty: Bool { blocks.isEmpty }
+
+    static let empty = TranscriptPresentationSnapshot(
+        blocks: [],
+        blocksByID: [:],
+        items: [],
+        assistantMarkerItemIDs: [],
+        assistantActionItemIDs: [],
+        toolActivityVisibility: .collapsed,
+        thinkingVisibility: .collapsed,
+        hasPendingPermission: false
+    )
+}
+
+/// Authoritative transcript input and its immutable presentation projection.
+/// Construction happens only at explicit commit points, never while SwiftUI
+/// evaluates a body because some unrelated AppModel property changed.
+@MainActor
+final class TranscriptPresentationModel: ObservableObject {
+    private struct State: Equatable {
+        var blocks: [ChatBlock] = []
+        var toolActivityVisibility = ToolActivityVisibility.collapsed
+        var thinkingVisibility = ThinkingVisibility.collapsed
+    }
+
+    private static let signposter = OSSignposter(
+        subsystem: Bundle.main.bundleIdentifier ?? "io.sparktales.locus",
+        category: "Transcript Presentation"
+    )
+
+    @Published private(set) var snapshot = TranscriptPresentationSnapshot.empty
+
+    /// Deterministic structural metric used by tests. Timings stay advisory;
+    /// this counter is the CI gate for accidental reconstruction.
+#if DEBUG
+    private(set) var snapshotBuildCountForTesting = 0
+#endif
+
+    private var state = State()
+    private var pendingPermissionDidChange: (Bool) -> Void = { _ in }
+
+    init() {
+        rebuildSnapshot()
+    }
+
+    func configure(
+        toolActivityVisibility: ToolActivityVisibility,
+        thinkingVisibility: ThinkingVisibility,
+        pendingPermissionDidChange: @escaping (Bool) -> Void
+    ) {
+        self.pendingPermissionDidChange = pendingPermissionDidChange
+        setPresentationVisibility(
+            toolActivity: toolActivityVisibility,
+            thinking: thinkingVisibility
+        )
+    }
+
+    func replaceBlocks(_ blocks: [ChatBlock]) {
+        commit { $0.blocks = blocks }
+    }
+
+    func updateBlocks(_ update: (inout [ChatBlock]) -> Void) {
+        commit { state in update(&state.blocks) }
+    }
+
+    func setPresentationVisibility(
+        toolActivity: ToolActivityVisibility,
+        thinking: ThinkingVisibility
+    ) {
+        commit { state in
+            state.toolActivityVisibility = toolActivity
+            state.thinkingVisibility = thinking
+        }
+    }
+
+    @discardableResult
+    private func commit(_ update: (inout State) -> Void) -> Bool {
+        let previous = state
+        update(&state)
+        guard state != previous else { return false }
+        rebuildSnapshot()
+        return true
+    }
+
+    private func rebuildSnapshot() {
+        let signpostID = Self.signposter.makeSignpostID()
+        let interval = Self.signposter.beginInterval(
+            "Build Transcript Snapshot",
+            id: signpostID,
+            "blocks=\(self.state.blocks.count)"
+        )
+        defer { Self.signposter.endInterval("Build Transcript Snapshot", interval) }
+
+#if DEBUG
+        snapshotBuildCountForTesting += 1
+#endif
+        let previousPendingPermission = snapshot.hasPendingPermission
+        snapshot = Self.makeSnapshot(state: state)
+        if snapshot.hasPendingPermission != previousPendingPermission {
+            pendingPermissionDidChange(snapshot.hasPendingPermission)
+        }
+    }
+
+    private static func makeSnapshot(state: State) -> TranscriptPresentationSnapshot {
+        let items = state.blocks.isEmpty ? [] : TranscriptPresentation.items(
+            from: state.blocks,
+            toolVisibility: state.toolActivityVisibility,
+            thinkingVisibility: state.thinkingVisibility
+        )
+        return TranscriptPresentationSnapshot(
+            blocks: state.blocks,
+            blocksByID: Dictionary(
+                state.blocks.map { ($0.id, $0) },
+                uniquingKeysWith: { existing, _ in existing }
+            ),
+            items: items,
+            assistantMarkerItemIDs: TranscriptPresentation.assistantMarkerItemIDs(in: items),
+            assistantActionItemIDs: TranscriptPresentation.assistantActionItemIDs(in: items),
+            toolActivityVisibility: state.toolActivityVisibility,
+            thinkingVisibility: state.thinkingVisibility,
+            hasPendingPermission: state.blocks.contains {
+                $0.tool?.status == .awaitingPermission
+            }
+        )
+    }
+}

--- a/Locus/TranscriptSearchModel.swift
+++ b/Locus/TranscriptSearchModel.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Owns the cross-session transcript search: the debounced FTS request and
 /// its hits/indexing state. Opening a hit stays with AppModel — it resumes
 /// sessions and drives the in-conversation find bar. AppModel wires it via
-/// configure(...) and bridges its publication; it never retains AppModel.
+/// configure(...); the sidebar observes this model directly.
 @MainActor
 final class TranscriptSearchModel: ObservableObject {
     @Published var transcriptHits: [TranscriptSearchHit] = []

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -7,15 +7,9 @@ struct WorkspaceView: View {
     @EnvironmentObject private var model: AppModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var modelPickerPresented = false
-    @State private var effortPickerPresented = false
     @State private var teamProgressPresented = false
     let sidebarVisible: Bool
     let showSidebar: () -> Void
-
-    private var sessionTitle: String {
-        model.sessions.first(where: { $0.id == model.currentSessionID })?.displayTitle
-            ?? (model.blocks.isEmpty ? "New session" : "Active session")
-    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -99,10 +93,9 @@ struct WorkspaceView: View {
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(sessionTitle)
-                    .font(.locus(size: 13, weight: .bold))
-                    .lineLimit(1)
-                    .accessibilityIdentifier("workspace.sessionTitle")
+                WorkspaceSessionTitle(
+                    sessionID: model.currentSessionID
+                )
 
                 HStack(spacing: 5) {
                     Image(systemName: "folder.fill")
@@ -182,7 +175,8 @@ struct WorkspaceView: View {
             }
 
             if !model.reasoningEffortOptions.isEmpty {
-                effortPicker
+                WorkspaceEffortPicker()
+                    .environmentObject(model)
             }
 
             Button {
@@ -238,104 +232,6 @@ struct WorkspaceView: View {
         .overlay(alignment: .bottom) {
             Rectangle().fill(LocusTheme.line).frame(height: 1)
         }
-    }
-
-    /// How hard the current model should think, beside the model it applies to.
-    ///
-    /// Only rendered when the route advertises efforts at all — most models
-    /// take no effort parameter, and a disabled control for them would be
-    /// permanent dead chrome for anyone on a local model.
-    private var effortPicker: some View {
-        Button {
-            effortPickerPresented.toggle()
-        } label: {
-            HStack(spacing: 5) {
-                Image(systemName: "gauge.with.dots.needle.33percent")
-                    .font(.locus(size: 9, weight: .semibold))
-                    .foregroundStyle(LocusTheme.muted)
-                Text(effortLabel)
-                    .font(.locus(size: 9, weight: .semibold))
-                    .lineLimit(1)
-                Image(systemName: "chevron.down")
-                    .font(.locus(size: 8, weight: .semibold))
-                    .foregroundStyle(LocusTheme.muted)
-            }
-            .padding(.horizontal, 9)
-            .frame(height: 28)
-            .background(LocusTheme.white.opacity(0.78))
-            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    .stroke(LocusTheme.line, lineWidth: 1)
-            }
-        }
-        .buttonStyle(.locus())
-        .help("Reasoning effort · \(effortLabel)")
-        .accessibilityLabel("Reasoning effort, \(effortLabel)")
-        .accessibilityIdentifier("workspace.effortPicker")
-        .frame(height: 28)
-        .popover(isPresented: $effortPickerPresented, arrowEdge: .top) {
-            effortPopover
-        }
-    }
-
-    /// "Auto" rather than "Default": the closed chip has no room to say what
-    /// the default is, and Auto reads as a choice the model makes.
-    private var effortLabel: String {
-        let effort = model.resolvedReasoningEffort
-        return effort.isEmpty ? "Auto" : effort.capitalized
-    }
-
-    private var effortPopover: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Reasoning effort")
-                .font(.locus(size: 10, weight: .bold))
-
-            effortRow(effort: "", title: "Auto")
-            ForEach(model.reasoningEffortOptions, id: \.self) { effort in
-                effortRow(effort: effort, title: effort.capitalized)
-            }
-
-            Divider().overlay(LocusTheme.line)
-
-            Text(
-                "Applies to this workspace and takes effect on the next message. "
-                + "Higher efforts think longer and cost more."
-            )
-            .font(.locus(size: 8))
-            .foregroundStyle(LocusTheme.muted)
-            .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(10)
-        .frame(width: 240)
-        .background(LocusTheme.white)
-        .accessibilityIdentifier("workspace.effortPicker.popover")
-    }
-
-    private func effortRow(effort: String, title: String) -> some View {
-        let selected = model.resolvedReasoningEffort == effort
-        return Button {
-            model.setReasoningEffort(effort)
-            effortPickerPresented = false
-        } label: {
-            HStack(spacing: 8) {
-                Text(title)
-                Spacer(minLength: 12)
-                if selected {
-                    Image(systemName: "checkmark")
-                        .font(.locus(size: 8, weight: .bold))
-                }
-            }
-            .font(.locus(size: 9, weight: .semibold))
-            .foregroundStyle(LocusTheme.inkSoft)
-            .padding(.horizontal, 8)
-            .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
-            .background(selected ? LocusTheme.paperDeep : Color.clear)
-            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.locus())
-        .accessibilityIdentifier("workspace.effortPicker.\(effort.isEmpty ? "auto" : effort)")
     }
 
     private var shouldShowWorkStatus: Bool {
@@ -424,6 +320,135 @@ struct WorkspaceView: View {
     }
 }
 
+private struct WorkspaceSessionTitle: View {
+    @EnvironmentObject private var sessionCatalog: SessionCatalogModel
+    @EnvironmentObject private var transcriptPresentation: TranscriptPresentationModel
+    let sessionID: String
+
+    var body: some View {
+        Text(
+            sessionCatalog.snapshot.sessionsByID[sessionID]?.displayTitle
+                ?? (transcriptPresentation.snapshot.isEmpty ? "New session" : "Active session")
+        )
+        .font(.locus(size: 13, weight: .bold))
+        .lineLimit(1)
+        .accessibilityIdentifier("workspace.sessionTitle")
+    }
+}
+
+/// Keeps workspace-profile publications scoped to the one header control that
+/// needs them instead of invalidating the full conversation workspace.
+private struct WorkspaceEffortPicker: View {
+    @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var sessionCatalog: SessionCatalogModel
+    @State private var isPresented = false
+
+    var body: some View {
+        let effort = resolvedEffort
+        let label = effort.isEmpty ? "Auto" : effort.capitalized
+        Button {
+            isPresented.toggle()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "gauge.with.dots.needle.33percent")
+                    .font(.locus(size: 9, weight: .semibold))
+                    .foregroundStyle(LocusTheme.muted)
+                Text(label)
+                    .font(.locus(size: 9, weight: .semibold))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.locus(size: 8, weight: .semibold))
+                    .foregroundStyle(LocusTheme.muted)
+            }
+            .padding(.horizontal, 9)
+            .frame(height: 28)
+            .background(LocusTheme.white.opacity(0.78))
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .stroke(LocusTheme.line, lineWidth: 1)
+            }
+        }
+        .buttonStyle(.locus())
+        .help("Reasoning effort · \(label)")
+        .accessibilityLabel("Reasoning effort, \(label)")
+        .accessibilityIdentifier("workspace.effortPicker")
+        .frame(height: 28)
+        .popover(isPresented: $isPresented, arrowEdge: .top) {
+            effortPopover(selectedEffort: effort)
+        }
+    }
+
+    private var resolvedEffort: String {
+        let path = SessionSummary.canonicalWorkspacePath(model.workspacePath)
+        if let workspaceEffort = sessionCatalog.snapshot.workspaceProfiles.first(where: {
+            SessionSummary.canonicalWorkspacePath($0.path) == path
+        })?.reasoningEffort {
+            return workspaceEffort
+        }
+        return model.activeAccount?.codexReasoningEffortValue ?? ""
+    }
+
+    private func effortPopover(selectedEffort: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Reasoning effort")
+                .font(.locus(size: 10, weight: .bold))
+
+            effortRow(effort: "", title: "Auto", selectedEffort: selectedEffort)
+            ForEach(model.reasoningEffortOptions, id: \.self) { effort in
+                effortRow(
+                    effort: effort,
+                    title: effort.capitalized,
+                    selectedEffort: selectedEffort
+                )
+            }
+
+            Divider().overlay(LocusTheme.line)
+
+            Text(
+                "Applies to this workspace and takes effect on the next message. "
+                + "Higher efforts think longer and cost more."
+            )
+            .font(.locus(size: 8))
+            .foregroundStyle(LocusTheme.muted)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(10)
+        .frame(width: 240)
+        .background(LocusTheme.white)
+        .accessibilityIdentifier("workspace.effortPicker.popover")
+    }
+
+    private func effortRow(
+        effort: String,
+        title: String,
+        selectedEffort: String
+    ) -> some View {
+        Button {
+            model.setReasoningEffort(effort)
+            isPresented = false
+        } label: {
+            HStack(spacing: 8) {
+                Text(title)
+                Spacer(minLength: 12)
+                if selectedEffort == effort {
+                    Image(systemName: "checkmark")
+                        .font(.locus(size: 8, weight: .bold))
+                }
+            }
+            .font(.locus(size: 9, weight: .semibold))
+            .foregroundStyle(LocusTheme.inkSoft)
+            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+            .background(selectedEffort == effort ? LocusTheme.paperDeep : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.locus())
+        .accessibilityIdentifier("workspace.effortPicker.\(effort.isEmpty ? "auto" : effort)")
+    }
+}
+
 /// Two fully addressable chat slots backed by the app's shared worker registry.
 /// The focused slot owns the live runtime UI; the other remains readable and
 /// editable from its cached transcript while its worker continues in the background.
@@ -438,6 +463,7 @@ enum ChatWorkspacePresentation: Equatable {
 
 struct SplitChatWorkspaceView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var sessionCatalog: SessionCatalogModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let sidebarVisible: Bool
     let showSidebar: () -> Void
@@ -491,7 +517,7 @@ struct SplitChatWorkspaceView: View {
                 }
                 .accessibilityIdentifier("split.pane.\(pane.rawValue).focused")
         } else if let sessionID = model.splitSessionID(for: pane),
-                  let session = model.sessions.first(where: { $0.id == sessionID })
+                  let session = sessionCatalog.snapshot.sessionsByID[sessionID]
         {
             BackgroundChatPane(
                 pane: pane,
@@ -1094,6 +1120,7 @@ struct ActivityActionButtonStyle: ButtonStyle {
 
 struct ActivityCenterView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var sessionCatalog: SessionCatalogModel
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1312,7 +1339,7 @@ struct ActivityCenterView: View {
 
     private func chatTitle(for run: OrchestrationRun) -> String {
         guard let sessionID = run.sessionID else { return "Unknown chat" }
-        return model.sessions.first(where: { $0.id == sessionID })?.displayTitle ?? "Saved chat"
+        return sessionCatalog.snapshot.sessionsByID[sessionID]?.displayTitle ?? "Saved chat"
     }
 
     private func workspaceTitle(for run: OrchestrationRun) -> String {
@@ -2232,6 +2259,7 @@ struct TranscriptFollowState: Equatable {
 
 private struct ConversationView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var transcriptPresentation: TranscriptPresentationModel
     let streamingReply: StreamingReplyState
     @StateObject private var scrollCoordinator = TranscriptScrollCoordinator()
     /// Owned here, outside the lazy list, so recycling a row cannot take the
@@ -2241,25 +2269,28 @@ private struct ConversationView: View {
     private let bottomID = "conversation-bottom"
 
     var body: some View {
-        let items = model.blocks.isEmpty ? [] : presentationItems
+        let transcript = transcriptPresentation.snapshot
+        let items = transcript.items
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    if model.blocks.isEmpty {
+                    if transcript.isEmpty {
                         EmptyConversationView()
                             .environmentObject(model)
                     } else {
-                        let markerIDs = TranscriptPresentation.assistantMarkerItemIDs(in: items)
-                        let actionIDs = TranscriptPresentation.assistantActionItemIDs(in: items)
                         ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
                             presentationRow(
                                 item,
-                                assistantMarkerItemIDs: markerIDs,
-                                assistantActionItemIDs: actionIDs
+                                assistantMarkerItemIDs: transcript.assistantMarkerItemIDs,
+                                assistantActionItemIDs: transcript.assistantActionItemIDs,
+                                toolActivityVisibility: transcript.toolActivityVisibility,
+                                thinkingVisibility: transcript.thinkingVisibility
                             )
                             .padding(.top, topSpacing(
                                 before: item,
-                                previous: index > 0 ? items[index - 1] : nil
+                                previous: index > 0 ? items[index - 1] : nil,
+                                toolActivityVisibility: transcript.toolActivityVisibility,
+                                thinkingVisibility: transcript.thinkingVisibility
                             ))
                         }
                     }
@@ -2278,14 +2309,14 @@ private struct ConversationView: View {
                 .background { TranscriptScrollBridge(coordinator: scrollCoordinator) }
                 .frame(maxWidth: 780)
                 .padding(.horizontal, 24)
-                .padding(.top, model.blocks.isEmpty ? 0 : 24)
+                .padding(.top, transcript.isEmpty ? 0 : 24)
                 .padding(.bottom, 40)
                 .frame(maxWidth: .infinity)
             }
             .accessibilityIdentifier("conversation.scroll")
             .chatAttachmentDropTarget()
             .overlay(alignment: .bottom) {
-                if scrollCoordinator.followState.showsJumpToLatest, !model.blocks.isEmpty {
+                if scrollCoordinator.followState.showsJumpToLatest, !transcript.isEmpty {
                     Button {
                         scrollCoordinator.jumpToLatest(animated: true)
                     } label: {
@@ -2304,10 +2335,10 @@ private struct ConversationView: View {
                     .accessibilityIdentifier("conversation.jumpToLatest")
                 }
             }
-            .onChange(of: model.blocks.count) { oldCount, newCount in
+            .onChange(of: transcript.blocks.count) { oldCount, newCount in
                 // Sending a message re-engages following even after the
                 // reader scrolled up, so the reply streams into view.
-                if newCount > oldCount, model.blocks.last?.kind == .user {
+                if newCount > oldCount, transcript.blocks.last?.kind == .user {
                     scrollCoordinator.jumpToLatest()
                 }
                 scrollCoordinator.contentMayHaveChanged()
@@ -2327,12 +2358,20 @@ private struct ConversationView: View {
             .onChange(of: model.currentSessionID) {
                 selection.reset()
             }
-            .onAppear { configureSelection(for: items) }
-            .onChange(of: items.map(\.id.stableKey)) { _, _ in
-                configureSelection(for: items)
+            .onAppear {
+                configureSelection(
+                    for: items,
+                    thinkingVisibility: transcript.thinkingVisibility
+                )
             }
-            .onChange(of: model.thinkingVisibility) { _, _ in
-                configureSelection(for: items)
+            .onChange(of: items.map(\.id.stableKey)) { _, _ in
+                configureSelection(
+                    for: items,
+                    thinkingVisibility: transcript.thinkingVisibility
+                )
+            }
+            .onChange(of: transcript.thinkingVisibility) { _, visibility in
+                configureSelection(for: items, thinkingVisibility: visibility)
             }
             .environment(\.runInTerminalAction) { [weak model] command in
                 model?.runCommandInTerminal(command)
@@ -2343,7 +2382,10 @@ private struct ConversationView: View {
     /// Keeps the store's idea of the transcript in step with what is rendered,
     /// and teaches it how to read a row that has not been realized — which is
     /// what lets Copy return a whole passage after a long scroll.
-    private func configureSelection(for items: [TranscriptPresentationItem]) {
+    private func configureSelection(
+        for items: [TranscriptPresentationItem],
+        thinkingVisibility: ThinkingVisibility
+    ) {
         let sources = Dictionary(
             items.compactMap { item -> (String, RowSelectionSource)? in
                 guard let source = Self.selectionSource(of: item) else { return nil }
@@ -2351,10 +2393,13 @@ private struct ConversationView: View {
             },
             uniquingKeysWith: { first, _ in first }
         )
-        let visibility = model.thinkingVisibility
         selection.spanProvider = { rowID in
             guard let source = sources[rowID] else { return [] }
-            return Self.spans(for: source, rowID: rowID, thinkingVisibility: visibility)
+            return Self.spans(
+                for: source,
+                rowID: rowID,
+                thinkingVisibility: thinkingVisibility
+            )
         }
         selection.onDragActiveChange = { active in
             scrollCoordinator.setSelectionDragActive(active)
@@ -2420,19 +2465,13 @@ private struct ConversationView: View {
         }
     }
 
-    private var presentationItems: [TranscriptPresentationItem] {
-        TranscriptPresentation.items(
-            from: model.blocks,
-            toolVisibility: model.toolActivityVisibility,
-            thinkingVisibility: model.thinkingVisibility
-        )
-    }
-
     @ViewBuilder
     private func presentationRow(
         _ item: TranscriptPresentationItem,
         assistantMarkerItemIDs: Set<TranscriptPresentationItem.ID>,
-        assistantActionItemIDs: Set<TranscriptPresentationItem.ID>
+        assistantActionItemIDs: Set<TranscriptPresentationItem.ID>,
+        toolActivityVisibility: ToolActivityVisibility,
+        thinkingVisibility: ThinkingVisibility
     ) -> some View {
         switch item {
         case .block(let block):
@@ -2450,6 +2489,7 @@ private struct ConversationView: View {
                     accessibilityIdentifier: block.completion == nil
                         ? "message.\(block.id.uuidString)"
                         : "turnCompletion.\(block.id.uuidString)",
+                    thinkingVisibility: thinkingVisibility,
                     showsAssistantMarker: assistantMarkerItemIDs.contains(item.id),
                     showsAssistantActions: assistantActionItemIDs.contains(item.id)
                 )
@@ -2463,6 +2503,7 @@ private struct ConversationView: View {
                 accessibilityIdentifier: segment.id.ordinal == 0
                     ? "message.\(segment.id.sourceBlockID.uuidString)"
                     : "message.\(segment.id.sourceBlockID.uuidString).segment.\(segment.id.ordinal)",
+                thinkingVisibility: thinkingVisibility,
                 showsAssistantMarker: assistantMarkerItemIDs.contains(item.id),
                 showsAssistantActions: assistantActionItemIDs.contains(item.id)
             )
@@ -2471,7 +2512,7 @@ private struct ConversationView: View {
             ToolActivityView(
                 groupID: id,
                 tools: tools,
-                visibility: model.toolActivityVisibility,
+                visibility: toolActivityVisibility,
                 accent: model.effectiveAccent,
                 showsMarker: assistantMarkerItemIDs.contains(item.id),
                 onExpansionChange: scrollCoordinator.detach
@@ -2481,7 +2522,7 @@ private struct ConversationView: View {
             ThinkingActivityView(
                 groupID: id,
                 entries: entries,
-                visibility: model.thinkingVisibility,
+                visibility: thinkingVisibility,
                 accent: model.effectiveAccent,
                 showsMarker: assistantMarkerItemIDs.contains(item.id),
                 onExpansionChange: scrollCoordinator.detach
@@ -2512,6 +2553,7 @@ private struct ConversationView: View {
         sourceBlock: ChatBlock,
         presentationID: TranscriptPresentationItem.ID,
         accessibilityIdentifier: String,
+        thinkingVisibility: ThinkingVisibility,
         showsAssistantMarker: Bool,
         showsAssistantActions: Bool
     ) -> some View {
@@ -2521,7 +2563,7 @@ private struct ConversationView: View {
             {
                 ActiveAssistantBlockView(
                     reply: streamingReply,
-                    thinkingVisibility: model.thinkingVisibility,
+                    thinkingVisibility: thinkingVisibility,
                     accent: model.effectiveAccent,
                     workspacePath: model.workspacePath,
                     showsMarker: showsAssistantMarker,
@@ -2535,7 +2577,7 @@ private struct ConversationView: View {
             } else {
                 MessageBlockView(
                     block: displayBlock,
-                    thinkingVisibility: model.thinkingVisibility,
+                    thinkingVisibility: thinkingVisibility,
                     accent: model.effectiveAccent,
                     workspacePath: model.workspacePath,
                     actionsDisabled: model.isBusy || model.hasPendingPermission,
@@ -2594,7 +2636,7 @@ private struct ConversationView: View {
 
     private func scrollToCurrentMatch(_ proxy: ScrollViewProxy) {
         guard let match = model.currentTranscriptMatch else { return }
-        let destination = presentationItems.first(where: {
+        let destination = transcriptPresentation.snapshot.items.first(where: {
             $0.sourceBlockIDs.contains(match)
         })?.id ?? .block(match)
         withAnimation(LocusMotion.scroll) {
@@ -2603,10 +2645,11 @@ private struct ConversationView: View {
     }
 
     private func scrollToOverviewTarget(_ proxy: ScrollViewProxy) {
+        let transcript = transcriptPresentation.snapshot
         guard let target = model.transcriptJumpTarget,
-              let block = model.blocks.first(where: { $0.id == target })
+              let block = transcript.blocksByID[target]
         else { return }
-        let destination = presentationItems.first(where: { item in
+        let destination = transcript.items.first(where: { item in
             switch item {
             case .block(let candidate): return candidate.id == target
             case .assistantSegment(let segment):
@@ -2626,11 +2669,21 @@ private struct ConversationView: View {
 
     private func topSpacing(
         before item: TranscriptPresentationItem,
-        previous: TranscriptPresentationItem?
+        previous: TranscriptPresentationItem?,
+        toolActivityVisibility: ToolActivityVisibility,
+        thinkingVisibility: ThinkingVisibility
     ) -> CGFloat {
         guard let previous else { return 0 }
         if isTurnBoundary(item) || isTurnBoundary(previous) { return 24 }
-        if isCompactFlowItem(item) || isCompactFlowItem(previous) { return 14 }
+        if isCompactFlowItem(
+            item,
+            toolActivityVisibility: toolActivityVisibility,
+            thinkingVisibility: thinkingVisibility
+        ) || isCompactFlowItem(
+            previous,
+            toolActivityVisibility: toolActivityVisibility,
+            thinkingVisibility: thinkingVisibility
+        ) { return 14 }
         return 24
     }
 
@@ -2639,14 +2692,18 @@ private struct ConversationView: View {
         return block.kind == .user || block.completion != nil
     }
 
-    private func isCompactFlowItem(_ item: TranscriptPresentationItem) -> Bool {
+    private func isCompactFlowItem(
+        _ item: TranscriptPresentationItem,
+        toolActivityVisibility: ToolActivityVisibility,
+        thinkingVisibility: ThinkingVisibility
+    ) -> Bool {
         switch item {
         case .assistantSegment(let segment):
             return segment.sourceBlock.assistantPhase == .commentary
         case .toolGroup:
-            return model.toolActivityVisibility == .collapsed
+            return toolActivityVisibility == .collapsed
         case .thinkingGroup:
-            return model.thinkingVisibility == .collapsed
+            return thinkingVisibility == .collapsed
         case .block:
             return false
         }
@@ -3360,6 +3417,49 @@ private struct IncomingEventTranscriptCard: View {
     }
 }
 
+/// Gives user prompts a stable trailing measure at every window width. A fixed
+/// leading spacer only approximates this relationship and lets compact windows
+/// grow the prompt well beyond the intended reading-column proportion.
+private struct TrailingFractionLayout: Layout {
+    let maximumFraction: CGFloat
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        guard let subview = subviews.first else { return .zero }
+        let childProposal = ProposedViewSize(
+            width: proposal.width.map { $0 * maximumFraction },
+            height: proposal.height
+        )
+        let childSize = subview.sizeThatFits(childProposal)
+        return CGSize(
+            width: proposal.width ?? childSize.width,
+            height: childSize.height
+        )
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        guard let subview = subviews.first else { return }
+        let childProposal = ProposedViewSize(
+            width: bounds.width * maximumFraction,
+            height: proposal.height
+        )
+        let childSize = subview.sizeThatFits(childProposal)
+        subview.place(
+            at: CGPoint(x: bounds.maxX - childSize.width, y: bounds.minY),
+            anchor: .topLeading,
+            proposal: childProposal
+        )
+    }
+}
+
 private struct MessageBlockView: View, Equatable {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isHovering = false
@@ -3403,8 +3503,7 @@ private struct MessageBlockView: View, Equatable {
         Group {
             switch block.kind {
             case .user:
-                HStack(alignment: .top) {
-                    Spacer(minLength: 68)
+                TrailingFractionLayout(maximumFraction: 0.81) {
                     VStack(alignment: .trailing, spacing: 4) {
                         if let eventTrigger = block.eventTrigger {
                             IncomingEventTranscriptCard(context: eventTrigger)

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -2572,7 +2572,11 @@ final class AppModelTests: XCTestCase {
 
     @MainActor
     func testQueueDrainsAfterTurnDone() async throws {
-        let model = AppModel(startImmediately: false)
+        BackendStub.reset()
+        let model = AppModel(
+            startImmediately: false,
+            backendOverride: stubbedBackendService()
+        )
         model.agentRuntimePhase = .online
         model.isBusy = true
         model.send("queued message")
@@ -2580,7 +2584,9 @@ final class AppModelTests: XCTestCase {
 
         model.draftText = "typed while waiting"
         model.handleEventForTesting(["type": "turn_done"])
-        try await Task.sleep(for: .milliseconds(200))
+        for _ in 0..<100 where model.queuedMessages.isEmpty {
+            try await Task.sleep(for: .milliseconds(10))
+        }
 
         // With no live socket the drained message returns to the queue —
         // writing it into the draft would destroy what the user typed since.

--- a/LocusTests/SessionCatalogModelTests.swift
+++ b/LocusTests/SessionCatalogModelTests.swift
@@ -1,0 +1,394 @@
+import Combine
+import XCTest
+
+@testable import Locus
+
+@MainActor
+final class SessionCatalogModelTests: XCTestCase {
+    private func profile(
+        _ path: String,
+        lastOpened: TimeInterval
+    ) -> WorkspaceProfile {
+        WorkspaceProfile(
+            path: path,
+            lastOpened: Date(timeIntervalSince1970: lastOpened),
+            model: "",
+            accountID: nil,
+            mode: .work,
+            previewURL: "",
+            contextFiles: [],
+            draft: ""
+        )
+    }
+
+    private func session(
+        _ id: String,
+        title: String? = nil,
+        preview: String = "",
+        mtime: TimeInterval,
+        pinned: Bool = false,
+        archived: Bool = false,
+        workspace: String? = nil,
+        folderID: String? = nil,
+        sortOrder: Int? = nil
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            name: "\(id).jsonl",
+            preview: preview,
+            mtime: mtime,
+            size: 1,
+            title: title,
+            pinned: pinned,
+            archived: archived,
+            cwd: workspace,
+            folderID: folderID,
+            sortOrder: sortOrder
+        )
+    }
+
+    private func folder(
+        _ id: String,
+        workspace: String,
+        parentID: String? = nil,
+        name: String,
+        order: Int
+    ) -> ChatFolderRecord {
+        ChatFolderRecord(
+            id: id,
+            workspace: workspace,
+            parentID: parentID,
+            name: name,
+            order: order
+        )
+    }
+
+    func testWorkspaceOrderingKeepsEmptyProfilesAndLegacyChats() {
+        let alpha = "/tmp/locus-catalog-alpha"
+        let beta = "/tmp/locus-catalog-beta"
+        let catalog = SessionCatalogModel { $0 != beta }
+        catalog.replaceWorkspaceProfiles([
+            profile(alpha, lastOpened: 10),
+            profile(beta, lastOpened: 20),
+        ])
+        catalog.setActiveWorkspacePath(alpha)
+        catalog.replaceSessions([
+            session("alpha-chat", preview: "Alpha", mtime: 30, workspace: alpha),
+            session("legacy-chat", preview: "Legacy", mtime: 5),
+        ])
+
+        let groups = catalog.snapshot.sidebarGroups
+        XCTAssertEqual(groups.map(\.id), [alpha, beta, SessionCatalogModel.otherWorkspaceID])
+        XCTAssertEqual(groups[0].group.chats.map(\.id), ["alpha-chat"])
+        XCTAssertTrue(groups[1].group.chats.isEmpty, "empty saved workspaces remain visible")
+        XCTAssertFalse(groups[1].group.isAvailable)
+        XCTAssertEqual(groups[2].group.title, "Other Chats")
+        XCTAssertEqual(groups[2].unfiledChats.map(\.id), ["legacy-chat"])
+        XCTAssertEqual(catalog.snapshot.recentWorkspaceProfiles.map(\.path), [beta, alpha])
+        XCTAssertEqual(catalog.snapshot.workspaceAvailabilityByProfileID[alpha], true)
+        XCTAssertEqual(catalog.snapshot.workspaceAvailabilityByProfileID[beta], false)
+
+        catalog.setSearchQuery("not-present")
+        XCTAssertEqual(catalog.snapshot.workspaceAvailabilityByProfileID[alpha], true)
+        XCTAssertEqual(catalog.snapshot.workspaceAvailabilityByProfileID[beta], false)
+    }
+
+    func testPinnedOrderingAndArchivedVisibility() {
+        let workspace = "/tmp/locus-catalog-ordering"
+        let catalog = SessionCatalogModel(fileExists: { _ in true })
+        catalog.replaceSessions([
+            session("recent", mtime: 30, workspace: workspace, sortOrder: 2),
+            session("ordered", mtime: 10, workspace: workspace, sortOrder: 1),
+            session("pinned", mtime: 1, pinned: true, workspace: workspace, sortOrder: 9),
+            session("archived", mtime: 100, archived: true, workspace: workspace),
+        ])
+
+        let visible = catalog.snapshot.sidebarGroups.first { $0.id == workspace }
+        XCTAssertEqual(visible?.unfiledChats.map(\.id), ["pinned", "ordered", "recent"])
+        XCTAssertFalse(catalog.snapshot.filteredSessions.contains { $0.id == "archived" })
+
+        catalog.setShowArchivedSessions(true)
+
+        XCTAssertTrue(catalog.snapshot.filteredSessions.contains { $0.id == "archived" })
+        XCTAssertTrue(
+            catalog.snapshot.sidebarGroups
+                .first { $0.id == workspace }?
+                .unfiledChats.contains { $0.id == "archived" } == true
+        )
+    }
+
+    func testSessionAndNestedFolderSearchPreserveAncestors() {
+        let workspace = "/tmp/locus-catalog-search"
+        let catalog = SessionCatalogModel(fileExists: { _ in true })
+        catalog.replaceRemoteCatalog(
+            sessions: [
+                session(
+                    "direct", title: "Needle discussion", mtime: 10,
+                    workspace: workspace
+                ),
+                session(
+                    "nested", title: "Unrelated", mtime: 20,
+                    workspace: workspace, folderID: "sources"
+                ),
+            ],
+            chatFolders: [
+                folder("research", workspace: workspace, name: "Research", order: 0),
+                folder(
+                    "sources", workspace: workspace, parentID: "research",
+                    name: "Sources", order: 0
+                ),
+            ]
+        )
+
+        catalog.setSearchQuery("needle")
+        XCTAssertEqual(catalog.snapshot.filteredSessions.map(\.id), ["direct"])
+        XCTAssertTrue(catalog.snapshot.sidebarGroups[0].rootFolders.isEmpty)
+
+        catalog.setSearchQuery("Research")
+        XCTAssertEqual(catalog.snapshot.filteredSessions.map(\.id), ["nested"])
+        let research = catalog.snapshot.sidebarGroups[0].rootFolders
+        XCTAssertEqual(research.map(\.id), ["research"])
+        XCTAssertEqual(research[0].children.map(\.id), ["sources"])
+        XCTAssertEqual(research[0].children[0].chats.map(\.id), ["nested"])
+
+        catalog.setSearchQuery("Sources")
+        XCTAssertEqual(catalog.snapshot.sidebarGroups[0].rootFolders.map(\.id), ["research"])
+        XCTAssertEqual(
+            catalog.snapshot.sidebarGroups[0].rootFolders[0].children.map(\.id),
+            ["sources"]
+        )
+    }
+
+    func testNestedFolderTreeAndChatOrderingArePrebuilt() {
+        let workspace = "/tmp/locus-catalog-tree"
+        let catalog = SessionCatalogModel(fileExists: { _ in true })
+        catalog.replaceRemoteCatalog(
+            sessions: [
+                session(
+                    "child-new", mtime: 30, workspace: workspace,
+                    folderID: "child-a", sortOrder: 1
+                ),
+                session(
+                    "child-pinned", mtime: 1, pinned: true, workspace: workspace,
+                    folderID: "child-a", sortOrder: 9
+                ),
+                session("unfiled-late", mtime: 30, workspace: workspace, sortOrder: 2),
+                session("unfiled-first", mtime: 10, workspace: workspace, sortOrder: 1),
+            ],
+            chatFolders: [
+                folder("root-later", workspace: workspace, name: "Later", order: 2),
+                folder("root-first", workspace: workspace, name: "First", order: 1),
+                folder(
+                    "child-b", workspace: workspace, parentID: "root-first",
+                    name: "B", order: 2
+                ),
+                folder(
+                    "child-a", workspace: workspace, parentID: "root-first",
+                    name: "A", order: 1
+                ),
+            ]
+        )
+
+        let group = catalog.snapshot.sidebarGroups[0]
+        XCTAssertEqual(group.rootFolders.map(\.id), ["root-first", "root-later"])
+        XCTAssertEqual(group.rootFolders[0].children.map(\.id), ["child-a", "child-b"])
+        XCTAssertEqual(
+            group.rootFolders[0].children[0].chats.map(\.id),
+            ["child-pinned", "child-new"]
+        )
+        XCTAssertEqual(group.unfiledChats.map(\.id), ["unfiled-first", "unfiled-late"])
+        XCTAssertEqual(
+            catalog.snapshot.folderMoveTargetsByFolderID["root-first"]?.map(\.id),
+            ["root-later"]
+        )
+    }
+
+    func testExpansionPersistenceFocusRequestsAndSearchCallback() {
+        let suiteName = "SessionCatalogModelTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        var queries: [String] = []
+        let catalog = SessionCatalogModel(fileExists: { _ in true })
+        catalog.configure(
+            persistenceEnabled: true,
+            defaults: defaults,
+            searchQueryDidChange: { queries.append($0) }
+        )
+        catalog.setWorkspaceExpanded("workspace", expanded: true)
+        catalog.setChatFolderExpanded("folder", expanded: true)
+        catalog.setSearchQuery("needle")
+        catalog.setSearchQuery("needle")
+        let focusToken = catalog.snapshot.sidebarSearchFocusToken
+        catalog.requestSearchFocus()
+
+        XCTAssertEqual(queries, ["needle"])
+        XCTAssertNotEqual(catalog.snapshot.sidebarSearchFocusToken, focusToken)
+        XCTAssertEqual(defaults.stringArray(forKey: "Locus.expandedWorkspaces"), ["workspace"])
+        XCTAssertEqual(defaults.stringArray(forKey: "Locus.expandedChatFolders"), ["folder"])
+
+        let restored = SessionCatalogModel(fileExists: { _ in true })
+        restored.configure(
+            persistenceEnabled: true,
+            defaults: defaults,
+            searchQueryDidChange: { _ in }
+        )
+        XCTAssertEqual(restored.snapshot.expandedWorkspaceIDs, ["workspace"])
+        XCTAssertEqual(restored.snapshot.expandedChatFolderIDs, ["folder"])
+    }
+
+    func testInjectedAvailabilityRunsOnlyDuringSnapshotRebuilds() {
+        let first = "/tmp/locus-catalog-available"
+        let second = "/tmp/locus-catalog-unavailable"
+        var checkedPaths: [String] = []
+        let catalog = SessionCatalogModel { path in
+            checkedPaths.append(path)
+            return path == first
+        }
+        catalog.replaceWorkspaceProfiles([
+            profile(first, lastOpened: 2),
+            profile(second, lastOpened: 1),
+        ])
+        let rebuilds = catalog.snapshotBuildCountForTesting
+        let availabilityChecks = checkedPaths.count
+
+        for _ in 0..<20 {
+            _ = catalog.snapshot.sidebarGroups
+            _ = catalog.snapshot.sessionsByID
+        }
+
+        XCTAssertEqual(catalog.snapshotBuildCountForTesting, rebuilds)
+        XCTAssertEqual(checkedPaths.count, availabilityChecks)
+        XCTAssertEqual(
+            catalog.snapshot.sidebarGroups.first { $0.id == first }?.group.isAvailable,
+            true
+        )
+        XCTAssertEqual(
+            catalog.snapshot.sidebarGroups.first { $0.id == second }?.group.isAvailable,
+            false
+        )
+    }
+
+    func testCombinedRemoteReplacementBuildsAndPublishesExactlyOnce() {
+        let workspace = "/tmp/locus-catalog-transaction"
+        let catalog = SessionCatalogModel(fileExists: { _ in true })
+        let baseline = catalog.snapshotBuildCountForTesting
+        var publications = 0
+        let subscription = catalog.objectWillChange.sink { publications += 1 }
+
+        catalog.replaceRemoteCatalog(
+            sessions: [session("chat", mtime: 1, workspace: workspace)],
+            chatFolders: [
+                folder("folder", workspace: workspace, name: "Folder", order: 0),
+            ]
+        )
+
+        XCTAssertEqual(catalog.snapshotBuildCountForTesting, baseline + 1)
+        XCTAssertEqual(publications, 1)
+        XCTAssertEqual(catalog.snapshot.sessions.map(\.id), ["chat"])
+        XCTAssertEqual(catalog.snapshot.chatFolders.map(\.id), ["folder"])
+        withExtendedLifetime(subscription) {}
+    }
+
+    func testUnrelatedAppAndChildPublicationsDoNotRebuildCatalog() {
+        let app = AppModel(startImmediately: false)
+        let baseline = app.sessionCatalog.snapshotBuildCountForTesting
+
+        app.backendLogHint = "changed"
+        app.toastCenter.objectWillChange.send()
+
+        XCTAssertEqual(app.sessionCatalog.snapshotBuildCountForTesting, baseline)
+    }
+
+    func testCatalogChangesDoNotPublishAppModel() {
+        let app = AppModel(startImmediately: false)
+        var appPublications = 0
+        let subscription = app.objectWillChange.sink { appPublications += 1 }
+
+        app.sessionCatalog.replaceSessions([
+            session("isolated", mtime: 1, workspace: "/tmp/locus-catalog-isolated"),
+        ])
+        app.sessionCatalog.setSearchQuery("catalog")
+
+        XCTAssertEqual(appPublications, 0)
+        app.transcriptSearch.cancelAll()
+        withExtendedLifetime(subscription) {}
+    }
+
+    func testBenchmarkInitialConstructionWithBackendMaximumFixture() {
+        let fixture = benchmarkFixture()
+        measure(metrics: [XCTClockMetric()]) {
+            let catalog = SessionCatalogModel(fileExists: { _ in true })
+            catalog.replaceWorkspaceProfiles(fixture.profiles)
+            catalog.replaceRemoteCatalog(
+                sessions: fixture.sessions,
+                chatFolders: fixture.folders
+            )
+            _ = catalog.snapshot.sidebarGroups.count
+        }
+    }
+
+    func testBenchmarkSearchUpdatesWithBackendMaximumFixture() {
+        let fixture = benchmarkFixture()
+        let catalog = SessionCatalogModel(fileExists: { _ in true })
+        catalog.replaceWorkspaceProfiles(fixture.profiles)
+        catalog.replaceRemoteCatalog(
+            sessions: fixture.sessions,
+            chatFolders: fixture.folders
+        )
+        var useMatchingQuery = false
+
+        measure(metrics: [XCTClockMetric()]) {
+            useMatchingQuery.toggle()
+            catalog.setSearchQuery(useMatchingQuery ? "needle" : "not-present")
+            _ = catalog.snapshot.filteredSessions.count
+        }
+    }
+
+    private func benchmarkFixture() -> (
+        profiles: [WorkspaceProfile],
+        folders: [ChatFolderRecord],
+        sessions: [SessionSummary]
+    ) {
+        var profiles: [WorkspaceProfile] = []
+        var folders: [ChatFolderRecord] = []
+        var sessions: [SessionSummary] = []
+        for workspaceIndex in 0..<20 {
+            let workspace = "/tmp/locus-catalog-benchmark-\(workspaceIndex)"
+            let rootID = "root-\(workspaceIndex)"
+            let childID = "child-\(workspaceIndex)"
+            profiles.append(profile(workspace, lastOpened: TimeInterval(workspaceIndex)))
+            folders.append(
+                folder(rootID, workspace: workspace, name: "Research", order: 0)
+            )
+            folders.append(
+                folder(
+                    childID, workspace: workspace, parentID: rootID,
+                    name: "Sources", order: 0
+                )
+            )
+            for chatIndex in 0..<25 {
+                let id = "chat-\(workspaceIndex)-\(chatIndex)"
+                let destination: String? = switch chatIndex % 3 {
+                case 0: childID
+                case 1: rootID
+                default: nil
+                }
+                sessions.append(
+                    session(
+                        id,
+                        title: chatIndex.isMultiple(of: 10) ? "Needle \(id)" : "Chat \(id)",
+                        mtime: TimeInterval(workspaceIndex * 100 + chatIndex),
+                        pinned: chatIndex.isMultiple(of: 17),
+                        workspace: workspace,
+                        folderID: destination,
+                        sortOrder: chatIndex
+                    )
+                )
+            }
+        }
+        XCTAssertEqual(sessions.count, 500)
+        return (profiles, folders, sessions)
+    }
+}

--- a/LocusTests/TranscriptFollowTests.swift
+++ b/LocusTests/TranscriptFollowTests.swift
@@ -95,6 +95,8 @@ final class TranscriptFollowTests: XCTestCase {
     private func mount(_ model: AppModel, size: NSSize) -> NSView {
         let host = NSHostingView(rootView: FollowProbeRoot()
             .environmentObject(model)
+            .environmentObject(model.sessionCatalog)
+            .environmentObject(model.transcriptPresentation)
             .environmentObject(AppUpdateController(startImmediately: false)))
         host.frame = NSRect(origin: .zero, size: size)
         let window = NSWindow(

--- a/LocusTests/TranscriptPresentationModelTests.swift
+++ b/LocusTests/TranscriptPresentationModelTests.swift
@@ -1,0 +1,195 @@
+import Combine
+import XCTest
+
+@testable import Locus
+
+@MainActor
+final class TranscriptPresentationModelTests: XCTestCase {
+    func testSnapshotPrecomputesPresentationLookupsAndActionOwnership() {
+        let user = ChatBlock(kind: .user, text: "Review the extraction")
+        let assistant = ChatBlock(
+            kind: .assistant,
+            text: "The ownership boundary is sound.",
+            reasoningText: "Checking invalidation paths"
+        )
+        let model = TranscriptPresentationModel()
+
+        model.replaceBlocks([user, assistant])
+
+        let snapshot = model.snapshot
+        XCTAssertEqual(snapshot.blocksByID[user.id], user)
+        XCTAssertEqual(snapshot.blocksByID[assistant.id], assistant)
+        XCTAssertEqual(snapshot.items.count, 3)
+        XCTAssertTrue(snapshot.assistantMarkerItemIDs.contains(snapshot.items[1].id))
+        XCTAssertTrue(snapshot.assistantActionItemIDs.contains(snapshot.items[2].id))
+        XCTAssertFalse(snapshot.hasPendingPermission)
+    }
+
+    func testBatchedBlockMutationBuildsAndPublishesExactlyOnce() {
+        let model = TranscriptPresentationModel()
+        model.replaceBlocks([
+            ChatBlock(kind: .assistant, text: "", isStreaming: true),
+        ])
+        let baseline = model.snapshotBuildCountForTesting
+        var publications = 0
+        let subscription = model.objectWillChange.sink { publications += 1 }
+
+        model.updateBlocks {
+            $0[0].text = "Finished"
+            $0[0].reasoningText = "Verified"
+            $0[0].isStreaming = false
+        }
+
+        XCTAssertEqual(model.snapshotBuildCountForTesting, baseline + 1)
+        XCTAssertEqual(publications, 1)
+        XCTAssertEqual(model.snapshot.blocks[0].text, "Finished")
+        XCTAssertEqual(model.snapshot.blocks[0].reasoningText, "Verified")
+        XCTAssertFalse(model.snapshot.blocks[0].isStreaming)
+        withExtendedLifetime(subscription) {}
+    }
+
+    func testRepeatedSnapshotReadsAndEquivalentCommitsDoNotRebuild() {
+        let block = ChatBlock(kind: .user, text: "Stable")
+        let model = TranscriptPresentationModel()
+        model.replaceBlocks([block])
+        let baseline = model.snapshotBuildCountForTesting
+
+        for _ in 0..<20 {
+            _ = model.snapshot.items
+            _ = model.snapshot.blocksByID[block.id]
+        }
+        model.replaceBlocks([block])
+        model.setPresentationVisibility(toolActivity: .collapsed, thinking: .collapsed)
+
+        XCTAssertEqual(model.snapshotBuildCountForTesting, baseline)
+    }
+
+    func testVisibilityCommitRebuildsOneCompleteProjection() {
+        let tool = ToolPayload(
+            toolID: "tool-1",
+            tool: "read_file",
+            summary: "Read one file",
+            detail: "README.md",
+            status: .done
+        )
+        let model = TranscriptPresentationModel()
+        model.replaceBlocks([ChatBlock(kind: .tool, tool: tool)])
+        let baseline = model.snapshotBuildCountForTesting
+        var publications = 0
+        let subscription = model.objectWillChange.sink { publications += 1 }
+
+        model.setPresentationVisibility(toolActivity: .verbose, thinking: .expanded)
+
+        XCTAssertEqual(model.snapshotBuildCountForTesting, baseline + 1)
+        XCTAssertEqual(publications, 1)
+        XCTAssertEqual(model.snapshot.toolActivityVisibility, .verbose)
+        XCTAssertEqual(model.snapshot.thinkingVisibility, .expanded)
+        guard case .block(let block) = model.snapshot.items.first else {
+            return XCTFail("Verbose tool activity must expose the source block")
+        }
+        XCTAssertEqual(block.tool?.toolID, "tool-1")
+        withExtendedLifetime(subscription) {}
+    }
+
+    func testUnrelatedAppAndChildPublicationsDoNotRebuildTranscript() {
+        let app = AppModel(startImmediately: false)
+        app.blocks = [ChatBlock(kind: .user, text: "Owned by transcript")]
+        let baseline = app.transcriptPresentation.snapshotBuildCountForTesting
+
+        app.backendLogHint = "changed"
+        app.toastCenter.objectWillChange.send()
+
+        XCTAssertEqual(app.transcriptPresentation.snapshotBuildCountForTesting, baseline)
+    }
+
+    func testOrdinaryTranscriptChangesDoNotPublishAppModel() {
+        let app = AppModel(startImmediately: false)
+        var appPublications = 0
+        let subscription = app.objectWillChange.sink { appPublications += 1 }
+
+        app.blocks.append(ChatBlock(kind: .user, text: "Isolated publication"))
+
+        XCTAssertEqual(appPublications, 0)
+        XCTAssertEqual(app.transcriptPresentation.snapshot.blocks.count, 1)
+        withExtendedLifetime(subscription) {}
+    }
+
+    func testPendingPermissionCompatibilityPublishesOnlyWhenAvailabilityChanges() {
+        let app = AppModel(startImmediately: false)
+        let tool = ToolPayload(
+            toolID: "tool-1",
+            tool: "shell",
+            summary: "Run command",
+            detail: "swift test",
+            status: .awaitingPermission,
+            requestID: "request-1"
+        )
+        var appPublications = 0
+        let subscription = app.objectWillChange.sink { appPublications += 1 }
+
+        app.blocks = [ChatBlock(kind: .tool, tool: tool)]
+        let permissionPublicationCount = appPublications
+        app.blocks[0].tool?.summary = "Run the focused tests"
+
+        XCTAssertTrue(app.hasPendingPermission)
+        XCTAssertEqual(permissionPublicationCount, 1)
+        XCTAssertEqual(appPublications, permissionPublicationCount)
+
+        app.blocks[0].tool?.status = .done
+        XCTAssertFalse(app.hasPendingPermission)
+        XCTAssertEqual(appPublications, permissionPublicationCount + 1)
+        withExtendedLifetime(subscription) {}
+    }
+
+    func testBenchmarkInitialConstructionWithLargeTranscriptFixture() {
+        let fixture = benchmarkFixture()
+
+        measure(metrics: [XCTClockMetric()]) {
+            let model = TranscriptPresentationModel()
+            model.replaceBlocks(fixture)
+            _ = model.snapshot.items.count
+        }
+    }
+
+    func testBenchmarkVisibilityUpdatesWithLargeTranscriptFixture() {
+        let model = TranscriptPresentationModel()
+        model.replaceBlocks(benchmarkFixture())
+        var expanded = false
+
+        measure(metrics: [XCTClockMetric()]) {
+            expanded.toggle()
+            model.setPresentationVisibility(
+                toolActivity: expanded ? .verbose : .collapsed,
+                thinking: expanded ? .expanded : .collapsed
+            )
+            _ = model.snapshot.assistantActionItemIDs.count
+        }
+    }
+
+    private func benchmarkFixture() -> [ChatBlock] {
+        var blocks: [ChatBlock] = []
+        blocks.reserveCapacity(500)
+        for index in 0..<125 {
+            blocks.append(ChatBlock(kind: .user, text: "Request \(index)"))
+            blocks.append(ChatBlock(
+                kind: .assistant,
+                text: "Commentary for request \(index)",
+                assistantPhase: .commentary,
+                reasoningText: "Inspecting dependency \(index)"
+            ))
+            blocks.append(ChatBlock(kind: .tool, tool: ToolPayload(
+                toolID: "tool-\(index)",
+                tool: "read_file",
+                summary: "Read source \(index)",
+                detail: "Source\(index).swift",
+                status: .done
+            )))
+            blocks.append(ChatBlock(
+                kind: .assistant,
+                text: "Final answer for request \(index)",
+                assistantPhase: .finalAnswer
+            ))
+        }
+        return blocks
+    }
+}

--- a/LocusTests/TranscriptRelayoutTests.swift
+++ b/LocusTests/TranscriptRelayoutTests.swift
@@ -100,6 +100,8 @@ final class TranscriptRelayoutTests: XCTestCase {
     private func mount(_ model: AppModel, size: NSSize) -> NSView {
         let host = NSHostingView(rootView: RelayoutProbeRoot()
             .environmentObject(model)
+            .environmentObject(model.sessionCatalog)
+            .environmentObject(model.transcriptPresentation)
             .environmentObject(AppUpdateController(startImmediately: false)))
         host.frame = NSRect(origin: .zero, size: size)
         let window = NSWindow(

--- a/LocusTests/TranscriptSearchModelTests.swift
+++ b/LocusTests/TranscriptSearchModelTests.swift
@@ -71,13 +71,19 @@ final class TranscriptSearchModelTests: XCTestCase {
         XCTAssertTrue(BackendStub.requests[0].url?.query?.contains("second") ?? false)
     }
 
-    func testAppModelRepublishesSearchChanges() async throws {
+    func testSearchChangesPublishOnlyTheDirectlyObservedChildModel() {
         let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
+        var appPublications = 0
+        var searchPublications = 0
+        let appCancellable = app.objectWillChange.sink { _ in appPublications += 1 }
+        let searchCancellable = app.transcriptSearch.objectWillChange.sink {
+            searchPublications += 1
+        }
+
         app.transcriptSearch.transcriptHits = []
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
+
+        XCTAssertEqual(searchPublications, 1)
+        XCTAssertEqual(appPublications, 0)
+        withExtendedLifetime((appCancellable, searchCancellable)) {}
     }
 }


### PR DESCRIPTION
## Summary
- move session/sidebar data into an authoritative `SessionCatalogModel` snapshot
- make sidebar and related consumers observe the catalog directly
- precompute transcript presentation in a separate model with signposting and deterministic rebuild tests
- preserve AppModel compatibility accessors and existing persistence/backend behavior

## Verification
- generated project diff check
- design-system audit
- protocol manifest check
- shared iOS wire-type check
- 1,001 Swift unit tests, 0 failures
- focused sidebar and transcript UI checks completed during implementation