### PR TITLE
refactor: observe feature models directly

### DIFF
--- a/Docs/AppModelPublicationOptimizationPlan.md
+++ b/Docs/AppModelPublicationOptimizationPlan.md
@@ -81,6 +81,9 @@ Commit boundary: tests and measurement only.
 
 ### 2. Stop forwarding feature publications
 
+Status: implemented by the direct feature-observation extraction. Later
+extractions retain this boundary and must not reintroduce parent republishing.
+
 - Inject existing child models at the scene boundary only where a scene needs
   them, or pass them as `@ObservedObject` dependencies to the owning subview.
 - Migrate reactive reads of providers, teams, live team runs, landing, runs,

--- a/Docs/AppModelPublicationOptimizationPlan.md
+++ b/Docs/AppModelPublicationOptimizationPlan.md
@@ -1,0 +1,262 @@
+# AppModel publication-graph optimization
+
+## Outcome
+
+Complete the performance extraction started by `SessionCatalogModel` and
+`TranscriptPresentationModel` in one implementation run, on one branch, and in
+one pull request. The work remains split into reviewable commits, but it has no
+mid-run product or architecture decision gate.
+
+This is a behavior-preserving native-app refactor. It does not change backend
+routes, persistence formats, session data, provider behavior, or user-facing
+interaction.
+
+## Audited baseline
+
+The first extraction removed sidebar hierarchy construction and transcript
+presentation construction from broad `AppModel` invalidations. The remaining
+cost is the publication graph around the composition root:
+
+- `AppModel.swift` is 1,784 lines and declares 81 `@Published` properties.
+- `AppModel` republishes 18 child `ObservableObject` publishers through
+  `objectWillChange` or equivalent capability callbacks.
+- Native views contain 93 `@EnvironmentObject AppModel` declarations.
+- The broadest subscribed source files are `WorkspaceView.swift` (4,440
+  lines), `InspectorView.swift` (3,461), `Sheets.swift` (3,357), and
+  `ComposerView.swift` (1,961).
+- Existing feature models already own Git, files, providers, teams, runs,
+  schedules, activity, extensions, knowledge, evaluations, voice, landing,
+  background services, and instructions. Their changes are nevertheless
+  forwarded into `AppModel`, invalidating unrelated workspace consumers.
+- `SessionCatalogModel`, `TranscriptPresentationModel`, `NotebookModel`,
+  `TerminalSession`, and `BrowserService` prove that direct feature observation
+  works without republishing the composition root.
+
+The main optimization target is therefore invalidation scope, not collection
+algorithm speed. Large Swift files are secondary unless splitting them creates
+a smaller observation boundary.
+
+## Target ownership
+
+`AppModel` remains the composition root and turn/session orchestrator. It wires
+backend events and cross-feature callbacks, but it is no longer the observable
+container for feature state or workspace presentation.
+
+The completed boundary has four kinds of owner:
+
+1. Existing feature models remain authoritative for their domains and are
+   observed directly by the smallest view that renders them.
+2. `WorkspacePresentationModel` owns window chrome and navigation state:
+   sidebar/inspector visibility and sizes, inspector tabs and zoom, split-chat
+   presentation, sheet/dialog destinations, and one-shot navigation tokens.
+3. `ComposerSessionModel` owns composer-local state: draft, mode, history,
+   queued messages, attachments/context selection, focus, notices, and the
+   transcript-search presentation controls that sit beside the composer.
+4. `TurnPresentationModel` publishes one immutable snapshot of active-session
+   runtime state: session identity/info, busy and permission status, todos,
+   plan/question prompts, runtime phases, steering/work status, lifecycle
+   notices, and the active orchestration summary. Backend workflow and worker
+   ownership may remain in `AppModel`; explicit commits update this snapshot.
+
+Each extracted model has internal state, explicit mutations, an immutable
+snapshot where several fields must change transactionally, and compatibility
+accessors in `AppModel` while extension files migrate. None of these models
+retain or import `AppModel`.
+
+## Single-run implementation
+
+### 1. Pin the publication budget
+
+- Add a DEBUG-only `AppModel` publication counter and reset/read helpers for
+  tests. Do not add production payload logging.
+- Add a source manifest listing the temporary composition-root properties and
+  the views allowed to observe `AppModel`; make the manifest check deterministic
+  in CI.
+- Characterize current turn, split-pane, composer, inspector, sheet, and
+  settings behavior before moving ownership.
+- Retain the existing session-catalog and transcript build counters as
+  regression gates.
+
+Commit boundary: tests and measurement only.
+
+### 2. Stop forwarding feature publications
+
+- Inject existing child models at the scene boundary only where a scene needs
+  them, or pass them as `@ObservedObject` dependencies to the owning subview.
+- Migrate reactive reads of providers, teams, live team runs, landing, runs,
+  evaluations, knowledge, activity, schedules, background services,
+  extensions, Git, files, instructions, voice, application context, toasts,
+  and the downloadable component away from `AppModel` observation.
+- Keep actions on the owning feature model. For true cross-feature actions,
+  pass a narrow closure from a composition view; do not create another global
+  observable action facade.
+- Remove every child-to-`AppModel.objectWillChange` forwarding bridge. Replace
+  subscriptions that also perform a capability side effect with a dedicated
+  callback that performs only that side effect.
+- Preserve temporary computed feature facades only for non-reactive extension
+  code, and mark them for deletion in the final cleanup commit.
+
+Deterministic gate: publishing every child model in isolation produces zero
+`AppModel.objectWillChange` events and does not rebuild either existing
+snapshot model.
+
+Commit boundary: direct feature observation and bridge removal.
+
+### 3. Extract workspace presentation
+
+- Add `@MainActor WorkspacePresentationModel: ObservableObject` with private
+  state and a snapshot for coupled layout values.
+- Move sidebar collapse/width, inspector selection/open tabs/collapse/width,
+  inspector zoom, split-chat restoration/ratio/focus, and workspace-level
+  sheet/dialog/navigation destinations into it.
+- Move the existing UserDefaults-backed layout persistence into this model,
+  retaining every current key and the unit-test persistence isolation rules.
+- Route multi-value transitions—Just Chat inspector restoration, inspector
+  zoom/sidebar restoration, closing selected tabs, and split-pane focus—through
+  one commit so each interaction publishes once.
+- Back `AppModel` compatibility accessors with the new owner until all
+  extensions compile against the boundary.
+- Split `WorkspaceView`, `InspectorView`, and the workspace-owned portions of
+  `Sheets.swift` into small observation wrappers. A wrapper observes only the
+  presentation or feature model needed for that subtree.
+
+Deterministic gates: each compound transition publishes one presentation
+snapshot; repeated reads publish zero; feature and transcript updates publish
+zero workspace-presentation changes.
+
+Commit boundary: workspace chrome and navigation ownership.
+
+### 4. Extract composer/session-local state
+
+- Add `@MainActor ComposerSessionModel: ObservableObject` and move draft,
+  selected mode, prompt history, queued messages, attachments, context files,
+  loading/notice state, composer focus, and conversation-search presentation
+  into it.
+- Keep send orchestration in `AppModel`; provide a narrow immutable send input
+  assembled by the composer model and explicit callbacks for send, steer,
+  stop, and retry.
+- Make attachment ingestion, slash/mention/skill completion, voice transcript
+  acceptance, history navigation, and split-pane draft save/restore mutate the
+  composer owner rather than manually sending `AppModel.objectWillChange`.
+- Preserve workspace draft persistence, queue ordering, search selection,
+  focus behavior, and all keyboard shortcuts.
+- Split `ComposerView` into observation-scoped input, context, routing, voice,
+  and queue subviews. Existing feature models remain direct dependencies.
+
+Deterministic gates: draft edits do not publish the workspace presentation,
+Git/files/provider/team changes do not publish composer state, and one
+transactional split-pane restore publishes once.
+
+Commit boundary: composer state and composer UI observation.
+
+### 5. Publish turn presentation at one boundary
+
+- Add `@MainActor TurnPresentationModel: ObservableObject` with a complete,
+  immutable `TurnPresentationSnapshot` for state rendered by the conversation
+  header, work-status strip, plan/question/permission prompts, and session
+  overview.
+- Update it only through explicit turn-lifecycle commits: session activation,
+  send start, backend event batch, permission/question/plan transition,
+  completion/interruption, runtime recovery, and active-worker switch.
+- Batch fields that currently change together so a backend event causes at most
+  one turn-presentation publication. Transcript blocks continue to publish only
+  through `TranscriptPresentationModel`.
+- Keep backend services, task-worker registry, optimistic session mutations,
+  and lifecycle orchestration in `AppModel` for this optimization run.
+- Migrate `WorkspaceView` header/status, conversation prompts, session overview,
+  menu disabled states, and command availability to observe the snapshot at
+  their smallest owning wrappers.
+
+Deterministic gates: one representative backend event produces no more than one
+turn snapshot, streaming transcript updates do not republish `AppModel`, and an
+unrelated feature publication changes neither turn nor catalog snapshots.
+
+Commit boundary: active-turn presentation ownership.
+
+### 6. Remove compatibility observation and verify the complete graph
+
+- Delete migrated `AppModel` published storage, bridge cancellables, manual
+  `objectWillChange.send()` calls used only for UI refresh, and obsolete feature
+  facades.
+- Leave `AppModel` observation only in an explicit composition-root allowlist.
+  Leaf feature views must observe a feature/presentation model or receive value
+  inputs and action closures.
+- Update `Docs/Architecture.md` with the final ownership and publication rules.
+- Add production-safe signposts for workspace-presentation and turn-snapshot
+  construction. Record counts and duration only—never prompt text, titles,
+  paths, provider credentials, or message contents.
+- Run the full verification matrix below from a clean worktree and audit the
+  generated project diff before opening the pull request.
+
+Commit boundary: compatibility deletion, documentation, and final guards.
+
+## Verification matrix
+
+### Unit and structural tests
+
+- Existing session-catalog and transcript-presentation suites.
+- Workspace presentation: layout persistence, Just Chat restoration, inspector
+  tabs/zoom, split-pane focus/ratio, sheets and navigation tokens.
+- Composer session: history, queue, attachments, context, mentions/skills,
+  focus, search, split-pane restoration, and persistence isolation.
+- Turn presentation: runtime recovery, permission/plan/question state machine,
+  worker switching, event batching, completion, interruption, and stale-event
+  rejection.
+- Publication graph:
+  - child feature publication -> 0 `AppModel` publications;
+  - unrelated feature publication -> 0 catalog/transcript/workspace/composer/
+    turn rebuilds;
+  - repeated snapshot reads -> 0 rebuilds;
+  - each documented compound mutation -> exactly 1 owner publication.
+- Structural allowlists for `@Published` members on `AppModel`, remaining
+  `@EnvironmentObject AppModel` declarations, and direct
+  `objectWillChange.send()` calls.
+
+### Advisory fixtures
+
+- Keep the 500-session, multi-workspace nested-folder fixture.
+- Add a realistic active workspace fixture with 500 sessions, 2,000 transcript
+  blocks, 20 changed files, 12 provider/team records, and 100 simulated turn
+  events.
+- Measure initial construction, search, split restoration, draft editing, Git
+  refresh, team progress, and event-batch updates. Timings remain advisory;
+  publication and rebuild limits are the CI failures.
+
+### Project gates
+
+1. Generate the Xcode project and require a clean generated diff.
+2. Run `Tools/AuditDesignSystem.sh`.
+3. Run `Tools/ProtocolManifest.py` and the shared iOS wire-type typecheck.
+4. Run the full Swift unit suite.
+5. Run focused sidebar, composer, inspector, split-pane, plan/question,
+   permission, accessibility, and keyboard UI tests.
+6. Compile direct-download and App Store release configurations.
+7. Run the Python, mobile, wallet-signer, and full protected CI jobs before
+   merge.
+
+## One-PR constraints
+
+- Work on `codex/appmodel-optimization-next` from the merge commit containing
+  the session-catalog extraction.
+- Keep the six commit boundaries above; every commit must compile and pass its
+  narrow suite.
+- Do not mix backend APIs, persistence migrations, visual redesign, or feature
+  behavior with this refactor.
+- Preserve user-owned working-tree changes by doing all work in an isolated
+  worktree.
+- If a behavior cannot be characterized, add the characterization test before
+  moving it; do not defer the uncertainty to final integration.
+
+## Completion criteria
+
+The run is complete when all six commits are on one pull request, protected CI
+is green, and all of the following are true:
+
+- no child model republishes `AppModel`;
+- no manual UI-refresh bridge remains;
+- leaf views do not observe `AppModel`;
+- session, transcript, workspace, composer, and turn owners rebuild only from
+  their documented inputs;
+- current persistence keys and backend contracts are unchanged; and
+- the generated project, design audit, protocol manifest, unit tests, focused
+  UI tests, and both release configurations pass from the exact PR head.

--- a/Docs/Architecture.md
+++ b/Docs/Architecture.md
@@ -53,11 +53,12 @@ files hold the few deliberately permanent forwarders (for example
 `showToast` and the turn-critical provider/team state); each facade
 documents why its members survive.
 
-Views for a feature should observe its feature model directly
-(`model.knowledge`, `model.extensionsModel`, …). A composition view may read
-a child model through `AppModel`; when it does, `AppModel` must deliberately
-bridge publication rather than assuming nested observable objects invalidate
-their parent — every feature model is bridged in `AppModel.init` today.
+Views observe feature models directly through the scene-level
+`AppFeatureEnvironmentModifier`, or receive an existing model explicitly as an
+`@ObservedObject`. Reactive views must not reach through `AppModel` feature
+facades. `AppModel` does not republish child `objectWillChange` events; its two
+remaining child subscriptions perform capability side effects only. Computed
+facades remain temporarily for non-reactive orchestration and extension code.
 
 Dependencies flow toward feature models. A feature model must not import or
 retain `AppModel`; the composition root supplies narrow callbacks for shared

--- a/Locus.xcodeproj/project.pbxproj
+++ b/Locus.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		721E997882A22C989DED3C01 /* AppModel+ActivityCenterFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16033E84DC973F0FD1BFA21 /* AppModel+ActivityCenterFacade.swift */; };
 		7432692999A8039E364E8475 /* TranscriptPresentationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0E76969AEB69AC1D510292 /* TranscriptPresentationModel.swift */; };
 		74A5BCF6953128864737A070 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D4CA41C622A34E45EF21F54 /* Assets.xcassets */; };
+		74B231AD518C57E7E352BF79 /* AppFeatureEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A14E63C34A77899861E73ED /* AppFeatureEnvironment.swift */; };
 		75FD85BD1189A435949FBFC0 /* SessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603951DA29612321B84516AE /* SessionModels.swift */; };
 		75FF0B7CA9E8580EE2585DE0 /* CodexComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111E527F52DFD9F5F6EC39D9 /* CodexComponentTests.swift */; };
 		761AC5EBD60B20ED1FC22FEB /* WalletPublicStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC12E6C12585983905497773 /* WalletPublicStore.swift */; };
@@ -325,6 +326,7 @@
 		BFD9B220064B1A7D36E1D116 /* HostedScreenshotConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319231FBA55F2DE9A5EB9377 /* HostedScreenshotConsent.swift */; };
 		BFDA43DEA4FD15631A0D8A54 /* ScheduleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F234376C385182244FC1AA19 /* ScheduleModel.swift */; };
 		C036FA6F79B4AF1F181958E2 /* AccentPropagationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D67A726DCC6ECB4D8557128 /* AccentPropagationTests.swift */; };
+		C043E43658BD6E9DF7CA24FF /* AppFeatureEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A14E63C34A77899861E73ED /* AppFeatureEnvironment.swift */; };
 		C0888AD9C1A69FEDBCF58E8E /* TextSelectionMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB36421DC413C2F3F5BDA72 /* TextSelectionMenu.swift */; };
 		C0E82F8A928841455031CFA2 /* ProxyConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F29AE63F7A646BB5043E54 /* ProxyConfigurator.swift */; };
 		C0EB8EF86FF9954D89CC082E /* InspectorPlanTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD0CDE34355390B1AB4691E /* InspectorPlanTab.swift */; };
@@ -396,6 +398,7 @@
 		E9C0EF3C309C45C946A1D4E5 /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5118157AFFA0FF82EDCA5BED /* AppModel.swift */; };
 		E9F4EF0EA873C28080008298 /* GitWorkflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D865DBE30EBEB947619172 /* GitWorkflowTests.swift */; };
 		E9FEE16772490F3AB7B3051F /* AppModel+Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032390CC6CE531E43C5D2DEE /* AppModel+Commands.swift */; };
+		EAF862A73D4A46E4F8235990 /* AppModelObservationBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7444F14DD8EEB57AFF1D8A9 /* AppModelObservationBoundaryTests.swift */; };
 		EC06B39AD364D426B2D17A75 /* AgentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8CB595C9539FB091A47A05 /* AgentModels.swift */; };
 		ED01D2FB6F84F4B82660CD05 /* CommandAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFF6B3CE2F946B371F8A9EA /* CommandAction.swift */; };
 		EDBAB7476E0212A6FD1FA8EB /* WalletProviderCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E1A0B244EB9A2F9852BA8A /* WalletProviderCoordinator.swift */; };
@@ -611,6 +614,7 @@
 		73FB5B7D276424050FE55E24 /* LocusUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LocusUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		766496079870F565A68EE51D /* WorkspaceArtifactOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceArtifactOpener.swift; sourceTree = "<group>"; };
 		78188AFFEC80498E68C2EE3A /* SlashCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommands.swift; sourceTree = "<group>"; };
+		7A14E63C34A77899861E73ED /* AppFeatureEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureEnvironment.swift; sourceTree = "<group>"; };
 		7B7FCF48D140BDC503F90A41 /* AppModel+MobileCompanion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+MobileCompanion.swift"; sourceTree = "<group>"; };
 		7D427058C21A8F1993C532E8 /* CredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialStore.swift; sourceTree = "<group>"; };
 		7D7261686C41E5A17833AC6E /* AppModel+AgentTeamsFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+AgentTeamsFacade.swift"; sourceTree = "<group>"; };
@@ -654,6 +658,7 @@
 		A65386A2C6C14183D519D510 /* BrowserInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserInput.swift; sourceTree = "<group>"; };
 		A65C8C0698978C8CF184FCA3 /* AppModel+UITestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+UITestFixtures.swift"; sourceTree = "<group>"; };
 		A6D865DBE30EBEB947619172 /* GitWorkflowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkflowTests.swift; sourceTree = "<group>"; };
+		A7444F14DD8EEB57AFF1D8A9 /* AppModelObservationBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppModelObservationBoundaryTests.swift; sourceTree = "<group>"; };
 		A7EC9F73687880887B6C9153 /* BrowserSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserSettingsView.swift; sourceTree = "<group>"; };
 		AB6C801D489BBF80BE16EBD6 /* ChatAttachmentLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentLoader.swift; sourceTree = "<group>"; };
 		AB6FDC689EAD2746CF542B95 /* AppModel+TeamOps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+TeamOps.swift"; sourceTree = "<group>"; };
@@ -795,6 +800,7 @@
 				B8A6B77A929CA91E6E421529 /* ActivityCenterModelTests.swift */,
 				005F300A2BA98F36F1DF154C /* AgentInstructionsModelTests.swift */,
 				246491EFA199B2B975050307 /* AgentTeamsModelTests.swift */,
+				A7444F14DD8EEB57AFF1D8A9 /* AppModelObservationBoundaryTests.swift */,
 				C41E39F35E0F75A05095B5EC /* AppModelTests.swift */,
 				5F812F42D54F996DD9AE8F7D /* AppUpdateControllerTests.swift */,
 				CCBABE255234EFEAAAE40D72 /* BackendStubSupport.swift */,
@@ -888,6 +894,7 @@
 				9F997982C2B7C5C5A6F8CB20 /* AgentTeams.swift */,
 				AD57FF854E0D56B9953A1E92 /* AgentTeamsModel.swift */,
 				29912FD4FFA8E9056AD4FCA2 /* AgentTeamsSettingsView.swift */,
+				7A14E63C34A77899861E73ED /* AppFeatureEnvironment.swift */,
 				66094C6E78704DAC44D56838 /* ApplicationContextService.swift */,
 				A119AF362322FDA5B7F02E8D /* ApplicationLifecycleCoordinator.swift */,
 				81270ABC0C4D667173248A3F /* AppLifecycleJournal.swift */,
@@ -1502,6 +1509,7 @@
 				C878B1EE0046D9C203A7FEA5 /* ActivityCenterModelTests.swift in Sources */,
 				194ECD343B9C4558832D7998 /* AgentInstructionsModelTests.swift in Sources */,
 				B02DC6304F1E5B8BA6A8941A /* AgentTeamsModelTests.swift in Sources */,
+				EAF862A73D4A46E4F8235990 /* AppModelObservationBoundaryTests.swift in Sources */,
 				6CB6F6C625981B438BD534AB /* AppModelTests.swift in Sources */,
 				81859D894E60EF5508ECE7D0 /* AppUpdateControllerTests.swift in Sources */,
 				EFD1168F955FCA878E3A30E3 /* BackendStubSupport.swift in Sources */,
@@ -1566,6 +1574,7 @@
 				66859836FE528C753ABAEB49 /* AgentTeams.swift in Sources */,
 				3C0756B5AEEC8CF0B499514E /* AgentTeamsModel.swift in Sources */,
 				7161D1119A9B7183F6843C62 /* AgentTeamsSettingsView.swift in Sources */,
+				74B231AD518C57E7E352BF79 /* AppFeatureEnvironment.swift in Sources */,
 				CD5FB66D63F293316CAB7B7C /* AppLifecycleJournal.swift in Sources */,
 				721E997882A22C989DED3C01 /* AppModel+ActivityCenterFacade.swift in Sources */,
 				7E0B38C59FEFB081EAB457E5 /* AppModel+AgentTeamsFacade.swift in Sources */,
@@ -1747,6 +1756,7 @@
 				FC22E1FCFE6A7F6863A1BF05 /* AgentTeams.swift in Sources */,
 				8F0FD6852C5C0D1EA2F8ED6A /* AgentTeamsModel.swift in Sources */,
 				419A2176224E57C1AEEE8165 /* AgentTeamsSettingsView.swift in Sources */,
+				C043E43658BD6E9DF7CA24FF /* AppFeatureEnvironment.swift in Sources */,
 				90C2ED2DE9CA123B0A892707 /* AppLifecycleJournal.swift in Sources */,
 				1CBE8880E4FCED38F33D0E88 /* AppModel+ActivityCenterFacade.swift in Sources */,
 				BBA8BFD52B305C0947380763 /* AppModel+AgentTeamsFacade.swift in Sources */,

--- a/Locus/AccountEditorView.swift
+++ b/Locus/AccountEditorView.swift
@@ -7,6 +7,10 @@ import SwiftUI
 /// written while the sheet is open, so Cancel really does leave no trace.
 struct AccountEditorView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
+#if !LOCUS_APP_STORE
+    @EnvironmentObject private var codexComponent: CodexComponentInstaller
+#endif
     @Environment(\.dismiss) private var dismiss
 
     /// The account being edited, or a fresh one for the chosen provider.
@@ -241,14 +245,14 @@ struct AccountEditorView: View {
                 nativeMode = account.codexNativeModeEnabled
                 webSearch = account.codexWebSearchEnabled
                 reasoningEffort = account.codexReasoningEffortValue
-                Task { await model.providerAccountsModel.refreshChatGPTAccount(for: account) }
+                Task { await providerAccounts.refreshChatGPTAccount(for: account) }
             }
         }
     }
 
     @ViewBuilder
     private var chatGPTControls: some View {
-        let status = model.providerAccountsModel.chatGPTAccounts[account.id]
+        let status = providerAccounts.chatGPTAccounts[account.id]
         VStack(alignment: .leading, spacing: 10) {
             if let status, status.status == "signed_in" {
                 Label("Signed in", systemImage: "checkmark.circle.fill")
@@ -264,25 +268,25 @@ struct AccountEditorView: View {
                 HStack {
                     Button("Refresh") {
                         Task {
-                            await model.providerAccountsModel.refreshChatGPTAccount(
+                            await providerAccounts.refreshChatGPTAccount(
                                 for: account,
                                 forceTokenRefresh: true
                             )
                         }
                     }
                     Button("Sign Out") {
-                        Task { await model.providerAccountsModel.signOutChatGPT(from: account) }
+                        Task { await providerAccounts.signOutChatGPT(from: account) }
                     }
                 }
-            } else if model.providerAccountsModel.chatGPTLoginIDs[account.id] != nil {
+            } else if providerAccounts.chatGPTLoginIDs[account.id] != nil {
                 Label("Finish signing in in your browser", systemImage: "safari")
                     .font(.locus(size: 10, weight: .semibold))
                 HStack {
                     Button("Refresh Status") {
-                        Task { await model.providerAccountsModel.refreshChatGPTAccount(for: account) }
+                        Task { await providerAccounts.refreshChatGPTAccount(for: account) }
                     }
                     Button("Cancel Login") {
-                        Task { await model.providerAccountsModel.cancelChatGPTLogin(for: account) }
+                        Task { await providerAccounts.cancelChatGPTLogin(for: account) }
                     }
                 }
             } else if model.chatGPTComponentMissing {
@@ -295,7 +299,7 @@ struct AccountEditorView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Button("Sign in with ChatGPT") {
-                    Task { await model.providerAccountsModel.startChatGPTLogin(for: account) }
+                    Task { await providerAccounts.startChatGPTLogin(for: account) }
                 }
                 .disabled(status?.runtimeAvailable == false)
                 .accessibilityIdentifier("accountEditor.chatGPT.signIn")
@@ -338,7 +342,7 @@ struct AccountEditorView: View {
     /// catalog; a fixed list stands in before the catalog has arrived. The
     /// stored choice is kept selectable even when the catalog drops it.
     private var reasoningEffortOptions: [String] {
-        var efforts = model.providerAccountsModel.accountModelCatalogs[account.id]?
+        var efforts = providerAccounts.accountModelCatalogs[account.id]?
             .first(where: { $0.id == account.preferredModel })?
             .supportedReasoningEfforts?
             .map(\.effort) ?? []
@@ -362,7 +366,7 @@ struct AccountEditorView: View {
     @ViewBuilder
     private var componentDownload: some View {
         VStack(alignment: .leading, spacing: 8) {
-            switch model.codexComponent.state {
+            switch codexComponent.state {
             case .idle:
                 Text(
                     "Using a ChatGPT plan needs a one-time component from SparkTales. "
@@ -382,7 +386,7 @@ struct AccountEditorView: View {
                     "Downloading \(byteLabel(received)) of \(byteLabel(total))…",
                     fraction: total > 0 ? Double(received) / Double(total) : nil
                 )
-                Button("Cancel") { model.codexComponent.cancel() }
+                Button("Cancel") { codexComponent.cancel() }
             case .verifying:
                 progressRow("Verifying the signature…", fraction: nil)
             case .installing:

--- a/Locus/AgentTeamsSettingsView.swift
+++ b/Locus/AgentTeamsSettingsView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct AgentTeamsSettingsView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
+    @EnvironmentObject private var evaluations: EvaluationsModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
     @Binding var advancedExpanded: Bool
     @State private var editingPrimaryAgent = false
     @State private var editingProfile: AgentProfile?
@@ -40,28 +43,28 @@ struct AgentTeamsSettingsView: View {
         .accessibilityIdentifier("settings.agents.root")
         .sheet(item: $editingProfile) { profile in
             AgentProfileEditor(profile: profile) {
-                model.agentTeamsModel.saveAgentProfile($0)
+                agentTeams.saveAgentProfile($0)
                 editingProfile = nil
             }
             .environmentObject(model)
         }
         .sheet(isPresented: $quickTeamPresented) {
-            QuickTeamBuilderView(suggestedName: model.agentTeamsModel.suggestedQuickTeamName())
+            QuickTeamBuilderView(suggestedName: agentTeams.suggestedQuickTeamName())
                 .environmentObject(model)
         }
         .sheet(isPresented: $editingPrimaryAgent) {
             AgentBehaviorEditor(
                 title: "Primary Agent",
-                behavior: model.agentTeamsModel.primaryAgentBehavior,
+                behavior: agentTeams.primaryAgentBehavior,
                 modelName: model.selectedModel
             ) {
-                model.agentTeamsModel.savePrimaryAgentBehavior($0)
+                agentTeams.savePrimaryAgentBehavior($0)
                 editingPrimaryAgent = false
             }
         }
         .sheet(item: $editingTeam) { team in
             AgentTeamEditor(team: team) {
-                model.agentTeamsModel.saveAgentTeam($0)
+                agentTeams.saveAgentTeam($0)
                 editingTeam = nil
             }
             .environmentObject(model)
@@ -71,7 +74,7 @@ struct AgentTeamsSettingsView: View {
         }
         .sheet(item: $editingSuite) { suite in
             EvaluationSuiteEditor(suite: suite) {
-                model.evaluations.saveEvaluationSuite($0)
+                evaluations.saveEvaluationSuite($0)
                 editingSuite = nil
             }
             .environmentObject(model)
@@ -86,7 +89,7 @@ struct AgentTeamsSettingsView: View {
         ) {
             if let account = consentAccount {
                 Button("Allow \(account.displayName)") {
-                    model.agentTeamsModel.grantAutomaticRoutingConsent(for: account.id)
+                    agentTeams.grantAutomaticRoutingConsent(for: account.id)
                     consentAccount = nil
                 }
             }
@@ -127,8 +130,8 @@ struct AgentTeamsSettingsView: View {
     private var runtimeSection: some View {
         Section("Scheduler") {
             Stepper(
-                "Up to \(model.agentTeamsModel.globalAgentConcurrency) simultaneous model calls",
-                value: $model.globalAgentConcurrency,
+                "Up to \(agentTeams.globalAgentConcurrency) simultaneous model calls",
+                value: $agentTeams.globalAgentConcurrency,
                 in: 1...8
             )
             Text("Shared fairly across running chats. Expired worker leases are reclaimed after a crash.")
@@ -141,7 +144,7 @@ struct AgentTeamsSettingsView: View {
         Section("Primary agent") {
             HStack {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(model.agentTeamsModel.primaryAgentBehavior.displayName)
+                    Text(agentTeams.primaryAgentBehavior.displayName)
                         .font(.locus(size: 11, weight: .semibold))
                     Text("Conversation model · \(model.selectedModel)")
                         .font(.caption)
@@ -170,10 +173,10 @@ struct AgentTeamsSettingsView: View {
                 accessCeiling: role == .implementer ? .workspaceWrite : .readOnly
             )
         } content: {
-            if model.agentProfiles.isEmpty {
+            if agentTeams.agentProfiles.isEmpty {
                 emptyRow("No agent profiles yet. Start with a Dispatcher and Implementer.")
             } else {
-                ForEach(model.agentProfiles) { profile in
+                ForEach(agentTeams.agentProfiles) { profile in
                     HStack(spacing: 10) {
                         providerLogo(for: profile.route)
                         VStack(alignment: .leading, spacing: 2) {
@@ -186,7 +189,7 @@ struct AgentTeamsSettingsView: View {
                         Spacer()
                         Button("Edit") { editingProfile = profile }
                             .buttonStyle(.locus())
-                        Button(role: .destructive) { model.agentTeamsModel.removeAgentProfile(profile) } label: {
+                        Button(role: .destructive) { agentTeams.removeAgentProfile(profile) } label: {
                             Image(systemName: "trash")
                         }
                         .buttonStyle(.locus())
@@ -200,8 +203,8 @@ struct AgentTeamsSettingsView: View {
 
     private var teamsSection: some View {
         settingsSection(title: "Teams", actionTitle: "Add Team") {
-            let dispatcher = model.agentProfiles.first(where: { $0.role == .dispatcher })
-            let writer = model.agentProfiles.first(where: { $0.accessCeiling.canWrite })
+            let dispatcher = agentTeams.agentProfiles.first(where: { $0.role == .dispatcher })
+            let writer = agentTeams.agentProfiles.first(where: { $0.accessCeiling.canWrite })
             let members = Array(Set([dispatcher?.id, writer?.id].compactMap { $0 }))
             editingTeam = AgentTeam(
                 name: "New Team",
@@ -214,11 +217,11 @@ struct AgentTeamsSettingsView: View {
                 routingWeights: .init()
             )
         } content: {
-            if model.agentTeams.isEmpty {
+            if agentTeams.agentTeams.isEmpty {
                 emptyRow("Teams are explicit: add a dispatcher, a lead writer, other coding agents, and any read-only specialists.")
             } else {
-                ForEach(model.agentTeams) { team in
-                    let errors = AgentTeamValidation.errors(team: team, profiles: model.agentProfiles)
+                ForEach(agentTeams.agentTeams) { team in
+                    let errors = AgentTeamValidation.errors(team: team, profiles: agentTeams.agentProfiles)
                     HStack(spacing: 10) {
                         Image(systemName: errors.isEmpty ? "person.2.fill" : "exclamationmark.triangle.fill")
                             .foregroundStyle(errors.isEmpty ? LocusTheme.signalDeep : LocusTheme.coral)
@@ -233,7 +236,7 @@ struct AgentTeamsSettingsView: View {
                         Spacer()
                         Button("Edit") { editingTeam = team }
                             .buttonStyle(.locus())
-                        Button(role: .destructive) { model.agentTeamsModel.removeAgentTeam(team) } label: {
+                        Button(role: .destructive) { agentTeams.removeAgentTeam(team) } label: {
                             Image(systemName: "trash")
                         }
                         .buttonStyle(.locus())
@@ -250,7 +253,7 @@ struct AgentTeamsSettingsView: View {
             Text("Locus asks once per account before a dispatcher may route team data to it automatically.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            ForEach(model.providerAccounts) { account in
+            ForEach(providerAccounts.providerAccounts) { account in
                 HStack(spacing: 10) {
                     ProviderLogo(
                         kind: account.kind,
@@ -264,8 +267,8 @@ struct AgentTeamsSettingsView: View {
                             .foregroundStyle(LocusTheme.muted)
                     }
                     Spacer()
-                    if model.agentTeamsModel.teamRoutingConsentAccountIDs.contains(account.id) {
-                        Button("Revoke") { model.agentTeamsModel.revokeAutomaticRoutingConsent(for: account.id) }
+                    if agentTeams.teamRoutingConsentAccountIDs.contains(account.id) {
+                        Button("Revoke") { agentTeams.revokeAutomaticRoutingConsent(for: account.id) }
                             .buttonStyle(.locus())
                     } else {
                         Button("Allow…") { consentAccount = account }
@@ -303,23 +306,23 @@ struct AgentTeamsSettingsView: View {
 
     private var evaluationsSection: some View {
         settingsSection(title: "Evaluation Lab", actionTitle: "Add Suite") {
-            model.evaluations.createEvaluationSuite()
+            evaluations.createEvaluationSuite()
         } content: {
             HStack {
                 Text("Local, reproducible suites")
                     .font(.locus(size: 8))
                     .foregroundStyle(LocusTheme.muted)
                 Spacer()
-                Button("Import JSON") { model.evaluations.importEvaluationSuite() }
+                Button("Import JSON") { evaluations.importEvaluationSuite() }
                     .buttonStyle(.locus())
                     .font(.locus(size: 8, weight: .semibold))
             }
             .padding(.vertical, 7)
             Divider()
-            if model.evaluations.evaluationSuites.isEmpty {
+            if evaluations.evaluationSuites.isEmpty {
                 emptyRow("Reusable local cases compare team quality, reliability, latency, tokens, and cost without touching the source workspace.")
             } else {
-                ForEach(model.evaluations.evaluationSuites) { suite in
+                ForEach(evaluations.evaluationSuites) { suite in
                     HStack(spacing: 10) {
                         Image(systemName: "checkmark.seal")
                             .foregroundStyle(LocusTheme.signalDeep)
@@ -330,24 +333,24 @@ struct AgentTeamsSettingsView: View {
                                 .foregroundStyle(LocusTheme.muted)
                         }
                         Spacer()
-                        Button("Run") { model.evaluations.runEvaluationSuite(suite) }
+                        Button("Run") { evaluations.runEvaluationSuite(suite) }
                             .buttonStyle(.bordered)
                             .controlSize(.small)
                             .disabled(
                                 model.isBusy
                                     || (suite.cases.contains { $0.target == "team" }
-                                        && model.selectedAgentTeam == nil)
+                                        && agentTeams.selectedAgentTeam == nil)
                             )
                         Button("Edit") { editingSuite = suite }.buttonStyle(.locus())
                         Button("Results") {
-                            Task { evaluationReport = await model.evaluations.loadEvaluationReport(suite) }
+                            Task { evaluationReport = await evaluations.loadEvaluationReport(suite) }
                         }
                         .buttonStyle(.locus())
-                        Button { model.evaluations.exportEvaluationSuite(suite) } label: {
+                        Button { evaluations.exportEvaluationSuite(suite) } label: {
                             Image(systemName: "square.and.arrow.up")
                         }
                         .buttonStyle(.locus())
-                        Button(role: .destructive) { model.evaluations.deleteEvaluationSuite(suite) } label: {
+                        Button(role: .destructive) { evaluations.deleteEvaluationSuite(suite) } label: {
                             Image(systemName: "trash")
                         }
                         .buttonStyle(.locus())
@@ -357,18 +360,18 @@ struct AgentTeamsSettingsView: View {
                     Divider()
                 }
             }
-            if let status = model.evaluations.evaluationStatus {
-                Label(status, systemImage: model.evaluations.activeEvaluationID == nil ? "checkmark.circle" : "progress.indicator")
+            if let status = evaluations.evaluationStatus {
+                Label(status, systemImage: evaluations.activeEvaluationID == nil ? "checkmark.circle" : "progress.indicator")
                     .font(.locus(size: 9, weight: .medium))
                     .foregroundStyle(LocusTheme.muted)
                     .padding(.vertical, 6)
             }
         }
-        .task { await model.evaluations.refreshEvaluations() }
+        .task { await evaluations.refreshEvaluations() }
     }
 
     private var nextSuggestedRole: AgentRole {
-        AgentRole.allCases.first { role in !model.agentProfiles.contains(where: { $0.role == role }) }
+        AgentRole.allCases.first { role in !agentTeams.agentProfiles.contains(where: { $0.role == role }) }
             ?? .generalist
     }
 
@@ -376,7 +379,7 @@ struct AgentTeamsSettingsView: View {
         switch route {
         case .localOllama: "Local Ollama"
         case .providerAccount(let id):
-            model.providerAccounts.first(where: { $0.id == id })?.displayName ?? "Unavailable account"
+            providerAccounts.providerAccounts.first(where: { $0.id == id })?.displayName ?? "Unavailable account"
         }
     }
 
@@ -413,7 +416,7 @@ struct AgentTeamsSettingsView: View {
         case .localOllama:
             ProviderLogo(name: "Ollama", size: 26)
         case .providerAccount(let id):
-            if let account = model.providerAccounts.first(where: { $0.id == id }) {
+            if let account = providerAccounts.providerAccounts.first(where: { $0.id == id }) {
                 ProviderLogo(
                     kind: account.kind,
                     name: account.displayName,
@@ -429,6 +432,8 @@ struct AgentTeamsSettingsView: View {
 
 struct QuickTeamBuilderView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
     @Environment(\.dismiss) private var dismiss
     @State private var draft: QuickTeamDraft
     @State private var activeLane: Lane = .dispatcher
@@ -502,7 +507,7 @@ struct QuickTeamBuilderView: View {
         .accessibilityIdentifier("quickTeam.builder")
         .task {
             await model.refreshMetadata()
-            await model.providerAccountsModel.refreshAccountCatalogs(force: true)
+            await providerAccounts.refreshAccountCatalogs(force: true)
         }
         .confirmationDialog(
             "Allow automatic hosted routing?",
@@ -514,7 +519,7 @@ struct QuickTeamBuilderView: View {
         ) {
             if let account = consentAccount {
                 Button("Allow \(account.displayName)") {
-                    model.agentTeamsModel.grantAutomaticRoutingConsent(for: account.id)
+                    agentTeams.grantAutomaticRoutingConsent(for: account.id)
                     consentAccount = nil
                 }
             }
@@ -801,7 +806,7 @@ struct QuickTeamBuilderView: View {
 
     @ViewBuilder
     private var consentSection: some View {
-        let accounts = model.agentTeamsModel.missingQuickTeamRoutingAccounts(for: draft)
+        let accounts = agentTeams.missingQuickTeamRoutingAccounts(for: draft)
         if !accounts.isEmpty {
             VStack(alignment: .leading, spacing: 9) {
                 Label("Hosted routing needs your approval", systemImage: "lock.shield.fill")
@@ -906,7 +911,7 @@ struct QuickTeamBuilderView: View {
         if model.isBusy { return "Stop the active run before creating a team." }
         let name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
         if name.isEmpty { return "Give the team a name." }
-        if model.agentTeams.contains(where: {
+        if agentTeams.agentTeams.contains(where: {
             $0.name.caseInsensitiveCompare(name) == .orderedSame
         }) {
             return "A team with that name already exists."
@@ -919,7 +924,7 @@ struct QuickTeamBuilderView: View {
         {
             return "A selected model is no longer available. Refresh and choose again."
         }
-        if let account = model.agentTeamsModel.missingQuickTeamRoutingAccounts(for: draft).first {
+        if let account = agentTeams.missingQuickTeamRoutingAccounts(for: draft).first {
             return "Allow routing for \(account.displayName) to continue."
         }
         return nil
@@ -983,7 +988,7 @@ struct QuickTeamBuilderView: View {
 
     private func createTeam() {
         creationError = nil
-        switch model.agentTeamsModel.createAndSelectQuickTeam(draft) {
+        switch agentTeams.createAndSelectQuickTeam(draft) {
         case .success:
             dismiss()
         case .failure(let error):
@@ -1332,6 +1337,8 @@ private struct AgentBehaviorEditor: View {
 struct AgentProfileEditor: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var extensionsModel: ExtensionsModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
     @Environment(\.dismiss) private var dismiss
     @State private var draft: AgentProfile
     @State private var tags: String
@@ -1375,7 +1382,7 @@ struct AgentProfileEditor: View {
                             .accessibilityIdentifier("agent.role")
                             Picker("Provider route", selection: $draft.route) {
                                 Text("Local Ollama").tag(AgentRoute.localOllama)
-                                ForEach(model.providerAccounts) { account in
+                                ForEach(providerAccounts.providerAccounts) { account in
                                     Text(account.displayName).tag(AgentRoute.providerAccount(account.id))
                                 }
                             }
@@ -1694,7 +1701,7 @@ struct AgentProfileEditor: View {
                 .font(.locus(size: 8, weight: .bold))
                 .tracking(0.8)
                 .foregroundStyle(LocusTheme.muted)
-            ForEach(model.extensionsModel.extensions.mcpServers) { server in
+            ForEach(extensionsModel.extensions.mcpServers) { server in
                 Toggle(server.name, isOn: Binding(
                     get: { draft.mcpPolicy?.serverIDs.contains(server.id) == true },
                     set: { enabled in
@@ -1762,13 +1769,13 @@ struct AgentProfileEditor: View {
         let values: [String]
         switch draft.route {
         case .localOllama:
-            values = model.providerAccountsModel.localModels.map(\.name)
+            values = providerAccounts.localModels.map(\.name)
         case .providerAccount(let id):
-            guard let account = model.providerAccounts.first(where: { $0.id == id }) else {
+            guard let account = providerAccounts.providerAccounts.first(where: { $0.id == id }) else {
                 return []
             }
             if account.kind.listsModels,
-               let reported = model.accountModels[id],
+               let reported = providerAccounts.accountModels[id],
                !reported.isEmpty
             {
                 values = account.kind == .custom ? reported : reported.filter {
@@ -1799,7 +1806,7 @@ struct AgentProfileEditor: View {
         case .localOllama:
             await model.refreshMetadata()
         case .providerAccount:
-            await model.providerAccountsModel.refreshAccountCatalogs(force: true)
+            await providerAccounts.refreshAccountCatalogs(force: true)
         }
     }
 
@@ -1812,6 +1819,8 @@ struct AgentProfileEditor: View {
 
 private struct AgentTeamEditor: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
     @Environment(\.dismiss) private var dismiss
     @State private var draft: AgentTeam
     @State private var evaluationTags: String
@@ -1832,14 +1841,14 @@ private struct AgentTeamEditor: View {
             draft.resolvedSwarmPolicy.engine == .openAIResponses && !openAIEngineEligible
         ) ? ["OpenAI Responses requires an OpenAI API dispatcher on GPT-5.6."] : []
         let errors = AgentTeamValidation.errors(
-            team: draft, profiles: model.agentProfiles
+            team: draft, profiles: agentTeams.agentProfiles
         ) + engineErrors
         VStack(spacing: 0) {
             ScrollView {
                 Form {
                     TextField("Team name", text: $draft.name)
                     Section("Members") {
-                        ForEach(model.agentProfiles) { profile in
+                        ForEach(agentTeams.agentProfiles) { profile in
                             Toggle(isOn: Binding(
                                 get: { draft.memberIDs.contains(profile.id) },
                                 set: { included in
@@ -2037,14 +2046,14 @@ private struct AgentTeamEditor: View {
     }
 
     private var memberProfiles: [AgentProfile] {
-        model.agentProfiles.filter { draft.memberIDs.contains($0.id) }
+        agentTeams.agentProfiles.filter { draft.memberIDs.contains($0.id) }
     }
 
     private var openAIEngineEligible: Bool {
         guard let dispatcherID = draft.dispatcherID,
-              let dispatcher = model.agentProfiles.first(where: { $0.id == dispatcherID }),
+              let dispatcher = agentTeams.agentProfiles.first(where: { $0.id == dispatcherID }),
               case .providerAccount(let accountID) = dispatcher.route,
-              model.providerAccounts.first(where: { $0.id == accountID })?.kind == .codex
+              providerAccounts.providerAccounts.first(where: { $0.id == accountID })?.kind == .codex
         else { return false }
         let name = dispatcher.model.lowercased()
         return name == "gpt-5.6" || name.hasPrefix("gpt-5.6-")
@@ -2081,6 +2090,7 @@ private struct AgentTeamEditor: View {
 private struct EvaluationSuiteEditor: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
     @State private var draft: EvaluationSuite
     @State private var tags: String
     let onSave: (EvaluationSuite) -> Void
@@ -2142,7 +2152,7 @@ private struct EvaluationSuiteEditor: View {
                             if draft.cases[index].target == "team" {
                                 Picker("Team", selection: $draft.cases[index].teamID) {
                                     Text("Selected team when run").tag("")
-                                    ForEach(model.agentTeams) { team in
+                                    ForEach(agentTeams.agentTeams) { team in
                                         Text(team.name).tag(team.id.uuidString)
                                     }
                                 }
@@ -2179,7 +2189,7 @@ private struct EvaluationSuiteEditor: View {
                         if !draft.cases[index].rubric.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                             Picker("Blind judge", selection: $draft.cases[index].judgeProfileID) {
                                 Text("No subjective judge").tag("")
-                                ForEach(model.agentProfiles.filter { $0.role == .reviewer }) { profile in
+                                ForEach(agentTeams.agentProfiles.filter { $0.role == .reviewer }) { profile in
                                     Text(profile.name).tag(profile.id.uuidString)
                                 }
                             }
@@ -2320,6 +2330,8 @@ private struct EvaluationSuiteEditor: View {
 
 struct WorkspaceKnowledgeSettingsView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
+    @EnvironmentObject private var knowledge: WorkspaceKnowledgeModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Binding var advancedExpanded: Bool
     @State private var enabled = true
@@ -2335,9 +2347,9 @@ struct WorkspaceKnowledgeSettingsView: View {
         Form {
             Section("Saved memory") {
                 Picker("Memory owner", selection: $selectedMemoryAgentID) {
-                    Text("Primary · \(model.agentTeamsModel.primaryAgentBehavior.displayName)")
+                    Text("Primary · \(agentTeams.primaryAgentBehavior.displayName)")
                         .tag("primary")
-                    ForEach(model.agentProfiles) { profile in
+                    ForEach(agentTeams.agentProfiles) { profile in
                         Text(profile.name).tag(profile.id.uuidString)
                     }
                 }
@@ -2345,7 +2357,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                if let vault = model.knowledge.memoryVaultStatus {
+                if let vault = knowledge.memoryVaultStatus {
                     Label {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(vault.encrypted ? "Private on this Mac" : "Encryption needs attention")
@@ -2364,9 +2376,9 @@ struct WorkspaceKnowledgeSettingsView: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Memory Inbox")
                             .fontWeight(.semibold)
-                        Text(model.knowledge.memoryCandidates.isEmpty
+                        Text(knowledge.memoryCandidates.isEmpty
                             ? "No suggestions waiting for review"
-                            : "\(model.knowledge.memoryCandidates.count) suggestion\(model.knowledge.memoryCandidates.count == 1 ? "" : "s") waiting")
+                            : "\(knowledge.memoryCandidates.count) suggestion\(knowledge.memoryCandidates.count == 1 ? "" : "s") waiting")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -2375,7 +2387,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                 }
                 .id("settings.memory.saved")
 
-                ForEach(model.knowledge.memoryCandidates) { memory in
+                ForEach(knowledge.memoryCandidates) { memory in
                     VStack(alignment: .leading, spacing: 6) {
                         Text(memory.title).fontWeight(.semibold)
                         Text(memory.content)
@@ -2390,14 +2402,14 @@ struct WorkspaceKnowledgeSettingsView: View {
                             }
                             Spacer()
                             Button("Reject", role: .destructive) {
-                                model.knowledge.deleteWorkspaceMemory(memory, agentID: selectedMemoryAgentID)
+                                knowledge.deleteWorkspaceMemory(memory, agentID: selectedMemoryAgentID)
                             }
                             if memory.hasConflicts {
                                 Button("Keep Both") {
-                                    model.knowledge.approveMemoryCandidate(memory, agentID: selectedMemoryAgentID)
+                                    knowledge.approveMemoryCandidate(memory, agentID: selectedMemoryAgentID)
                                 }
                                 Button("Replace Older") {
-                                    model.knowledge.approveMemoryCandidate(
+                                    knowledge.approveMemoryCandidate(
                                         memory,
                                         agentID: selectedMemoryAgentID,
                                         replacingConflicts: true
@@ -2407,7 +2419,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                                 .tint(LocusTheme.ink)
                             } else {
                                 Button("Approve") {
-                                    model.knowledge.approveMemoryCandidate(memory, agentID: selectedMemoryAgentID)
+                                    knowledge.approveMemoryCandidate(memory, agentID: selectedMemoryAgentID)
                                 }
                                 .buttonStyle(.borderedProminent)
                                 .tint(LocusTheme.ink)
@@ -2417,7 +2429,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                     .padding(.vertical, 3)
                 }
 
-                ForEach(model.knowledge.workspaceMemories) { memory in
+                ForEach(knowledge.workspaceMemories) { memory in
                     HStack(alignment: .top, spacing: 10) {
                         Image(systemName: memory.pinned ? "pin.fill" : "bookmark")
                             .foregroundStyle(memory.stale ? LocusTheme.warning : LocusTheme.accentAction)
@@ -2462,14 +2474,14 @@ struct WorkspaceKnowledgeSettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
-                    Text(model.knowledge.contextSnapshots.count.formatted())
+                    Text(knowledge.contextSnapshots.count.formatted())
                         .foregroundStyle(.secondary)
-                    Button("Clear All", role: .destructive) { model.knowledge.clearContextSnapshots() }
-                        .disabled(model.knowledge.contextSnapshots.isEmpty)
+                    Button("Clear All", role: .destructive) { knowledge.clearContextSnapshots() }
+                        .disabled(knowledge.contextSnapshots.isEmpty)
                 }
                 .id("settings.memory.context")
 
-                ForEach(model.knowledge.contextSnapshots.prefix(8)) { snapshot in
+                ForEach(knowledge.contextSnapshots.prefix(8)) { snapshot in
                     HStack(alignment: .top, spacing: 10) {
                         Image(systemName: snapshot.pinned ? "pin.fill" : "clock.arrow.circlepath")
                             .foregroundStyle(snapshot.pinned ? LocusTheme.accentAction : .secondary)
@@ -2484,9 +2496,9 @@ struct WorkspaceKnowledgeSettingsView: View {
                         }
                         Spacer()
                         Button(snapshot.pinned ? "Unpin" : "Pin") {
-                            model.knowledge.setContextSnapshotPinned(snapshot, pinned: !snapshot.pinned)
+                            knowledge.setContextSnapshotPinned(snapshot, pinned: !snapshot.pinned)
                         }
-                        Button(role: .destructive) { model.knowledge.deleteContextSnapshot(snapshot) } label: {
+                        Button(role: .destructive) { knowledge.deleteContextSnapshot(snapshot) } label: {
                             Image(systemName: "trash")
                         }
                     }
@@ -2509,10 +2521,10 @@ struct WorkspaceKnowledgeSettingsView: View {
         .formStyle(.grouped)
         .accessibilityIdentifier("settings.knowledge.root")
         .task(id: selectedMemoryAgentID) {
-            await model.knowledge.refreshWorkspaceKnowledge(agentID: selectedMemoryAgentID)
+            await knowledge.refreshWorkspaceKnowledge(agentID: selectedMemoryAgentID)
             syncDraft()
         }
-        .onChange(of: model.knowledge.knowledgeStatus) { _, _ in syncDraft() }
+        .onChange(of: knowledge.knowledgeStatus) { _, _ in syncDraft() }
         .sheet(item: $memoryDraft) { draft in
             WorkspaceMemoryEditor(draft: draft) { value in
                 saveMemoryDraft(value)
@@ -2525,7 +2537,7 @@ struct WorkspaceKnowledgeSettingsView: View {
             titleVisibility: .visible
         ) {
             Button("Delete Index and Memories", role: .destructive) {
-                model.knowledge.deleteAllWorkspaceKnowledge(agentID: selectedMemoryAgentID)
+                knowledge.deleteAllWorkspaceKnowledge(agentID: selectedMemoryAgentID)
             }
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -2537,7 +2549,7 @@ struct WorkspaceKnowledgeSettingsView: View {
             titleVisibility: .visible
         ) {
             Button("Delete Personal, Workspace & Agent Memory", role: .destructive) {
-                model.knowledge.deleteAllMemory(agentID: selectedMemoryAgentID)
+                knowledge.deleteAllMemory(agentID: selectedMemoryAgentID)
             }
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -2571,7 +2583,7 @@ struct WorkspaceKnowledgeSettingsView: View {
             )
             HStack {
                 Button("Save Index Settings") {
-                    model.knowledge.configureWorkspaceKnowledge(
+                    knowledge.configureWorkspaceKnowledge(
                         enabled: enabled,
                         embeddingModel: embeddingModel,
                         exclusions: exclusions.split(separator: ",").map {
@@ -2581,10 +2593,10 @@ struct WorkspaceKnowledgeSettingsView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(LocusTheme.ink)
-                Button("Rebuild Index") { model.knowledge.rebuildWorkspaceKnowledge() }
+                Button("Rebuild Index") { knowledge.rebuildWorkspaceKnowledge() }
                     .disabled(!enabled || model.isBusy)
             }
-            if let status = model.knowledge.knowledgeStatus {
+            if let status = knowledge.knowledgeStatus {
                 Text("\(status.documentCount) indexed files · \(status.chunkCount) searchable chunks")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -2599,11 +2611,11 @@ struct WorkspaceKnowledgeSettingsView: View {
 
         Section("Backup and maintenance") {
             HStack {
-                Button("Review Health") { model.knowledge.reviewMemoryHealth(agentID: selectedMemoryAgentID) }
-                Button("Import Memory…") { model.knowledge.importMemory(agentID: selectedMemoryAgentID) }
-                Button("Export Memory…") { model.knowledge.exportMemory(agentID: selectedMemoryAgentID) }
+                Button("Review Health") { knowledge.reviewMemoryHealth(agentID: selectedMemoryAgentID) }
+                Button("Import Memory…") { knowledge.importMemory(agentID: selectedMemoryAgentID) }
+                Button("Export Memory…") { knowledge.exportMemory(agentID: selectedMemoryAgentID) }
             }
-            if let vault = model.knowledge.memoryVaultStatus {
+            if let vault = knowledge.memoryVaultStatus {
                 Text("\(vault.cipher) · memory text and optional vectors are encrypted together on this Mac.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -2618,15 +2630,15 @@ struct WorkspaceKnowledgeSettingsView: View {
 
         Section("Skill observations") {
             HStack {
-                Text(model.knowledge.skillObservations.isEmpty
+                Text(knowledge.skillObservations.isEmpty
                     ? "No observations recorded"
-                    : "\(model.knowledge.skillObservations.count) improvement note\(model.knowledge.skillObservations.count == 1 ? "" : "s")")
+                    : "\(knowledge.skillObservations.count) improvement note\(knowledge.skillObservations.count == 1 ? "" : "s")")
                     .foregroundStyle(.secondary)
                 Spacer()
-                Button("Export…") { model.knowledge.exportSkillObservations() }
-                    .disabled(model.knowledge.skillObservations.isEmpty)
+                Button("Export…") { knowledge.exportSkillObservations() }
+                    .disabled(knowledge.skillObservations.isEmpty)
             }
-            ForEach(model.knowledge.skillObservations.prefix(20)) { observation in
+            ForEach(knowledge.skillObservations.prefix(20)) { observation in
                 HStack(alignment: .top, spacing: 10) {
                     Text("#\(observation.number)")
                         .font(.caption.monospacedDigit())
@@ -2640,17 +2652,17 @@ struct WorkspaceKnowledgeSettingsView: View {
                     Spacer()
                     if observation.status == "OPEN" {
                         Button("Actioned") {
-                            model.knowledge.setSkillObservationStatus(observation, status: "ACTIONED")
+                            knowledge.setSkillObservationStatus(observation, status: "ACTIONED")
                         }
                         Button("Decline") {
-                            model.knowledge.setSkillObservationStatus(observation, status: "DECLINED")
+                            knowledge.setSkillObservationStatus(observation, status: "DECLINED")
                         }
                     } else {
                         Button("Reopen") {
-                            model.knowledge.setSkillObservationStatus(observation, status: "OPEN")
+                            knowledge.setSkillObservationStatus(observation, status: "OPEN")
                         }
                     }
-                    Button(role: .destructive) { model.knowledge.deleteSkillObservation(observation) } label: {
+                    Button(role: .destructive) { knowledge.deleteSkillObservation(observation) } label: {
                         Image(systemName: "trash")
                     }
                 }
@@ -2659,11 +2671,11 @@ struct WorkspaceKnowledgeSettingsView: View {
 
         Section("Memory health") {
             Button("Analyze Selected Chat") {
-                model.knowledge.reprocessCurrentChatMemory(agentID: selectedMemoryAgentID)
+                knowledge.reprocessCurrentChatMemory(agentID: selectedMemoryAgentID)
             }
             .disabled(model.currentSessionID.isEmpty || model.isBusy)
             .accessibilityIdentifier("memory.health.analyze")
-            if let report = model.knowledge.memoryDiagnosticReport {
+            if let report = knowledge.memoryDiagnosticReport {
                 Text("\(report.approvedCount) approved · \(report.candidateCount) pending · \(report.staleCount ?? 0) stale")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -2682,7 +2694,7 @@ struct WorkspaceKnowledgeSettingsView: View {
     }
 
     private var knowledgeSummary: String {
-        guard let status = model.knowledge.knowledgeStatus else { return "Loading index status…" }
+        guard let status = knowledge.knowledgeStatus else { return "Loading index status…" }
         let method = status.embeddingModel.isEmpty ? "text search" : "text and local semantic search"
         return status.enabled
             ? "\(status.documentCount) files indexed with \(method)."
@@ -2698,16 +2710,16 @@ struct WorkspaceKnowledgeSettingsView: View {
             Button(memory.pinned ? "Unpin" : "Pin") {
                 var value = memory
                 value.pinned.toggle()
-                model.knowledge.updateWorkspaceMemory(value, agentID: selectedMemoryAgentID)
+                knowledge.updateWorkspaceMemory(value, agentID: selectedMemoryAgentID)
             }
             Button(memory.stale ? "Mark Current" : "Mark Stale") {
                 var value = memory
                 value.stale.toggle()
-                model.knowledge.updateWorkspaceMemory(value, agentID: selectedMemoryAgentID)
+                knowledge.updateWorkspaceMemory(value, agentID: selectedMemoryAgentID)
             }
             Divider()
             Button("Delete", role: .destructive) {
-                model.knowledge.deleteWorkspaceMemory(memory, agentID: selectedMemoryAgentID)
+                knowledge.deleteWorkspaceMemory(memory, agentID: selectedMemoryAgentID)
             }
         } label: {
             Image(systemName: "ellipsis.circle")
@@ -2719,7 +2731,7 @@ struct WorkspaceKnowledgeSettingsView: View {
     private func saveMemoryDraft(_ value: WorkspaceMemoryDraft) {
         switch value.original {
         case .none:
-            model.knowledge.rememberWorkspaceFact(
+            knowledge.rememberWorkspaceFact(
                 title: value.title,
                 content: value.content,
                 tags: value.tags.split(separator: ",").map(String.init),
@@ -2737,7 +2749,7 @@ struct WorkspaceKnowledgeSettingsView: View {
             memory.kind = value.kind.rawValue
             memory.confidence = value.confidence
             memory.validUntil = value.expires ? value.validUntil.timeIntervalSince1970 : nil
-            model.knowledge.updateWorkspaceMemory(memory, agentID: selectedMemoryAgentID)
+            knowledge.updateWorkspaceMemory(memory, agentID: selectedMemoryAgentID)
         }
     }
 
@@ -2760,9 +2772,9 @@ struct WorkspaceKnowledgeSettingsView: View {
                     Text("Memory owner")
                         .font(.locus(size: 9, weight: .semibold))
                     Picker("Memory owner", selection: $selectedMemoryAgentID) {
-                        Text("Primary · \(model.agentTeamsModel.primaryAgentBehavior.displayName)")
+                        Text("Primary · \(agentTeams.primaryAgentBehavior.displayName)")
                             .tag("primary")
-                        ForEach(model.agentProfiles) { profile in
+                        ForEach(agentTeams.agentProfiles) { profile in
                             Text(profile.name).tag(profile.id.uuidString)
                         }
                     }
@@ -2822,7 +2834,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                             .fixedSize(horizontal: false, vertical: true)
                         HStack {
                             Button("Save") {
-                                model.knowledge.configureWorkspaceKnowledge(
+                                knowledge.configureWorkspaceKnowledge(
                                     enabled: enabled,
                                     embeddingModel: embeddingModel,
                                     exclusions: exclusions.split(separator: ",").map {
@@ -2832,7 +2844,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                             }
                             .buttonStyle(.borderedProminent)
                             .tint(LocusTheme.ink)
-                            Button("Rebuild Index") { model.knowledge.rebuildWorkspaceKnowledge() }
+                            Button("Rebuild Index") { knowledge.rebuildWorkspaceKnowledge() }
                                 .disabled(!enabled || model.isBusy)
                             Spacer()
                             Button("Delete All Workspace Knowledge…", role: .destructive) {
@@ -2846,15 +2858,15 @@ struct WorkspaceKnowledgeSettingsView: View {
                                 .foregroundStyle(LocusTheme.muted)
                             Spacer()
                             Button("Review Health") {
-                                model.knowledge.reviewMemoryHealth(agentID: selectedMemoryAgentID)
+                                knowledge.reviewMemoryHealth(agentID: selectedMemoryAgentID)
                             }
                             .buttonStyle(.locus())
                             Button("Import Memory") {
-                                model.knowledge.importMemory(agentID: selectedMemoryAgentID)
+                                knowledge.importMemory(agentID: selectedMemoryAgentID)
                             }
                             .buttonStyle(.locus())
                             Button("Export Memory") {
-                                model.knowledge.exportMemory(agentID: selectedMemoryAgentID)
+                                knowledge.exportMemory(agentID: selectedMemoryAgentID)
                             }
                             .buttonStyle(.locus())
                             Button("Delete All Memory…", role: .destructive) {
@@ -2862,11 +2874,11 @@ struct WorkspaceKnowledgeSettingsView: View {
                             }
                             .buttonStyle(.locus())
                         }
-                        if let status = model.knowledge.knowledgeStatus {
+                        if let status = knowledge.knowledgeStatus {
                             HStack(spacing: 14) {
                                 metric("Indexed files", status.documentCount)
                                 metric("Search chunks", status.chunkCount)
-                                metric("Saved memories", model.knowledge.workspaceMemories.count)
+                                metric("Saved memories", knowledge.workspaceMemories.count)
                                 Spacer()
                                 Text(status.embeddingModel.isEmpty ? "FTS5 text search" : "Text + local vectors")
                                     .font(.locus(size: 8, design: .monospaced))
@@ -2882,7 +2894,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                                     .foregroundStyle(LocusTheme.coral)
                             }
                         }
-                        if let vault = model.knowledge.memoryVaultStatus {
+                        if let vault = knowledge.memoryVaultStatus {
                             Divider()
                             Text("LOCAL STORAGE")
                                 .font(.locus(size: 8, weight: .bold))
@@ -2899,7 +2911,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                     .transition(LocusMotion.transition(edge: .top, reduceMotion: reduceMotion))
                 }
 
-                if let vault = model.knowledge.memoryVaultStatus {
+                if let vault = knowledge.memoryVaultStatus {
                     HStack(spacing: 10) {
                         Image(systemName: vault.encrypted ? "lock.fill" : "lock.open.fill")
                             .foregroundStyle(vault.encrypted ? LocusTheme.signalDeep : LocusTheme.warning)
@@ -2930,24 +2942,24 @@ struct WorkspaceKnowledgeSettingsView: View {
                                 .font(.locus(size: 10, weight: .semibold))
                         }
                         Spacer()
-                        Text("\(model.knowledge.contextSnapshots.count)")
+                        Text("\(knowledge.contextSnapshots.count)")
                             .font(.locus(size: 9, design: .monospaced))
                             .foregroundStyle(LocusTheme.muted)
                         Button("Clear All", role: .destructive) {
-                            model.knowledge.clearContextSnapshots()
+                            knowledge.clearContextSnapshots()
                         }
-                        .disabled(model.knowledge.contextSnapshots.isEmpty)
+                        .disabled(knowledge.contextSnapshots.isEmpty)
                     }
                     Text("Only Work, Plan, and Grill can save or recall these snapshots. Automatic recall is capped by the selected agent's memory policy; Just Chat never receives them.")
                         .font(.locus(size: 8))
                         .foregroundStyle(LocusTheme.muted)
                         .fixedSize(horizontal: false, vertical: true)
-                    if model.knowledge.contextSnapshots.isEmpty {
+                    if knowledge.contextSnapshots.isEmpty {
                         Text("No session handoffs have been saved yet.")
                             .font(.locus(size: 9))
                             .foregroundStyle(LocusTheme.muted)
                     } else {
-                        ForEach(model.knowledge.contextSnapshots.prefix(12)) { snapshot in
+                        ForEach(knowledge.contextSnapshots.prefix(12)) { snapshot in
                             HStack(alignment: .top, spacing: 10) {
                                 Image(systemName: snapshot.pinned ? "pin.fill" : "clock.arrow.circlepath")
                                     .foregroundStyle(snapshot.pinned ? LocusTheme.signalDeep : LocusTheme.muted)
@@ -2967,11 +2979,11 @@ struct WorkspaceKnowledgeSettingsView: View {
                                 }
                                 Spacer()
                                 Button(snapshot.pinned ? "Unpin" : "Pin") {
-                                    model.knowledge.setContextSnapshotPinned(snapshot, pinned: !snapshot.pinned)
+                                    knowledge.setContextSnapshotPinned(snapshot, pinned: !snapshot.pinned)
                                 }
                                 .buttonStyle(.locus())
                                 Button(role: .destructive) {
-                                    model.knowledge.deleteContextSnapshot(snapshot)
+                                    knowledge.deleteContextSnapshot(snapshot)
                                 } label: {
                                     Image(systemName: "trash")
                                 }
@@ -2995,15 +3007,15 @@ struct WorkspaceKnowledgeSettingsView: View {
                                 .font(.locus(size: 10, weight: .semibold))
                         }
                         Spacer()
-                        Button("Export") { model.knowledge.exportSkillObservations() }
-                            .disabled(model.knowledge.skillObservations.isEmpty)
+                        Button("Export") { knowledge.exportSkillObservations() }
+                            .disabled(knowledge.skillObservations.isEmpty)
                     }
-                    if model.knowledge.skillObservations.isEmpty {
+                    if knowledge.skillObservations.isEmpty {
                         Text("No observations recorded.")
                             .font(.locus(size: 9))
                             .foregroundStyle(LocusTheme.muted)
                     } else {
-                        ForEach(model.knowledge.skillObservations.prefix(20)) { observation in
+                        ForEach(knowledge.skillObservations.prefix(20)) { observation in
                             HStack(alignment: .top, spacing: 10) {
                                 Text("#\(observation.number)")
                                     .font(.locus(size: 8, design: .monospaced))
@@ -3024,21 +3036,21 @@ struct WorkspaceKnowledgeSettingsView: View {
                                 Spacer()
                                 if observation.status == "OPEN" {
                                     Button("Actioned") {
-                                        model.knowledge.setSkillObservationStatus(observation, status: "ACTIONED")
+                                        knowledge.setSkillObservationStatus(observation, status: "ACTIONED")
                                     }
                                     .buttonStyle(.locus())
                                     Button("Decline") {
-                                        model.knowledge.setSkillObservationStatus(observation, status: "DECLINED")
+                                        knowledge.setSkillObservationStatus(observation, status: "DECLINED")
                                     }
                                     .buttonStyle(.locus())
                                 } else {
                                     Button("Reopen") {
-                                        model.knowledge.setSkillObservationStatus(observation, status: "OPEN")
+                                        knowledge.setSkillObservationStatus(observation, status: "OPEN")
                                     }
                                     .buttonStyle(.locus())
                                 }
                                 Button(role: .destructive) {
-                                    model.knowledge.deleteSkillObservation(observation)
+                                    knowledge.deleteSkillObservation(observation)
                                 } label: {
                                     Image(systemName: "trash")
                                 }
@@ -3063,13 +3075,13 @@ struct WorkspaceKnowledgeSettingsView: View {
                         }
                         Spacer()
                         Button("Analyze Selected Chat") {
-                            model.knowledge.reprocessCurrentChatMemory(agentID: selectedMemoryAgentID)
+                            knowledge.reprocessCurrentChatMemory(agentID: selectedMemoryAgentID)
                         }
                         .disabled(model.currentSessionID.isEmpty || model.isBusy)
                         .accessibilityIdentifier("memory.analyzeSelectedChat")
                     }
 
-                    if let report = model.knowledge.memoryDiagnosticReport {
+                    if let report = knowledge.memoryDiagnosticReport {
                         HStack(spacing: 18) {
                             metric("Indexed files", report.indexedFiles)
                             metric("Search chunks", report.searchChunks)
@@ -3168,8 +3180,8 @@ struct WorkspaceKnowledgeSettingsView: View {
                         Text("Memory suggestions")
                             .font(LocusType.title)
                         Spacer()
-                        if !model.knowledge.memoryCandidates.isEmpty {
-                            Text("\(model.knowledge.memoryCandidates.count) waiting")
+                        if !knowledge.memoryCandidates.isEmpty {
+                            Text("\(knowledge.memoryCandidates.count) waiting")
                                 .font(LocusType.badge)
                                 .foregroundStyle(LocusTheme.brandInk)
                                 .padding(.horizontal, 8)
@@ -3181,13 +3193,13 @@ struct WorkspaceKnowledgeSettingsView: View {
                     Text("In work modes, the agent may suggest only explicit preferences, repeated constraints, and confirmed decisions or outcomes. Suggestions never affect future answers until you approve them.")
                         .font(LocusType.callout)
                         .foregroundStyle(LocusTheme.textTertiary)
-                    if model.knowledge.memoryCandidates.isEmpty {
+                    if knowledge.memoryCandidates.isEmpty {
                         Text("No suggestions waiting for review.")
                             .font(.locus(size: 9))
                             .foregroundStyle(LocusTheme.muted)
                             .padding(.vertical, 8)
                     }
-                    ForEach(model.knowledge.memoryCandidates) { memory in
+                    ForEach(knowledge.memoryCandidates) { memory in
                         VStack(alignment: .leading, spacing: 8) {
                             HStack {
                                 Text(memory.title).font(.locus(size: 10, weight: .semibold))
@@ -3196,7 +3208,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                                     .foregroundStyle(LocusTheme.accentAction)
                                 Spacer()
                                 Button("Reject", role: .destructive) {
-                                    model.knowledge.deleteWorkspaceMemory(
+                                    knowledge.deleteWorkspaceMemory(
                                         memory,
                                         agentID: selectedMemoryAgentID
                                     )
@@ -3204,7 +3216,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                                 .buttonStyle(.locus())
                                 if !memory.hasConflicts {
                                     Button("Approve") {
-                                        model.knowledge.approveMemoryCandidate(
+                                        knowledge.approveMemoryCandidate(
                                             memory,
                                             agentID: selectedMemoryAgentID
                                         )
@@ -3228,12 +3240,12 @@ struct WorkspaceKnowledgeSettingsView: View {
                                     .foregroundStyle(LocusTheme.warning)
                                 HStack {
                                     Button("Keep Both") {
-                                        model.knowledge.approveMemoryCandidate(
+                                        knowledge.approveMemoryCandidate(
                                             memory, agentID: selectedMemoryAgentID
                                         )
                                     }
                                     Button("Replace Older") {
-                                        model.knowledge.approveMemoryCandidate(
+                                        knowledge.approveMemoryCandidate(
                                             memory,
                                             agentID: selectedMemoryAgentID,
                                             replacingConflicts: true
@@ -3264,13 +3276,13 @@ struct WorkspaceKnowledgeSettingsView: View {
                     Text("The vault stays encrypted on disk. An exported JSON file is intentionally readable so you can inspect or move it.")
                         .font(.locus(size: 8))
                         .foregroundStyle(LocusTheme.muted)
-                    if model.knowledge.workspaceMemories.isEmpty {
+                    if knowledge.workspaceMemories.isEmpty {
                         Text("No approved decisions, conventions, or facts yet.")
                             .font(.locus(size: 9))
                             .foregroundStyle(LocusTheme.muted)
                             .padding(.vertical, 10)
                     }
-                    ForEach(model.knowledge.workspaceMemories) { memory in
+                    ForEach(knowledge.workspaceMemories) { memory in
                         VStack(alignment: .leading, spacing: 4) {
                             HStack {
                                 Image(systemName: memory.pinned ? "pin.fill" : "bookmark")
@@ -3295,21 +3307,21 @@ struct WorkspaceKnowledgeSettingsView: View {
                                     Button("Edit") { memoryDraft = .existing(memory) }
                                     Button(memory.pinned ? "Unpin" : "Pin") {
                                         var value = memory; value.pinned.toggle()
-                                        model.knowledge.updateWorkspaceMemory(
+                                        knowledge.updateWorkspaceMemory(
                                             value,
                                             agentID: selectedMemoryAgentID
                                         )
                                     }
                                     Button(memory.stale ? "Mark Current" : "Mark Stale") {
                                         var value = memory; value.stale.toggle()
-                                        model.knowledge.updateWorkspaceMemory(
+                                        knowledge.updateWorkspaceMemory(
                                             value,
                                             agentID: selectedMemoryAgentID
                                         )
                                     }
                                     Divider()
                                     Button("Delete", role: .destructive) {
-                                        model.knowledge.deleteWorkspaceMemory(
+                                        knowledge.deleteWorkspaceMemory(
                                             memory,
                                             agentID: selectedMemoryAgentID
                                         )
@@ -3345,15 +3357,15 @@ struct WorkspaceKnowledgeSettingsView: View {
             .padding(20)
         }
         .task(id: selectedMemoryAgentID) {
-            await model.knowledge.refreshWorkspaceKnowledge(agentID: selectedMemoryAgentID)
+            await knowledge.refreshWorkspaceKnowledge(agentID: selectedMemoryAgentID)
             syncDraft()
         }
-        .onChange(of: model.knowledge.knowledgeStatus) { _, _ in syncDraft() }
+        .onChange(of: knowledge.knowledgeStatus) { _, _ in syncDraft() }
         .sheet(item: $memoryDraft) { draft in
             WorkspaceMemoryEditor(draft: draft) { value in
                 switch value.original {
                 case .none:
-                    model.knowledge.rememberWorkspaceFact(
+                    knowledge.rememberWorkspaceFact(
                         title: value.title, content: value.content,
                         tags: value.tags.split(separator: ",").map(String.init),
                         scope: value.scope,
@@ -3371,7 +3383,7 @@ struct WorkspaceKnowledgeSettingsView: View {
                     memory.confidence = value.confidence
                     memory.validUntil = value.expires
                         ? value.validUntil.timeIntervalSince1970 : nil
-                    model.knowledge.updateWorkspaceMemory(
+                    knowledge.updateWorkspaceMemory(
                         memory,
                         agentID: selectedMemoryAgentID
                     )
@@ -3385,7 +3397,7 @@ struct WorkspaceKnowledgeSettingsView: View {
             titleVisibility: .visible
         ) {
             Button("Delete Index and Memories", role: .destructive) {
-                model.knowledge.deleteAllWorkspaceKnowledge(agentID: selectedMemoryAgentID)
+                knowledge.deleteAllWorkspaceKnowledge(agentID: selectedMemoryAgentID)
             }
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -3397,7 +3409,7 @@ struct WorkspaceKnowledgeSettingsView: View {
             titleVisibility: .visible
         ) {
             Button("Delete Personal, Workspace & Agent Memory", role: .destructive) {
-                model.knowledge.deleteAllMemory(agentID: selectedMemoryAgentID)
+                knowledge.deleteAllMemory(agentID: selectedMemoryAgentID)
             }
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -3406,7 +3418,7 @@ struct WorkspaceKnowledgeSettingsView: View {
     }
 
     private func syncDraft() {
-        guard let status = model.knowledge.knowledgeStatus else { return }
+        guard let status = knowledge.knowledgeStatus else { return }
         enabled = status.enabled
         embeddingModel = status.embeddingModel
         exclusions = (status.exclusions ?? []).joined(separator: ", ")

--- a/Locus/AppFeatureEnvironment.swift
+++ b/Locus/AppFeatureEnvironment.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Installs the feature models that own reactive UI state.
+///
+/// Views observe these objects directly instead of relying on `AppModel` to
+/// republish every child change. `AppModel` remains available for orchestration
+/// and cross-feature actions.
+struct AppFeatureEnvironmentModifier: ViewModifier {
+    let model: AppModel
+
+    func body(content: Content) -> some View {
+        featureEnvironment(content)
+    }
+
+    @ViewBuilder
+    private func featureEnvironment(_ content: Content) -> some View {
+        content
+            .environmentObject(model)
+            .environmentObject(model.sessionCatalog)
+            .environmentObject(model.transcriptPresentation)
+            .environmentObject(model.providerAccountsModel)
+            .environmentObject(model.voiceControl)
+            .environmentObject(model.agentTeamsModel)
+            .environmentObject(model.teamRunLive)
+            .environmentObject(model.landingFlow)
+            .environmentObject(model.runs)
+            .environmentObject(model.evaluations)
+            .environmentObject(model.knowledge)
+            .environmentObject(model.activity)
+            .environmentObject(model.schedule)
+            .environmentObject(model.backgroundServicesModel)
+            .environmentObject(model.extensionsModel)
+            .environmentObject(model.gitWorkspace)
+            .environmentObject(model.workspaceFiles)
+            .environmentObject(model.agentInstructions)
+            .environmentObject(model.applicationContext)
+            .environmentObject(model.toastCenter)
+            .environmentObject(model.computerControl)
+            .environmentObject(model.simulatorControl)
+#if !LOCUS_APP_STORE
+            .environmentObject(model.codexComponent)
+#endif
+    }
+}
+
+extension View {
+    func appFeatureEnvironment(from model: AppModel) -> some View {
+        modifier(AppFeatureEnvironmentModifier(model: model))
+    }
+}

--- a/Locus/AppModel+ActivityCenterFacade.swift
+++ b/Locus/AppModel+ActivityCenterFacade.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-// Facade API — permanent forwarder; broadly load-bearing across views and
-// the companion surface. Everything else on ActivityCenterModel is reached
-// through `model.activity` directly.
+// Compatibility facade for non-reactive orchestration and the companion
+// surface. Reactive views observe ActivityCenterModel directly.
 extension AppModel {
     var visibleActivityRuns: [OrchestrationRun] { activity.visibleActivityRuns }
 }

--- a/Locus/AppModel+AgentTeamsFacade.swift
+++ b/Locus/AppModel+AgentTeamsFacade.swift
@@ -1,9 +1,8 @@
 import Foundation
 
-// Facade API — the routing state the send pipeline, split panes, chat
-// workers, and team ops read on nearly every turn, plus the three
-// collection members views observe broadly. Verbs and everything else
-// live on `model.agentTeamsModel` directly.
+// Compatibility facade for routing state used by the send pipeline, split
+// panes, chat workers, and team orchestration. Reactive views observe
+// AgentTeamsModel directly.
 extension AppModel {
     var primaryAgentBehavior: AgentBehavior { agentTeamsModel.primaryAgentBehavior }
     var teamRoutingConsentAccountIDs: Set<UUID> { agentTeamsModel.teamRoutingConsentAccountIDs }

--- a/Locus/AppModel+BackendEvents.swift
+++ b/Locus/AppModel+BackendEvents.swift
@@ -847,7 +847,6 @@ extension AppModel {
         if startsFreshOverview, !previousSessionID.isEmpty, previousSessionID != info.sessionID {
             liveApplicationTargets.removeValue(forKey: previousSessionID)
             simulatorControl.detach(sessionID: previousSessionID)
-            objectWillChange.send()
         }
         activateSessionOverview(info, reset: startsFreshOverview)
         sendComputerControlCapability()

--- a/Locus/AppModel+ComposerAttachments.swift
+++ b/Locus/AppModel+ComposerAttachments.swift
@@ -183,7 +183,6 @@ extension AppModel {
                     sessionID: currentSessionID,
                     udid: device.udid
                 )
-                objectWillChange.send()
                 sendSimulatorControlCapability()
                 selectInspectorTab(.simulator)
                 showToast("Attached \(device.name)")
@@ -198,13 +197,11 @@ extension AppModel {
         guard let target = simulatorControl.target(for: owner) else { return }
         cancelSimulatorActions(sessionID: owner)
         simulatorControl.detach(sessionID: owner)
-        objectWillChange.send()
         announceSimulatorControlCapability()
         showToast("Detached \(target.device.name)")
     }
 
     func simulatorDidDetachNatively() {
-        objectWillChange.send()
         announceSimulatorControlCapability()
         showToast("Simulator shut down and detached")
     }
@@ -219,7 +216,6 @@ extension AppModel {
         if !enabled {
             cancelSimulatorActions()
             simulatorControl.detachAll()
-            objectWillChange.send()
         }
         announceSimulatorControlCapability()
         showToast(enabled ? "iOS Simulator control enabled" : "iOS Simulator control disabled")

--- a/Locus/AppModel+LandingFlowFacade.swift
+++ b/Locus/AppModel+LandingFlowFacade.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-// Facade API — kept for InspectorView, which a concurrent branch owns
-// right now; fold into `model.landingFlow` when that branch lands.
+// Compatibility facade for non-reactive AppModel extension code. Reactive
+// views observe LandingFlowModel directly.
 extension AppModel {
     var taskHasChanges: Bool { landingFlow.taskHasChanges }
     func prepareReviewAndLand() { landingFlow.prepareReviewAndLand() }

--- a/Locus/AppModel+OrchestrationRunsFacade.swift
+++ b/Locus/AppModel+OrchestrationRunsFacade.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-// Facade API — kept for InspectorView (a concurrent branch owns it),
-// AppModelTests, and the dispatcher/run-queue seams. Shrinks to nothing
-// once that branch lands and the tests are re-pointed in the follow-up.
+// Compatibility facade for AppModel tests and dispatcher/run-queue seams.
+// Reactive views observe OrchestrationRunsModel directly.
 extension AppModel {
     var orchestrationRuns: [OrchestrationRun] {
         get { runs.orchestrationRuns }

--- a/Locus/AppModel+PermissionsAndCapabilities.swift
+++ b/Locus/AppModel+PermissionsAndCapabilities.swift
@@ -125,7 +125,6 @@ extension AppModel {
                 "result": result,
             ])
             if tool == "simulator_detach" {
-                self.objectWillChange.send()
                 self.announceSimulatorControlCapability()
             }
         }

--- a/Locus/AppModel+ProviderAccountsFacade.swift
+++ b/Locus/AppModel+ProviderAccountsFacade.swift
@@ -1,10 +1,8 @@
 import Foundation
 
-// Facade API — the account/catalog state that the send pipeline, model
-// router, settings apply, and team ops read on nearly every turn. These
-// stay as forwarders; narrowing them is part of the router follow-up.
-// Everything else on ProviderAccountsModel is reached through
-// `model.providerAccountsModel` directly.
+// Compatibility facade for the send pipeline, model router, settings apply,
+// and team orchestration. Reactive views observe ProviderAccountsModel
+// directly; these forwarders do not establish an observation boundary.
 extension AppModel {
     var models: [ModelInfo] {
         get { providerAccountsModel.models }

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -22,16 +22,14 @@ final class AppModel: ObservableObject {
     var isAgentOnline: Bool { agentRuntimePhase.isOnline }
     var isModelOnline: Bool { modelRuntimePhase.isOnline }
     let providerAccountsModel = ProviderAccountsModel()
-    private var providerAccountsBridge: AnyCancellable?
+    private var providerAccountsCapabilityObservation: AnyCancellable?
     let voiceControl = VoiceControlModel()
-    private var voiceControlBridge: AnyCancellable?
 
     #if !LOCUS_APP_STORE
     /// The ChatGPT-plan helpers ship as a downloadable component in the direct
     /// download. Owned here so the account editor and the settings row observe
     /// the same install rather than racing two of them.
     let codexComponent = CodexComponentInstaller()
-    private var codexComponentBridge: AnyCancellable?
     #endif
 
     #if !LOCUS_APP_STORE
@@ -61,36 +59,26 @@ final class AppModel: ObservableObject {
         #endif
     }
     let agentTeamsModel = AgentTeamsModel()
-    private var agentTeamsBridge: AnyCancellable?
     @Published var orchestrationRunID: String?  // internal(for: AppModel+UITestFixtures)
     @Published var orchestrationState: TeamRunState?  // internal(for: AppModel+UITestFixtures)
     @Published var activeWorkerID: String?  // internal(for: AppModel extension files)
     @Published var taskConversationStates: [String: TaskConversationState] = [:]  // internal(for: AppModel+UITestFixtures)
     let teamRunLive = TeamRunLiveModel()
-    private var teamRunLiveBridge: AnyCancellable?
     @Published var activeTaskRecord: TaskRecord?  // internal(for: AppModel+UITestFixtures)
     var pendingProviderSwitch: (accountID: UUID?, model: String)?  // internal(for: AppModel extension files)
     let landingFlow = LandingFlowModel()
-    private var landingFlowBridge: AnyCancellable?
     let runs = OrchestrationRunsModel()
-    private var runsBridge: AnyCancellable?
     @Published var runsNavigationRequest: RunsNavigationRequest?  // internal(for: AppModel+UITestFixtures)
     let evaluations = EvaluationsModel()
-    private var evaluationsBridge: AnyCancellable?
     let knowledge = WorkspaceKnowledgeModel()
-    private var knowledgeBridge: AnyCancellable?
     let activity = ActivityCenterModel()
-    private var activityBridge: AnyCancellable?
     let schedule = ScheduleModel()
-    private var scheduleBridge: AnyCancellable?
     let companionGateway = CompanionGateway()
     @Published private(set) var companionGatewayState = CompanionGatewayState.disabled
     @Published var companionPairingPayload: CompanionPairingPayload?  // internal(for: AppModel+MobileCompanion)
     @Published var companionPairingError: String?  // internal(for: AppModel+MobileCompanion)
     let backgroundServicesModel = BackgroundServicesModel()
-    private var backgroundServicesBridge: AnyCancellable?
     let extensionsModel = ExtensionsModel()
-    private var extensionsBridge: AnyCancellable?
     let sessionCatalog = SessionCatalogModel()
     let transcriptPresentation = TranscriptPresentationModel()
     var sessions: [SessionSummary] {
@@ -229,10 +217,7 @@ final class AppModel: ObservableObject {
     /// observes this directly, and republishing here would invalidate the whole
     /// workspace view every time its list changed.
     let notebook = NotebookModel()
-    private var gitWorkspaceBridge: AnyCancellable?
-    private var workspaceFilesBridge: AnyCancellable?
     let agentInstructions = AgentInstructionsModel()
-    private var agentInstructionsBridge: AnyCancellable?
     @Published var contextFiles: [ContextFile] = []
     @Published var chatAttachments: [ChatAttachment] = []
     @Published var chatAttachmentNotice: String?
@@ -340,7 +325,6 @@ final class AppModel: ObservableObject {
     @Published var transcriptJumpTarget: UUID?
     @Published var streamRevision = 0
     let toastCenter = ToastCenter()
-    private var toastCenterBridge: AnyCancellable?
     var toastMessage: String? { toast?.message }
     @Published var lifecycleRecoveryMessage: String?  // internal(for: AppModel+UITestFixtures)
     @Published var backendLogHint = ""
@@ -353,7 +337,7 @@ final class AppModel: ObservableObject {
     let applicationContext = ApplicationContextService()
     let simulatorControl = SimulatorControlService()
     let eventAutomations = EventAutomationModel()
-    private var applicationContextBridge: AnyCancellable?
+    private var applicationContextCapabilityObservation: AnyCancellable?
     /// The browser, for the same reason as the terminal: its tab list and load
     /// progress change far too often to republish AppModel over.
     let browser = BrowserService()
@@ -826,21 +810,13 @@ final class AppModel: ObservableObject {
             }
         }
 
-        applicationContextBridge = applicationContext.objectWillChange.sink { [weak self] _ in
+        applicationContextCapabilityObservation = applicationContext.objectWillChange.sink { [weak self] _ in
             Task { @MainActor [weak self] in
                 // @Published sends before replacing its value. Recalculate on
                 // the next actor turn so a terminated scoped app loses tools.
                 await Task.yield()
-                guard let self else { return }
-                self.objectWillChange.send()
-                self.announceComputerControlCapability()
+                self?.announceComputerControlCapability()
             }
-        }
-        gitWorkspaceBridge = gitWorkspace.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
-        workspaceFilesBridge = workspaceFiles.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
         }
         agentInstructions.configure(
             backend: backend,
@@ -853,9 +829,6 @@ final class AppModel: ObservableObject {
             toastHandler: { [weak self] message in self?.showToast(message) },
             workspaceFilesChanged: { [weak self] in self?.workspaceFiles.refresh(force: true) }
         )
-        agentInstructionsBridge = agentInstructions.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         knowledge.configure(
             backend: backend,
             isUITesting: isUITesting,
@@ -867,9 +840,6 @@ final class AppModel: ObservableObject {
             knowledgePageVisible: { [weak self] in self?.settingsPage == .knowledge },
             toastHandler: { [weak self] message in self?.showToast(message) }
         )
-        knowledgeBridge = knowledge.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         evaluations.configure(
             backend: backend,
             workspacePathProvider: { [weak self] in self?.workspacePath ?? "" },
@@ -879,29 +849,17 @@ final class AppModel: ObservableObject {
             },
             toastHandler: { [weak self] message in self?.showToast(message) }
         )
-        evaluationsBridge = evaluations.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         extensionsModel.configure(
             backend: backend,
             isUITesting: isUITesting,
             workspacePathProvider: { [weak self] in self?.workspacePath ?? "" },
             toastHandler: { [weak self] message in self?.showToast(message) }
         )
-        extensionsBridge = extensionsModel.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         activity.configure(
             backend: backend,
             toastHandler: { [weak self] message in self?.showToast(message) }
         )
-        activityBridge = activity.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         toastCenter.onToastReplaced = { [weak self] in self?.pendingDeletedChat = nil }
-        toastCenterBridge = toastCenter.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         backgroundServicesModel.configure(
             transportProvider: { [weak self] in self?.conversationBackend },
             recordingSessionIDProvider: { [weak self] in self?.sessionOverview.activeSessionID ?? "" },
@@ -910,9 +868,6 @@ final class AppModel: ObservableObject {
             },
             toastHandler: { [weak self] message in self?.showToast(message) }
         )
-        backgroundServicesBridge = backgroundServicesModel.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         transcriptSearch.configure(backend: backend)
         schedule.configure(
             backend: backend,
@@ -935,9 +890,6 @@ final class AppModel: ObservableObject {
             },
             toastHandler: { [weak self] message in self?.showToast(message) }
         )
-        scheduleBridge = schedule.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         eventAutomations.configure(
             backend: backend,
             onQueuedRun: { [weak self] run in
@@ -984,8 +936,7 @@ final class AppModel: ObservableObject {
             },
             toastHandler: { [weak self] message in self?.showToast(message) }
         )
-        providerAccountsBridge = providerAccountsModel.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+        providerAccountsCapabilityObservation = providerAccountsModel.objectWillChange.sink { [weak self] _ in
             self?.voiceControl.invalidateCapabilityTest()
         }
         voiceControl.configure(
@@ -999,9 +950,6 @@ final class AppModel: ObservableObject {
                 self?.setAppleNetworkRecognitionConsent(allowed)
             }
         )
-        voiceControlBridge = voiceControl.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         agentTeamsModel.configure(
             isBusyProvider: { [weak self] in self?.isBusy ?? false },
             workspacePersistenceRequested: { [weak self] in self?.scheduleWorkspacePersistence() },
@@ -1010,9 +958,6 @@ final class AppModel: ObservableObject {
             accountModelsProvider: { [weak self] id in self?.accountModels[id] },
             toastHandler: { [weak self] message in self?.showToast(message) }
         )
-        agentTeamsBridge = agentTeamsModel.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         runs.configure(
             backend: backend,
             sessionIDProvider: { [weak self] in self?.currentSessionID ?? "" },
@@ -1024,9 +969,6 @@ final class AppModel: ObservableObject {
             setLiveState: { [weak self] state in self?.orchestrationState = state },
             toastHandler: { [weak self] message in self?.showToast(message) }
         )
-        runsBridge = runs.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         teamRunLive.configure(
             isBusyProvider: { [weak self] in self?.isBusy ?? false },
             liveRunID: { [weak self] in self?.orchestrationRunID },
@@ -1037,9 +979,6 @@ final class AppModel: ObservableObject {
             },
             selectedTeamProvider: { [weak self] in self?.selectedAgentTeam }
         )
-        teamRunLiveBridge = teamRunLive.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         landingFlow.configure(
             backend: backend,
             isUITesting: isUITesting,
@@ -1061,14 +1000,9 @@ final class AppModel: ObservableObject {
             gitRefresh: { [weak self] in self?.gitWorkspace.refreshStatus() },
             toastHandler: { [weak self] message in self?.showToast(message) }
         )
-        landingFlowBridge = landingFlow.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
         simulatorControl.capabilityDidChange = { [weak self] in
             Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.objectWillChange.send()
-                self.announceSimulatorControlCapability()
+                self?.announceSimulatorControlCapability()
             }
         }
 
@@ -1185,16 +1119,6 @@ final class AppModel: ObservableObject {
             scheduleProxyHealthMonitoring()
         }
 
-        #if !LOCUS_APP_STORE
-        // `codexComponent` is a nested ObservableObject. A view holding
-        // `@EnvironmentObject var model: AppModel` subscribes to AppModel's
-        // publisher only, so without this the installer's progress and its
-        // final state never invalidate anything and the download UI sits
-        // frozen on "Download and Continue" while the work actually happens.
-        codexComponentBridge = codexComponent.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
-        #endif
         walletGateway.configureRPCURL(loadedSettings.walletSepoliaRPCURL)
         walletGateway.applyFeatureAccess(
             walletEnabled: loadedSettings.walletAlphaEnabled,

--- a/Locus/ComposerView.swift
+++ b/Locus/ComposerView.swift
@@ -29,6 +29,13 @@ enum ComposerMetrics {
 
 struct ComposerView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var voiceControl: VoiceControlModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
+    @EnvironmentObject private var teamRunLive: TeamRunLiveModel
+    @EnvironmentObject private var extensionsModel: ExtensionsModel
+    @EnvironmentObject private var workspaceFiles: WorkspaceFileModel
+    @EnvironmentObject private var applicationContext: ApplicationContextService
+    @EnvironmentObject private var simulatorControl: SimulatorControlService
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var contextPresented = false
     @State private var permissionModesPresented = false
@@ -136,9 +143,9 @@ struct ComposerView: View {
                     }
 
                     if model.settings.voiceControlsEnabled,
-                       model.voiceControl.isVoiceModeActive
-                        || model.voiceControl.state != .idle {
-                        VoiceComposerStrip(voice: model.voiceControl)
+                       voiceControl.isVoiceModeActive
+                        || voiceControl.state != .idle {
+                        VoiceComposerStrip(voice: voiceControl)
                             .environmentObject(model)
                     }
 
@@ -182,23 +189,23 @@ struct ComposerView: View {
         .animation(LocusMotion.spatial, value: model.activePermissionRequest?.requestID)
         .animation(LocusMotion.spatial, value: model.planApprovalPending)
         .sheet(isPresented: $quickTeamPresented) {
-            QuickTeamBuilderView(suggestedName: model.agentTeamsModel.suggestedQuickTeamName())
+            QuickTeamBuilderView(suggestedName: agentTeams.suggestedQuickTeamName())
                 .environmentObject(model)
         }
         .onAppear { restoreFocus() }
-        .onDisappear { model.voiceControl.cancelRecording() }
+        .onDisappear { voiceControl.cancelRecording() }
         .alert(
             "Allow Apple Online Speech Recognition?",
             isPresented: Binding(
-                get: { model.voiceControl.networkRecognitionConsentRequested },
-                set: { model.voiceControl.networkRecognitionConsentRequested = $0 }
+                get: { voiceControl.networkRecognitionConsentRequested },
+                set: { voiceControl.networkRecognitionConsentRequested = $0 }
             )
         ) {
             Button("Not Now", role: .cancel) {
-                model.voiceControl.respondToAppleNetworkConsent(allowed: false)
+                voiceControl.respondToAppleNetworkConsent(allowed: false)
             }
             Button("Allow") {
-                model.voiceControl.respondToAppleNetworkConsent(allowed: true)
+                voiceControl.respondToAppleNetworkConsent(allowed: true)
             }
         } message: {
             Text("On-device recognition is unavailable for this language. If allowed, Apple may process dictation audio online. Locus will remember this choice and will never switch to a provider speech service automatically.")
@@ -216,8 +223,8 @@ struct ComposerView: View {
         .onChange(of: model.composerFocusToken) {
             restoreFocus()
         }
-        .onChange(of: model.teamRunLive.shouldShowTeamDispatchApproval) {
-            if !model.teamRunLive.shouldShowTeamDispatchApproval && !model.teamRunLive.shouldShowTeamDispatchProgress {
+        .onChange(of: teamRunLive.shouldShowTeamDispatchApproval) {
+            if !teamRunLive.shouldShowTeamDispatchApproval && !teamRunLive.shouldShowTeamDispatchProgress {
                 restoreFocus()
             }
         }
@@ -228,7 +235,7 @@ struct ComposerView: View {
             }
             if !model.justChatEnabled,
                WorkspaceIndex.activeMention(in: model.draftText) != nil {
-                model.workspaceFiles.refresh()
+                workspaceFiles.refresh()
             }
         }
     }
@@ -257,8 +264,8 @@ struct ComposerView: View {
         if let mention = WorkspaceIndex.activeMention(in: model.draftText) {
             let query = mention.query.lowercased()
             let targets: [TeamMentionTarget] = (
-                model.agentTeams.map(TeamMentionTarget.team)
-                    + model.agentProfiles.map(TeamMentionTarget.agent)
+                agentTeams.agentTeams.map(TeamMentionTarget.team)
+                    + agentTeams.agentProfiles.map(TeamMentionTarget.agent)
             ).filter {
                 query.isEmpty || $0.name.lowercased().contains(query)
             }
@@ -267,13 +274,13 @@ struct ComposerView: View {
             }
             let matches = WorkspaceIndex.matches(
                 query: mention.query,
-                in: model.workspaceFiles.files,
+                in: workspaceFiles.files,
                 root: model.workspacePath
             )
             return matches.isEmpty ? nil : .mention(matches)
         }
         if let query = activeSkillQuery {
-            let matches = model.extensionsModel.extensions.skills.filter {
+            let matches = extensionsModel.extensions.skills.filter {
                 $0.enabled && $0.error == nil
                     && (query.isEmpty || $0.id.localizedCaseInsensitiveContains(query))
             }
@@ -604,13 +611,13 @@ struct ComposerView: View {
                 teamPickerPresented.toggle()
             } label: {
                 HStack(spacing: 5) {
-                    Image(systemName: model.agentTeamsModel.teamModeEnabled
+                    Image(systemName: agentTeams.teamModeEnabled
                         ? "person.2.fill" : "person.fill")
-                    Text(model.selectedAgentTeam?.name ?? "Solo")
+                    Text(agentTeams.selectedAgentTeam?.name ?? "Solo")
                         .lineLimit(1)
                 }
                 .font(.locus(size: 9, weight: .semibold))
-                .foregroundStyle(model.agentTeamsModel.teamModeEnabled ? accentAction : LocusTheme.muted)
+                .foregroundStyle(agentTeams.teamModeEnabled ? accentAction : LocusTheme.muted)
                 .padding(.horizontal, 8)
                 .frame(height: 24)
                     .background(LocusTheme.paperDeep.opacity(0.8))
@@ -636,7 +643,7 @@ struct ComposerView: View {
                 .environmentObject(model)
             }
             .accessibilityLabel("Solo or team routing")
-            .accessibilityValue(model.selectedAgentTeam?.name ?? "Solo")
+            .accessibilityValue(agentTeams.selectedAgentTeam?.name ?? "Solo")
             .accessibilityIdentifier("composer.team")
         }
     }
@@ -739,7 +746,7 @@ struct ComposerView: View {
             Spacer()
 
             if model.settings.voiceControlsEnabled {
-                VoiceComposerButtons(voice: model.voiceControl)
+                VoiceComposerButtons(voice: voiceControl)
                     .environmentObject(model)
                 Divider()
                     .frame(height: 17)
@@ -1034,11 +1041,11 @@ struct ComposerView: View {
                         title: target.device.name + (
                             model.justChatEnabled
                                 ? " · paused"
-                                : (model.simulatorControl.nativeAvailable ? "" : " · disconnected")
+                                : (simulatorControl.nativeAvailable ? "" : " · disconnected")
                         ),
                         symbol: serviceSymbol,
                         iconData: nil,
-                        warning: !model.simulatorControl.nativeAvailable,
+                        warning: !simulatorControl.nativeAvailable,
                         open: {
                             if !model.justChatEnabled { model.selectInspectorTab(.simulator) }
                         },
@@ -1053,7 +1060,7 @@ struct ComposerView: View {
     }
 
     private var serviceSymbol: String {
-        model.simulatorControl.nativeAvailable
+        simulatorControl.nativeAvailable
             ? "ipad.and.iphone" : "exclamationmark.triangle"
     }
 
@@ -1197,6 +1204,8 @@ enum ComposerReturnAction: Equatable {
 
 private struct ComposerTeamPickerPopover: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
     let dismiss: () -> Void
     let createQuickTeam: () -> Void
     let manageAdvanced: () -> Void
@@ -1235,7 +1244,7 @@ private struct ComposerTeamPickerPopover: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 9) {
                     soloCard
-                    if model.agentTeams.isEmpty {
+                    if agentTeams.agentTeams.isEmpty {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("No saved teams yet")
                                 .font(.locus(size: 10, weight: .semibold))
@@ -1252,7 +1261,7 @@ private struct ComposerTeamPickerPopover: View {
                             .tracking(0.7)
                             .foregroundStyle(LocusTheme.muted)
                             .padding(.top, 3)
-                        ForEach(model.agentTeams) { team in
+                        ForEach(agentTeams.agentTeams) { team in
                             teamCard(team)
                         }
                     }
@@ -1287,9 +1296,9 @@ private struct ComposerTeamPickerPopover: View {
     }
 
     private var soloCard: some View {
-        let selected = model.agentTeamsModel.selectedAgentTeamID == nil
+        let selected = agentTeams.selectedAgentTeamID == nil
         return Button {
-            model.agentTeamsModel.selectSoloRoute()
+            agentTeams.selectSoloRoute()
             dismiss()
         } label: {
             HStack(spacing: 10) {
@@ -1326,9 +1335,9 @@ private struct ComposerTeamPickerPopover: View {
     }
 
     private func teamCard(_ team: AgentTeam) -> some View {
-        let selected = model.agentTeamsModel.selectedAgentTeamID == team.id
+        let selected = agentTeams.selectedAgentTeamID == team.id
         let profiles = team.memberIDs.compactMap { id in
-            model.agentProfiles.first(where: { $0.id == id })
+            agentTeams.agentProfiles.first(where: { $0.id == id })
         }
         let dispatcher = team.dispatcherID.flatMap { id in
             profiles.first(where: { $0.id == id })
@@ -1340,7 +1349,7 @@ private struct ComposerTeamPickerPopover: View {
         let issue = teamIssue(team)
 
         return Button {
-            model.agentTeamsModel.selectAgentTeam(team.id)
+            agentTeams.selectAgentTeam(team.id)
             dismiss()
         } label: {
             VStack(alignment: .leading, spacing: 7) {
@@ -1416,14 +1425,14 @@ private struct ComposerTeamPickerPopover: View {
     }
 
     private func teamIssue(_ team: AgentTeam) -> String? {
-        if let error = AgentTeamValidation.errors(team: team, profiles: model.agentProfiles).first {
+        if let error = AgentTeamValidation.errors(team: team, profiles: agentTeams.agentProfiles).first {
             return error
         }
         let memberAccountIDs = Set(team.memberIDs.compactMap { id in
-            model.agentProfiles.first(where: { $0.id == id })?.route.accountID
+            agentTeams.agentProfiles.first(where: { $0.id == id })?.route.accountID
         })
         for accountID in memberAccountIDs {
-            guard let account = model.providerAccounts.first(where: { $0.id == accountID }) else {
+            guard let account = providerAccounts.providerAccounts.first(where: { $0.id == accountID }) else {
                 return "A hosted provider used by this team is unavailable."
             }
             if !account.isCredentialReady {
@@ -1432,14 +1441,14 @@ private struct ComposerTeamPickerPopover: View {
         }
         if let error = AgentTeamValidation.routeErrors(
             team: team,
-            profiles: model.agentProfiles,
-            accounts: model.providerAccounts,
-            accountModels: model.accountModels
+            profiles: agentTeams.agentProfiles,
+            accounts: providerAccounts.providerAccounts,
+            accountModels: providerAccounts.accountModels
         ).first {
             return error
         }
-        if let missingID = memberAccountIDs.subtracting(model.agentTeamsModel.teamRoutingConsentAccountIDs).first {
-            let name = model.providerAccounts.first(where: { $0.id == missingID })?.displayName
+        if let missingID = memberAccountIDs.subtracting(agentTeams.teamRoutingConsentAccountIDs).first {
+            let name = providerAccounts.providerAccounts.first(where: { $0.id == missingID })?.displayName
                 ?? "a hosted provider"
             return "Allow automatic routing for \(name) in Advanced settings."
         }
@@ -1450,7 +1459,7 @@ private struct ComposerTeamPickerPopover: View {
         switch route {
         case .localOllama: "Local"
         case .providerAccount(let accountID):
-            model.providerAccounts.first(where: { $0.id == accountID })?.shortName
+            providerAccounts.providerAccounts.first(where: { $0.id == accountID })?.shortName
                 ?? "Unavailable"
         }
     }
@@ -1495,6 +1504,8 @@ private enum ComposerAttachmentMenuStyle {
 
 private struct ComposerAttachmentSourceMenu: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var applicationContext: ApplicationContextService
+    @EnvironmentObject private var simulatorControl: SimulatorControlService
     @State private var reviewPresented = false
     @State private var refreshRevision = 0
     let style: ComposerAttachmentMenuStyle
@@ -1512,7 +1523,7 @@ private struct ComposerAttachmentSourceMenu: View {
             .disabled(model.isLoadingChatAttachments)
 
             if ApplicationContextService.isAvailable {
-                if let current = model.applicationContext.lastExternalApplication {
+                if let current = applicationContext.lastExternalApplication {
                     Button {
                         model.attachApplicationSnapshot(current)
                     } label: {
@@ -1530,11 +1541,11 @@ private struct ComposerAttachmentSourceMenu: View {
 
             if !model.justChatEnabled {
                 Menu("Attach live application…", systemImage: "scope") {
-                    if model.applicationContext.runningApplications.isEmpty {
+                    if applicationContext.runningApplications.isEmpty {
                         Button("No applications are available") {}
                             .disabled(true)
                     }
-                    ForEach(model.applicationContext.runningApplications) { target in
+                    ForEach(applicationContext.runningApplications) { target in
                         Button {
                             model.attachLiveApplication(target)
                         } label: {
@@ -1556,12 +1567,12 @@ private struct ComposerAttachmentSourceMenu: View {
                     if !SimulatorControlService.isSupportedBuild {
                         Button("Requires the direct-download build") {}
                             .disabled(true)
-                    } else if model.simulatorControl.devices.isEmpty {
+                    } else if simulatorControl.devices.isEmpty {
                         Button("No iPhone or iPad simulators found") {
                             model.refreshSimulatorDevices()
                         }
                     }
-                    ForEach(model.simulatorControl.devices) { device in
+                    ForEach(simulatorControl.devices) { device in
                         Button {
                             model.attachSimulator(device)
                         } label: {
@@ -1571,7 +1582,7 @@ private struct ComposerAttachmentSourceMenu: View {
                             )
                         }
                     }
-                    if model.simulatorControl.isRefreshing {
+                    if simulatorControl.isRefreshing {
                         Button("Refreshing simulators…") {}
                             .disabled(true)
                     } else {
@@ -1600,20 +1611,20 @@ private struct ComposerAttachmentSourceMenu: View {
             // workspace launch/termination notifications. Avoid refreshing on
             // every identity-driven menu rebuild, which otherwise forms a
             // publish → rebuild → onAppear loop.
-            if model.applicationContext.runningApplications.isEmpty {
-                model.applicationContext.refreshRunningApplications()
+            if applicationContext.runningApplications.isEmpty {
+                applicationContext.refreshRunningApplications()
             }
             if !model.justChatEnabled,
-               model.simulatorControl.devices.isEmpty,
-               !model.simulatorControl.isRefreshing
+               simulatorControl.devices.isEmpty,
+               !simulatorControl.isRefreshing
             {
                 model.refreshSimulatorDevices()
             }
         }
-        .onReceive(model.applicationContext.objectWillChange) { _ in
+        .onReceive(applicationContext.objectWillChange) { _ in
             refreshRevision &+= 1
         }
-        .onReceive(model.simulatorControl.objectWillChange) { _ in
+        .onReceive(simulatorControl.objectWillChange) { _ in
             refreshRevision &+= 1
         }
     }

--- a/Locus/InspectorAgentsTab.swift
+++ b/Locus/InspectorAgentsTab.swift
@@ -176,23 +176,24 @@ enum AgentInstructionsStarter: String, CaseIterable, Identifiable {
 
 struct InspectorAgentsTab: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var agentInstructions: AgentInstructionsModel
 
     var body: some View {
         VStack(spacing: 0) {
             header
 
-            if model.agentInstructions.isLoadingAgentInstructions {
+            if agentInstructions.isLoadingAgentInstructions {
                 ProgressView("Loading AGENTS.md…")
                     .controlSize(.small)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if model.agentInstructions.agentInstructionsExists {
+            } else if agentInstructions.agentInstructionsExists {
                 editor
             } else {
                 missingState
             }
         }
         .task(id: model.workspacePath) {
-            model.agentInstructions.refreshAgentInstructions()
+            agentInstructions.refreshAgentInstructions()
         }
     }
 
@@ -215,19 +216,19 @@ struct InspectorAgentsTab: View {
                 }
                 Spacer(minLength: 4)
                 Button {
-                    model.agentInstructions.refreshAgentInstructions()
+                    agentInstructions.refreshAgentInstructions()
                 } label: {
                     Image(systemName: "arrow.clockwise")
                 }
                 .buttonStyle(.locus())
                 .foregroundStyle(LocusTheme.muted)
-                .disabled(model.agentInstructions.isLoadingAgentInstructions || model.agentInstructions.isSavingAgentInstructions)
+                .disabled(agentInstructions.isLoadingAgentInstructions || agentInstructions.isSavingAgentInstructions)
                 .help("Reload AGENTS.md from disk")
                 .accessibilityLabel("Reload AGENTS.md from disk")
                 .accessibilityIdentifier("agents.refresh")
-                if model.agentInstructions.agentInstructionsExists {
+                if agentInstructions.agentInstructionsExists {
                     Button {
-                        model.agentInstructions.revealAgentInstructionsInFinder()
+                        agentInstructions.revealAgentInstructionsInFinder()
                     } label: {
                         Image(systemName: "folder")
                             .accessibilityHidden(true)
@@ -264,7 +265,7 @@ struct InspectorAgentsTab: View {
                 .accessibilityLabel("How AGENTS.md works")
                 .accessibilityIdentifier("agents.explanation")
 
-            if let error = model.agentInstructions.agentInstructionsError {
+            if let error = agentInstructions.agentInstructionsError {
                 Label(error, systemImage: "exclamationmark.triangle.fill")
                     .font(.locus(size: 8, weight: .medium))
                     .foregroundStyle(LocusTheme.coral)
@@ -284,13 +285,13 @@ struct InspectorAgentsTab: View {
                 starterMenu
                 Spacer()
                 Label(
-                    model.agentInstructions.agentInstructionsHasUnsavedChanges ? "Unsaved" : "Saved",
-                    systemImage: model.agentInstructions.agentInstructionsHasUnsavedChanges
+                    agentInstructions.agentInstructionsHasUnsavedChanges ? "Unsaved" : "Saved",
+                    systemImage: agentInstructions.agentInstructionsHasUnsavedChanges
                         ? "circle.fill" : "checkmark.circle.fill"
                 )
                 .font(.locus(size: 8, weight: .semibold))
                 .foregroundStyle(
-                    model.agentInstructions.agentInstructionsHasUnsavedChanges
+                    agentInstructions.agentInstructionsHasUnsavedChanges
                         ? LocusTheme.warning
                         : LocusTheme.success
                 )
@@ -304,8 +305,8 @@ struct InspectorAgentsTab: View {
             }
 
             TextEditor(text: Binding(
-                get: { model.agentInstructions.agentInstructionsDraft },
-                set: { model.agentInstructions.agentInstructionsDraft = $0 }
+                get: { agentInstructions.agentInstructionsDraft },
+                set: { agentInstructions.agentInstructionsDraft = $0 }
             ))
                 .font(.locus(size: 10, design: .monospaced))
                 .lineSpacing(2)
@@ -321,16 +322,16 @@ struct InspectorAgentsTab: View {
                     .foregroundStyle(LocusTheme.muted)
                 Spacer(minLength: 4)
                 Button("Revert") {
-                    model.agentInstructions.revertAgentInstructions()
+                    agentInstructions.revertAgentInstructions()
                 }
                 .buttonStyle(.locus())
                 .font(.locus(size: 9, weight: .semibold))
-                .disabled(!model.agentInstructions.agentInstructionsHasUnsavedChanges || model.agentInstructions.isSavingAgentInstructions)
+                .disabled(!agentInstructions.agentInstructionsHasUnsavedChanges || agentInstructions.isSavingAgentInstructions)
                 .accessibilityIdentifier("agents.revert")
                 Button {
-                    model.agentInstructions.saveAgentInstructions()
+                    agentInstructions.saveAgentInstructions()
                 } label: {
-                    if model.agentInstructions.isSavingAgentInstructions {
+                    if agentInstructions.isSavingAgentInstructions {
                         ProgressView().controlSize(.mini)
                     } else {
                         Text("Save")
@@ -340,8 +341,8 @@ struct InspectorAgentsTab: View {
                 .tint(LocusTheme.ink)
                 .controlSize(.small)
                 .disabled(
-                    !model.agentInstructions.agentInstructionsHasUnsavedChanges
-                        || model.agentInstructions.isSavingAgentInstructions
+                    !agentInstructions.agentInstructionsHasUnsavedChanges
+                        || agentInstructions.isSavingAgentInstructions
                         || model.isBusy
                         || model.hasPendingPermission
                 )
@@ -361,8 +362,8 @@ struct InspectorAgentsTab: View {
             Section("Append sample guidance") {
                 ForEach(AgentInstructionsStarter.allCases) { starter in
                     Button {
-                        model.agentInstructions.agentInstructionsDraft = starter.appending(
-                            to: model.agentInstructions.agentInstructionsDraft
+                        agentInstructions.agentInstructionsDraft = starter.appending(
+                            to: agentInstructions.agentInstructionsDraft
                         )
                     } label: {
                         Label(starter.title, systemImage: starter.symbol)
@@ -395,21 +396,21 @@ struct InspectorAgentsTab: View {
                 .lineSpacing(2)
                 .fixedSize(horizontal: false, vertical: true)
             Button {
-                model.agentInstructions.createAgentInstructions()
+                agentInstructions.createAgentInstructions()
             } label: {
                 Label("Create AGENTS.md", systemImage: "plus")
             }
             .buttonStyle(.borderedProminent)
             .tint(LocusTheme.ink)
             .controlSize(.small)
-            .disabled(model.isBusy || model.hasPendingPermission || model.agentInstructions.isSavingAgentInstructions)
+            .disabled(model.isBusy || model.hasPendingPermission || agentInstructions.isSavingAgentInstructions)
             .accessibilityIdentifier("agents.create")
 
             Menu {
                 ForEach(AgentInstructionsStarter.allCases) { starter in
                     Button {
-                        model.agentInstructions.agentInstructionsDraft = starter.document
-                        model.agentInstructions.saveAgentInstructions()
+                        agentInstructions.agentInstructionsDraft = starter.document
+                        agentInstructions.saveAgentInstructions()
                     } label: {
                         Label(starter.title, systemImage: starter.symbol)
                     }
@@ -421,7 +422,7 @@ struct InspectorAgentsTab: View {
             }
             .menuStyle(.borderlessButton)
             .fixedSize()
-            .disabled(model.isBusy || model.hasPendingPermission || model.agentInstructions.isSavingAgentInstructions)
+            .disabled(model.isBusy || model.hasPendingPermission || agentInstructions.isSavingAgentInstructions)
             .accessibilityIdentifier("agents.createFromStarter")
         }
         .padding(24)

--- a/Locus/InspectorRail.swift
+++ b/Locus/InspectorRail.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// live on the icons, so a run can ask for eyes without the panel being open.
 struct InspectorRail: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var gitWorkspace: GitWorkspaceModel
     @State private var hoveredTab: InspectorTab?
 
     /// Direct rail destinations stay one click away. The remaining workspace
@@ -162,7 +163,7 @@ struct InspectorRail: View {
                 .overlay(alignment: .topTrailing) {
                     // Changes lives in this menu, so its unseen dot surfaces
                     // here — the count itself waits in the menu title.
-                    if model.gitWorkspace.changesHaveUnseenUpdate {
+                    if gitWorkspace.changesHaveUnseenUpdate {
                         Circle()
                             .fill(LocusTheme.coral)
                             .frame(width: 5, height: 5)
@@ -181,8 +182,8 @@ struct InspectorRail: View {
     }
 
     private func menuTitle(for tab: InspectorTab) -> String {
-        if tab == .changes, model.gitWorkspace.changedFileCount > 0 {
-            return "\(tab.title) (\(model.gitWorkspace.changedFileCount))"
+        if tab == .changes, gitWorkspace.changedFileCount > 0 {
+            return "\(tab.title) (\(gitWorkspace.changedFileCount))"
         }
         if tab == .runs { return "Team Runs" }
         if tab == .router { return "Model Router" }
@@ -196,6 +197,7 @@ struct InspectorRail: View {
 struct WorkspaceActionsMenu: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var sessionCatalog: SessionCatalogModel
+    @EnvironmentObject private var gitWorkspace: GitWorkspaceModel
     @State private var createBranchPresented = false
     @State private var branchName = ""
 
@@ -213,7 +215,7 @@ struct WorkspaceActionsMenu: View {
                 {
                     Button("Restore Worktree") { model.restoreActiveTaskCheckout() }
                 }
-            } else if model.gitWorkspace.isGitRepository {
+            } else if gitWorkspace.isGitRepository {
                 Button("Hand Off to Worktree") { model.handoffCurrentChat(to: .worktree) }
                     .disabled(model.isBusy || model.hasPendingPermission)
             }
@@ -232,14 +234,14 @@ struct WorkspaceActionsMenu: View {
                     model.newWorktreeSession(in: model.workspacePath, baseRef: "HEAD")
                 }
                 .accessibilityIdentifier("workspace.actions.worktree.head")
-                ForEach(model.gitWorkspace.localBranches, id: \.self) { branch in
+                ForEach(gitWorkspace.localBranches, id: \.self) { branch in
                     Button(branch) {
                         model.newWorktreeSession(in: model.workspacePath, baseRef: branch)
                     }
                     .accessibilityIdentifier("workspace.actions.worktree.branch.\(branch)")
                 }
             }
-            .disabled(!model.gitWorkspace.isGitRepository)
+            .disabled(!gitWorkspace.isGitRepository)
             .accessibilityIdentifier("workspace.actions.newWorktreeSession")
             Button("Start New Local Chat") {
                 model.newSession(in: model.workspacePath, environment: .local)

--- a/Locus/InspectorTerminalTab.swift
+++ b/Locus/InspectorTerminalTab.swift
@@ -12,6 +12,7 @@ struct InspectorTerminalTab: View {
 
 private struct TerminalPanel: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var backgroundServices: BackgroundServicesModel
     @ObservedObject var terminal: TerminalSession
 
     var body: some View {
@@ -36,7 +37,7 @@ private struct TerminalPanel: View {
             configure()
             terminal.ensureStarted()
             terminal.focus()
-            model.backgroundServicesModel.refreshBackgroundServices()
+            backgroundServices.refreshBackgroundServices()
         }
         .onChange(of: model.workspacePath) { configure() }
         .onChange(of: model.settings.terminalShell) { configure() }
@@ -65,13 +66,13 @@ private struct TerminalPanel: View {
                 Label("Managed services", systemImage: "server.rack")
                     .font(.locus(size: 8, weight: .semibold))
                 Spacer()
-                Button { model.backgroundServicesModel.refreshBackgroundServices() } label: {
+                Button { backgroundServices.refreshBackgroundServices() } label: {
                     Image(systemName: "arrow.clockwise")
                 }
                 .buttonStyle(.locus())
                 .help("Refresh managed services")
             }
-            ForEach(model.backgroundServicesModel.backgroundServices) { service in
+            ForEach(backgroundServices.backgroundServices) { service in
                 HStack(spacing: 7) {
                     Circle()
                         .fill(service.running ? LocusTheme.success : LocusTheme.warning)
@@ -87,7 +88,7 @@ private struct TerminalPanel: View {
                     Spacer()
                     if service.running {
                         Button("Stop", role: .destructive) {
-                            model.backgroundServicesModel.stopBackgroundService(service)
+                            backgroundServices.stopBackgroundService(service)
                         }
                         .buttonStyle(.locus())
                         .font(.locus(size: 8))
@@ -97,7 +98,7 @@ private struct TerminalPanel: View {
                                 .font(.locus(size: 7, design: .monospaced))
                                 .foregroundStyle(LocusTheme.warning)
                             Button("Dismiss") {
-                                model.backgroundServicesModel.stopBackgroundService(service)
+                                backgroundServices.stopBackgroundService(service)
                             }
                             .buttonStyle(.locus())
                             .font(.locus(size: 8))
@@ -105,7 +106,7 @@ private struct TerminalPanel: View {
                     }
                 }
             }
-            if model.backgroundServicesModel.backgroundServices.isEmpty {
+            if backgroundServices.backgroundServices.isEmpty {
                 Text("No managed services. Agents use these for servers and watchers that should survive Stop.")
                     .font(.locus(size: 7))
                     .foregroundStyle(LocusTheme.muted)

--- a/Locus/InspectorView.swift
+++ b/Locus/InspectorView.swift
@@ -6,6 +6,9 @@ import SwiftUI
 /// handle on its leading edge.
 struct InspectorView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var gitWorkspace: GitWorkspaceModel
+    @EnvironmentObject private var workspaceFiles: WorkspaceFileModel
+    @EnvironmentObject private var simulatorControl: SimulatorControlService
 
     var body: some View {
         VStack(spacing: 0) {
@@ -23,15 +26,15 @@ struct InspectorView: View {
                 case .plan:
                     InspectorPlanTab()
                 case .changes:
-                    InspectorChangesTab(gitWorkspace: model.gitWorkspace)
+                    InspectorChangesTab(gitWorkspace: gitWorkspace)
                 case .files:
-                    InspectorFilesTab(workspaceFiles: model.workspaceFiles)
+                    InspectorFilesTab(workspaceFiles: workspaceFiles)
                 case .terminal:
                     InspectorTerminalTab()
                 case .preview:
                     InspectorBrowserTab()
                 case .simulator:
-                    InspectorSimulatorTab(service: model.simulatorControl)
+                    InspectorSimulatorTab(service: simulatorControl)
                 case .notes:
                     InspectorNotesTab(
                         workspacePath: model.workspacePath,
@@ -1182,17 +1185,18 @@ enum InspectorTabAppearance {
 /// vertical rail; the top bar uses only labels, badges, and close controls.
 private struct InspectorTextTabBadge: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var gitWorkspace: GitWorkspaceModel
     let tab: InspectorTab
 
     @ViewBuilder
     var body: some View {
-        if tab == .changes, model.gitWorkspace.changedFileCount > 0 {
-            Text(model.gitWorkspace.changedFileCount > 99 ? "99+" : "\(model.gitWorkspace.changedFileCount)")
+        if tab == .changes, gitWorkspace.changedFileCount > 0 {
+            Text(gitWorkspace.changedFileCount > 99 ? "99+" : "\(gitWorkspace.changedFileCount)")
                 .font(.locus(size: 7, weight: .bold))
                 .foregroundStyle(Color.white)
                 .padding(.horizontal, 3)
                 .frame(minHeight: 16)
-                .background(model.gitWorkspace.changesHaveUnseenUpdate ? LocusTheme.coral : LocusTheme.muted)
+                .background(gitWorkspace.changesHaveUnseenUpdate ? LocusTheme.coral : LocusTheme.muted)
                 .clipShape(Capsule())
                 .accessibilityHidden(true)
         } else if tab == .plan, model.planHasUnseenUpdate {
@@ -1234,14 +1238,15 @@ struct InspectorPlaceholder: View {
 /// asking for eyes exactly the way an open panel does.
 struct InspectorTabBadge: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var gitWorkspace: GitWorkspaceModel
     let tab: InspectorTab
 
     var body: some View {
-        if tab == .changes, model.gitWorkspace.changedFileCount > 0 {
+        if tab == .changes, gitWorkspace.changedFileCount > 0 {
             // Coral only while the change is still unseen; once you have opened
             // the tab the count stays but stops asking for attention.
-            let unseen = model.gitWorkspace.changesHaveUnseenUpdate
-            Text(model.gitWorkspace.changedFileCount > 99 ? "99+" : "\(model.gitWorkspace.changedFileCount)")
+            let unseen = gitWorkspace.changesHaveUnseenUpdate
+            Text(gitWorkspace.changedFileCount > 99 ? "99+" : "\(gitWorkspace.changedFileCount)")
                 .font(.locus(size: 7, weight: .bold))
                 .foregroundStyle(Color.white)
                 .padding(.horizontal, 3)
@@ -1252,8 +1257,8 @@ struct InspectorTabBadge: View {
                 .accessibilityElement()
                 .accessibilityLabel(
                     unseen
-                        ? "\(model.gitWorkspace.changedFileCount) changed files, new since you last looked"
-                        : "\(model.gitWorkspace.changedFileCount) changed files"
+                        ? "\(gitWorkspace.changedFileCount) changed files, new since you last looked"
+                        : "\(gitWorkspace.changedFileCount) changed files"
                 )
                 .accessibilityIdentifier("inspector.tab.changes.badge")
         } else if tab == .plan, model.planHasUnseenUpdate {
@@ -1406,6 +1411,10 @@ private enum RunsStatusFilter: String, CaseIterable, Identifiable {
 
 struct InspectorRunsTab: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var runs: OrchestrationRunsModel
+    @EnvironmentObject private var gitWorkspace: GitWorkspaceModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
+    @EnvironmentObject private var landingFlow: LandingFlowModel
     @State private var scope: RunScope = .all
     @State private var statusFilter: RunsStatusFilter = .all
     @State private var runSearch = ""
@@ -1440,8 +1449,8 @@ struct InspectorRunsTab: View {
             }
         }
         .task(id: model.currentSessionID) {
-            if !model.isLoadingOrchestrationRuns {
-                await model.refreshOrchestrationRuns()
+            if !runs.isLoadingOrchestrationRuns {
+                await runs.refreshOrchestrationRuns()
             }
         }
         .onChange(of: model.pendingDispatchPlan) { _, value in draftPlan = value }
@@ -1455,7 +1464,7 @@ struct InspectorRunsTab: View {
                 return
             }
             detailRunID = request.runID
-            await model.loadOrchestrationRun(request.runID)
+            await runs.loadOrchestrationRun(request.runID)
             if let run = model.runRecord(for: request.runID) {
                 scope = run.isSoloSwarm ? .soloSwarm : (run.runKind == "team" ? .teams : .all)
                 showingRunDetail = true
@@ -1503,7 +1512,7 @@ struct InspectorRunsTab: View {
                     .tracking(0.7)
                 Spacer()
                 Button {
-                    Task { await model.refreshOrchestrationRuns() }
+                    Task { await runs.refreshOrchestrationRuns() }
                 } label: { Image(systemName: "arrow.clockwise") }
                     .buttonStyle(.locus())
                     .help("Refresh run history")
@@ -1558,8 +1567,8 @@ struct InspectorRunsTab: View {
 
     private var runPickerRuns: [OrchestrationRun] {
         AppModel.orchestrationPickerRuns(
-            model.orchestrationRuns,
-            selected: model.selectedOrchestrationRun
+            runs.orchestrationRuns,
+            selected: runs.selectedOrchestrationRun
         )
     }
 
@@ -1645,7 +1654,7 @@ struct InspectorRunsTab: View {
 
     private var runList: some View {
         Group {
-            if model.isLoadingOrchestrationRuns && runPickerRuns.isEmpty {
+            if runs.isLoadingOrchestrationRuns && runPickerRuns.isEmpty {
                 ProgressView("Loading runs…")
                     .controlSize(.small)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -1689,7 +1698,7 @@ struct InspectorRunsTab: View {
             viewMode = "overview"
             filter = ""
             showingRunDetail = true
-            Task { await model.loadOrchestrationRun(run.id) }
+            Task { await runs.loadOrchestrationRun(run.id) }
         } label: {
             VStack(alignment: .leading, spacing: 6) {
                 HStack(alignment: .top, spacing: 8) {
@@ -1818,10 +1827,10 @@ struct InspectorRunsTab: View {
             }
             if let task = model.activeTaskRecord, task.id == run.taskID {
                 HStack(spacing: 7) {
-                    Button("Review & Land") { model.prepareReviewAndLand() }
-                        .disabled(model.isBusy || !model.taskHasChanges)
+                    Button("Review & Land") { landingFlow.prepareReviewAndLand() }
+                        .disabled(model.isBusy || !landingFlow.taskHasChanges)
                     Button("Copy Patch") { model.copyActiveTaskPatch() }
-                        .disabled(model.isBusy || !model.taskHasChanges)
+                        .disabled(model.isBusy || !landingFlow.taskHasChanges)
                     Menu {
                         Button("Open Checkout") { model.openActiveTaskCheckout() }
                         Button("Reveal in Finder") { model.revealActiveTaskCheckout() }
@@ -1941,6 +1950,8 @@ struct InspectorRunsTab: View {
         } label: { Image(systemName: "ellipsis.circle") }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
+            .accessibilityLabel("Run actions")
+            .accessibilityIdentifier("runs.actions")
     }
 
     private func overview(_ run: OrchestrationRun) -> some View {
@@ -1991,18 +2002,18 @@ struct InspectorRunsTab: View {
                         if let calls = run.usage?["model_calls"]?.integer {
                             metricRow("Model calls", calls.formatted())
                         }
-                        if run.id == model.orchestrationRunID, !model.gitWorkspace.gitChanges.isEmpty {
+                        if run.id == model.orchestrationRunID, !gitWorkspace.gitChanges.isEmpty {
                             VStack(alignment: .leading, spacing: 3) {
                                 Text("Changed files")
                                     .font(.locus(size: 8))
                                     .foregroundStyle(LocusTheme.textSecondary)
-                                ForEach(model.gitWorkspace.gitChanges.prefix(8)) { change in
+                                ForEach(gitWorkspace.gitChanges.prefix(8)) { change in
                                     Text("\(change.status.marker)  \(change.path)")
                                         .font(.locus(size: 7, design: .monospaced))
                                         .lineLimit(1)
                                 }
-                                if model.gitWorkspace.gitChanges.count > 8 {
-                                    Text("+ \(model.gitWorkspace.gitChanges.count - 8) more")
+                                if gitWorkspace.gitChanges.count > 8 {
+                                    Text("+ \(gitWorkspace.gitChanges.count - 8) more")
                                         .font(.locus(size: 7))
                                         .foregroundStyle(LocusTheme.textSecondary)
                                 }
@@ -2381,7 +2392,7 @@ struct InspectorRunsTab: View {
     }
 
     private func runWork(_ run: OrchestrationRun) -> RunWork {
-        RunWork(events: model.orchestrationEvents(for: run.id))
+        RunWork(events: runs.orchestrationEvents(for: run.id))
     }
 
     private func technicalDetails(_ run: OrchestrationRun) -> some View {
@@ -2426,7 +2437,7 @@ struct InspectorRunsTab: View {
     /// Provider and model are reported on the turn's terminal event, which the
     /// run row itself does not carry.
     private func runModelLabel(_ run: OrchestrationRun) -> String? {
-        guard let terminal = model.orchestrationEvents(for: run.id).last(where: {
+        guard let terminal = runs.orchestrationEvents(for: run.id).last(where: {
             $0.type == "turn_done" || $0.type == "orchestration_completed"
         }) else { return nil }
         let name = terminal.text("model") ?? ""
@@ -3061,8 +3072,8 @@ struct InspectorRunsTab: View {
     }
 
     private func eligibleProfiles(for job: DispatchJob) -> [AgentProfile] {
-        guard let team = model.selectedAgentTeam else { return [] }
-        return model.agentProfiles.filter { profile in
+        guard let team = agentTeams.selectedAgentTeam else { return [] }
+        return agentTeams.agentProfiles.filter { profile in
             guard team.memberIDs.contains(profile.id) else { return false }
             switch job.kind {
             case "writer":
@@ -3097,7 +3108,7 @@ struct InspectorRunsTab: View {
 
     private func filteredEvents(_ run: OrchestrationRun) -> [OrchestrationEvent] {
         let query = filter.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let durableEvents = model.orchestrationEvents(for: run.id)
+        let durableEvents = runs.orchestrationEvents(for: run.id)
             .filter { !$0.isTransientStream }
         guard !query.isEmpty else { return durableEvents }
         return durableEvents.filter { event in
@@ -3207,7 +3218,7 @@ struct InspectorRunsTab: View {
         // Phase headings describe a team's shape. A solo turn that delegated
         // nothing has one phase, and filing its whole timeline under a "Solo
         // workers" heading described workers that never existed.
-        if isSoloRun, agentTreeAttempts(model.selectedOrchestrationRun).isEmpty {
+        if isSoloRun, agentTreeAttempts(runs.selectedOrchestrationRun).isEmpty {
             return visible.isEmpty ? [] : [ActivityGroup(title: "Timeline", events: visible)]
         }
         let order = ["Solo workers", "Planning", "Approval", "Specialists", "Coding jobs", "Review", "Complete"]
@@ -3311,7 +3322,7 @@ struct InspectorRunsTab: View {
     }
 
     private var isSoloRun: Bool {
-        model.selectedOrchestrationRun?.runKind == "solo"
+        runs.selectedOrchestrationRun?.runKind == "solo"
     }
 
     private var soloWorkEventTypes: Set<String> {
@@ -3340,7 +3351,7 @@ struct InspectorRunsTab: View {
     }
 
     private func activityPhase(_ event: OrchestrationEvent) -> String {
-        let isSoloSwarm = model.selectedOrchestrationRun?.isSoloSwarm == true
+        let isSoloSwarm = runs.selectedOrchestrationRun?.isSoloSwarm == true
         if isSoloSwarm,
            ["run_started", "agent_spawned", "agent_branch_stopped",
             "swarm_telemetry", "turn_done", "note"].contains(event.type)
@@ -3374,7 +3385,7 @@ struct InspectorRunsTab: View {
     }
 
     private func friendlyEventTitle(_ event: OrchestrationEvent) -> String {
-        let isSoloSwarm = model.selectedOrchestrationRun?.isSoloSwarm == true
+        let isSoloSwarm = runs.selectedOrchestrationRun?.isSoloSwarm == true
         return switch event.type {
         case "run_started": isSoloSwarm ? "Solo run started" : "Run started"
         case "agent_spawned": isSoloSwarm ? "Solo worker started" : "Agent started"

--- a/Locus/LocusApp.swift
+++ b/Locus/LocusApp.swift
@@ -60,9 +60,7 @@ struct LocusApp: App {
     var body: some Scene {
         Window("Locus", id: "main") {
             sceneContent
-                .environmentObject(model)
-                .environmentObject(model.sessionCatalog)
-                .environmentObject(model.transcriptPresentation)
+                .appFeatureEnvironment(from: model)
                 .environmentObject(updates)
                 .onAppear {
                     appDelegate.model = model
@@ -207,9 +205,7 @@ struct LocusApp: App {
 
         Settings {
             SettingsView(presentationContext: .settingsWindow)
-                .environmentObject(model)
-                .environmentObject(model.sessionCatalog)
-                .environmentObject(model.transcriptPresentation)
+                .appFeatureEnvironment(from: model)
                 .environmentObject(updates)
                 .preferredColorScheme(model.effectiveAppearance.colorScheme)
                 .accentColor(model.accentActionColor)
@@ -219,9 +215,7 @@ struct LocusApp: App {
 
         MenuBarExtra {
             LocusMenuBarView(presenter: mainWindowPresenter)
-                .environmentObject(model)
-                .environmentObject(model.sessionCatalog)
-                .environmentObject(model.transcriptPresentation)
+                .appFeatureEnvironment(from: model)
         } label: {
             Image("MenuBarIcon")
                 .renderingMode(.template)
@@ -453,6 +447,8 @@ final class LocusApplicationDelegate: NSObject, NSApplicationDelegate,
 
 private struct LocusMenuBarView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var activityCenter: ActivityCenterModel
+    @EnvironmentObject private var schedule: ScheduleModel
     @Environment(\.openWindow) private var openWindow
     let presenter: MainWindowPresenter
 
@@ -469,7 +465,7 @@ private struct LocusMenuBarView: View {
         } else {
             Text("No work running")
         }
-        if let next = model.schedule.nextScheduledTask, let date = next.nextRunDate {
+        if let next = schedule.nextScheduledTask, let date = next.nextRunDate {
             Text("Next: \(next.name) · \(date.formatted(date: .omitted, time: .shortened))")
         } else {
             Text("No upcoming schedules")
@@ -482,7 +478,7 @@ private struct LocusMenuBarView: View {
     }
 
     private var runningCount: Int {
-        model.visibleActivityRuns.filter {
+        activityCenter.visibleActivityRuns.filter {
             ["queued", "dispatching", "running", "reviewing", "waiting_permission",
              "waiting_computer", "waiting_dispatch_approval", "paused"].contains($0.state)
         }.count
@@ -571,6 +567,10 @@ private final class MainWindowMarkerView: NSView {
 struct RootView: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var updates: AppUpdateController
+    @EnvironmentObject private var toastCenter: ToastCenter
+    @EnvironmentObject private var landingFlow: LandingFlowModel
+    @EnvironmentObject private var extensionsModel: ExtensionsModel
+    @EnvironmentObject private var schedule: ScheduleModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var compactSidebarPresented = false
 
@@ -720,7 +720,7 @@ struct RootView: View {
         .animation(LocusMotion.spatial, value: model.inspectorZoomed)
         .background(LocusTheme.paper)
         .overlay(alignment: .bottomTrailing) {
-            if let toast = model.toastCenter.toast {
+            if let toast = toastCenter.toast {
                 HStack(spacing: 12) {
                     Label(toast.message, systemImage: toast.systemImage)
                         .font(.locus(size: 11, weight: .semibold))
@@ -742,7 +742,7 @@ struct RootView: View {
                 .transition(LocusMotion.transition(edge: .bottom, reduceMotion: reduceMotion))
             }
         }
-        .animation(LocusMotion.content, value: model.toastCenter.toast?.id)
+        .animation(LocusMotion.content, value: toastCenter.toast?.id)
         // Reduced Motion is an app-wide contract. Individual components still
         // choose a gentler transition where useful, while this guard prevents
         // an overlooked state mutation from introducing spatial movement.
@@ -776,8 +776,8 @@ struct RootView: View {
                 .environmentObject(model)
         }
         .sheet(isPresented: Binding(
-            get: { model.landingFlow.reviewAndLandPresented },
-            set: { model.landingFlow.reviewAndLandPresented = $0 }
+            get: { landingFlow.reviewAndLandPresented },
+            set: { landingFlow.reviewAndLandPresented = $0 }
         )) {
             ReviewAndLandView()
                 .environmentObject(model)
@@ -815,15 +815,15 @@ struct RootView: View {
         }) {
             ConfigureAgentView(
                 automation: model.eventAutomations,
-                schedule: model.schedule
+                schedule: schedule
             )
             .environmentObject(model)
         }
         .sheet(item: Binding(
-            get: { model.extensionsModel.mcpInputRequest },
+            get: { extensionsModel.mcpInputRequest },
             set: { value in
-                if value == nil, model.extensionsModel.mcpInputRequest != nil {
-                    model.extensionsModel.answerMCPInput(action: "cancel")
+                if value == nil, extensionsModel.mcpInputRequest != nil {
+                    extensionsModel.answerMCPInput(action: "cancel")
                 }
             }
         )) { request in
@@ -888,6 +888,7 @@ struct RootView: View {
 
 private struct RememberConfirmationView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var knowledge: WorkspaceKnowledgeModel
     @Environment(\.dismiss) private var dismiss
     @State private var title: String
     @State private var content: String
@@ -929,7 +930,7 @@ private struct RememberConfirmationView: View {
                 Spacer()
                 Button("Cancel", role: .cancel) { dismiss() }
                 Button("Save Memory") {
-                    model.knowledge.rememberWorkspaceFact(
+                    knowledge.rememberWorkspaceFact(
                         title: title,
                         content: content,
                         tags: tags.split(separator: ",").map {
@@ -956,6 +957,7 @@ private struct RememberConfirmationView: View {
 
 private struct MCPInputRequestView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var extensionsModel: ExtensionsModel
     let request: MCPInputRequest
     @State private var textValues: [String: String] = [:]
     @State private var boolValues: [String: Bool] = [:]
@@ -1002,11 +1004,11 @@ private struct MCPInputRequestView: View {
                     .foregroundStyle(LocusTheme.muted)
             }
             HStack {
-                Button("Decline") { model.extensionsModel.answerMCPInput(action: "decline") }
-                Button("Cancel") { model.extensionsModel.answerMCPInput(action: "cancel") }
+                Button("Decline") { extensionsModel.answerMCPInput(action: "decline") }
+                Button("Cancel") { extensionsModel.answerMCPInput(action: "cancel") }
                 Spacer()
                 Button(request.mode == "url" ? "I've Completed It" : "Submit") {
-                    model.extensionsModel.answerMCPInput(action: "accept", content: formContent)
+                    extensionsModel.answerMCPInput(action: "accept", content: formContent)
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(LocusTheme.ink)

--- a/Locus/PinnedSummaryView.swift
+++ b/Locus/PinnedSummaryView.swift
@@ -31,6 +31,9 @@ enum SummaryDetail: Hashable {
 /// stay discoverable).
 struct PinnedSummaryCard: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var teamRunLive: TeamRunLiveModel
+    @EnvironmentObject private var backgroundServices: BackgroundServicesModel
+    @EnvironmentObject private var activityCenter: ActivityCenterModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject var session: SessionStateEmitter
     @ObservedObject var browser: BrowserService
@@ -41,12 +44,12 @@ struct PinnedSummaryCard: View {
     private var outputs: [PinnedSummary.OutputRow] { PinnedSummary.outputs(state: state) }
     private var sources: [PinnedSummary.SourceRow] { PinnedSummary.sources(state: state) }
     private var processes: [BackgroundServiceRecord] {
-        PinnedSummary.backgroundProcesses(model.backgroundServicesModel.backgroundServices)
+        PinnedSummary.backgroundProcesses(backgroundServices.backgroundServices)
     }
     private var subagents: [PinnedSummary.SubagentRow] {
         PinnedSummary.subagents(
-            activities: model.teamRunLive.agentActivities,
-            runs: model.visibleActivityRuns,
+            activities: teamRunLive.agentActivities,
+            runs: activityCenter.visibleActivityRuns,
             sessionID: model.currentSessionID
         )
     }
@@ -219,7 +222,7 @@ struct PinnedSummaryCard: View {
                 label: "Stop all background processes",
                 identifier: "plan.processes.stopAll"
             ) {
-                model.backgroundServicesModel.stopAllBackgroundServices()
+                backgroundServices.stopAllBackgroundServices()
             }
         } content: {
             VStack(spacing: 2) {
@@ -241,7 +244,7 @@ struct PinnedSummaryCard: View {
                         if let port = service.port, let url = URL(string: "http://localhost:\(port)") {
                             Button("Open in Browser Tab") { model.openURLInBrowserTab(url) }
                         }
-                        Button("Stop") { model.backgroundServicesModel.stopBackgroundService(service) }
+                        Button("Stop") { backgroundServices.stopBackgroundService(service) }
                     }
                 }
             }

--- a/Locus/PlanApprovalPromptView.swift
+++ b/Locus/PlanApprovalPromptView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// tool approval still appears in the normal composer permission panel.
 struct SoloSwarmPanelView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var teamRunLive: TeamRunLiveModel
     let runID: String
 
     var body: some View {
@@ -84,7 +85,7 @@ struct SoloSwarmPanelView: View {
     private var isActive: Bool { model.orchestrationRunID == runID && model.isBusy }
     private var liveActivities: [AgentActivity] {
         guard model.orchestrationRunID == runID else { return [] }
-        return model.teamRunLive.agentActivities.filter { $0.depth == 1 }
+        return teamRunLive.agentActivities.filter { $0.depth == 1 }
     }
     private var attempts: [AgentJobAttempt] { run?.attempts ?? [] }
     private var hasDelegation: Bool {
@@ -101,11 +102,11 @@ struct SoloSwarmPanelView: View {
         return attempts.filter { $0.state == "completed" }.count
     }
     private var modelCalls: Int {
-        if !liveActivities.isEmpty { return model.teamRunLive.teamModelCalls }
+        if !liveActivities.isEmpty { return teamRunLive.teamModelCalls }
         return attempts.reduce(0) { $0 + $1.modelCalls }
     }
     private var delegatedTokens: Int {
-        if !liveActivities.isEmpty { return model.teamRunLive.teamMeteredTokens }
+        if !liveActivities.isEmpty { return teamRunLive.teamMeteredTokens }
         return attempts.reduce(0) { $0 + $1.promptTokens + $1.completionTokens }
     }
     private var isSuccessful: Bool {
@@ -134,6 +135,9 @@ struct SoloSwarmPanelView: View {
 /// planning and execution never displace the message composer.
 struct TeamRunBoardView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var teamRunLive: TeamRunLiveModel
+    @EnvironmentObject private var landingFlow: LandingFlowModel
+    @EnvironmentObject private var runs: OrchestrationRunsModel
     let runID: String
     let request: String
 
@@ -141,10 +145,10 @@ struct TeamRunBoardView: View {
 
     var body: some View {
         Group {
-            if isActive, model.teamRunLive.shouldShowTeamDispatchProgress {
+            if isActive, teamRunLive.shouldShowTeamDispatchProgress {
                 TeamDispatchProgressView()
-            } else if isActive, model.teamRunLive.shouldShowTeamDispatchApproval,
-                      let plan = model.teamRunLive.pendingDispatchPlan
+            } else if isActive, teamRunLive.shouldShowTeamDispatchApproval,
+                      let plan = teamRunLive.pendingDispatchPlan
             {
                 TeamDispatchApprovalPromptView(plan: plan)
             } else if shouldCollapseTerminal, !terminalExpanded {
@@ -256,8 +260,8 @@ struct TeamRunBoardView: View {
                 Text(teamName).font(.locus(size: 12, weight: .bold))
             }
             Spacer()
-            if isActive, model.teamRunLive.teamModelCalls > 0 || model.teamRunLive.teamMeteredTokens > 0 {
-                Text("\(model.teamRunLive.teamModelCalls) calls · \(model.teamRunLive.teamMeteredTokens.formatted()) tokens")
+            if isActive, teamRunLive.teamModelCalls > 0 || teamRunLive.teamMeteredTokens > 0 {
+                Text("\(teamRunLive.teamModelCalls) calls · \(teamRunLive.teamMeteredTokens.formatted()) tokens")
                     .font(.locus(size: 8, design: .monospaced))
                     .foregroundStyle(LocusTheme.muted)
             }
@@ -392,8 +396,8 @@ struct TeamRunBoardView: View {
                         .accessibilityIdentifier("teamBoard.stop")
                 }
             }
-            if state == .completed, model.landingFlow.taskHasChanges, isActive {
-                Button("Review & Land") { model.landingFlow.prepareReviewAndLand() }
+            if state == .completed, landingFlow.taskHasChanges, isActive {
+                Button("Review & Land") { landingFlow.prepareReviewAndLand() }
                     .buttonStyle(.borderedProminent)
                     .tint(LocusTheme.ink)
             }
@@ -406,8 +410,8 @@ struct TeamRunBoardView: View {
     }
 
     private var run: OrchestrationRun? {
-        if model.runs.selectedOrchestrationRun?.id == runID { return model.runs.selectedOrchestrationRun }
-        return model.runs.orchestrationRuns.first(where: { $0.id == runID })
+        if runs.selectedOrchestrationRun?.id == runID { return runs.selectedOrchestrationRun }
+        return runs.orchestrationRuns.first(where: { $0.id == runID })
     }
 
     private var presentation: TeamRunPresentation {
@@ -421,12 +425,12 @@ struct TeamRunBoardView: View {
         presentation.state
     }
     private var teamName: String {
-        if isActive, let name = model.teamRunLive.activeOrchestrationTeam?.name { return name }
+        if isActive, let name = teamRunLive.activeOrchestrationTeam?.name { return name }
         return run?.teamName ?? "Team run"
     }
     private var visibleActivities: [AgentActivity] {
         guard isActive else { return [] }
-        return model.teamRunLive.agentActivities
+        return teamRunLive.agentActivities
     }
     private var phases: [String] { ["Plan", "Approve", "Specialists", "Coding", "Review", "Done"] }
     private var currentPhase: Int {
@@ -434,14 +438,14 @@ struct TeamRunBoardView: View {
         case .queued, .dispatching: 0
         case .waitingDispatchApproval: 1
         case .running, .waitingPermission, .waitingComputer:
-            model.teamRunLive.agentActivities.contains(where: { $0.writerPosition != nil }) ? 3 : 2
+            teamRunLive.agentActivities.contains(where: { $0.writerPosition != nil }) ? 3 : 2
         case .reviewing: 4
         case .completed: 5
         case .paused, .failed, .interrupted, .cancelled, .discarded: interruptedPhase
         }
     }
     private var interruptedPhase: Int {
-        if model.teamRunLive.pendingDispatchPlan != nil { return 1 }
+        if teamRunLive.pendingDispatchPlan != nil { return 1 }
         if visibleActivities.contains(where: { $0.writerPosition != nil }) { return 3 }
         if let kind = run?.checkpoint?.kind.lowercased() {
             if kind.contains("synthesis") { return 5 }
@@ -494,8 +498,8 @@ struct TeamRunBoardView: View {
     }
     private var terminalSummary: String {
         let completed = run?.completedJobCount
-            ?? (isActive ? model.teamRunLive.agentActivities.filter { $0.state == .completed }.count : 0)
-        let total = run?.jobCount ?? (isActive ? model.teamRunLive.agentActivities.count : 0)
+            ?? (isActive ? teamRunLive.agentActivities.filter { $0.state == .completed }.count : 0)
+        let total = run?.jobCount ?? (isActive ? teamRunLive.agentActivities.count : 0)
         let jobs = total > 0 ? "\(completed)/\(total) jobs" : "Run finished"
         let duration: String
         if let run {
@@ -505,7 +509,7 @@ struct TeamRunBoardView: View {
         } else {
             duration = ""
         }
-        let changes = isActive && model.landingFlow.taskHasChanges ? "changes ready" : ""
+        let changes = isActive && landingFlow.taskHasChanges ? "changes ready" : ""
         let failure = state == .completed ? "" : (run?.recoveryReason ?? "")
         return [jobs, duration, changes, failure]
             .filter { !$0.isEmpty }
@@ -519,6 +523,10 @@ struct TeamRunBoardView: View {
 struct TeamDispatchProgressView: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var transcriptPresentation: TranscriptPresentationModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
+    @EnvironmentObject private var teamRunLive: TeamRunLiveModel
+    @EnvironmentObject private var runs: OrchestrationRunsModel
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 1)) { timeline in
@@ -527,7 +535,7 @@ struct TeamDispatchProgressView: View {
     }
 
     private func content(now: Date) -> some View {
-        let startedAt = model.teamRunLive.dispatcherActivity?.startedAt ?? model.activeWorkStartedAt
+        let startedAt = teamRunLive.dispatcherActivity?.startedAt ?? model.activeWorkStartedAt
         let elapsed = startedAt.map { max(now.timeIntervalSince($0), 0) } ?? 0
 
         return VStack(alignment: .leading, spacing: 0) {
@@ -541,7 +549,7 @@ struct TeamDispatchProgressView: View {
                         .tracking(0.8)
                         .foregroundStyle(LocusTheme.signalDeep)
                         .accessibilityIdentifier("teamDispatch.progress")
-                    Text(model.teamRunLive.activeOrchestrationTeam?.name ?? "Team run")
+                    Text(teamRunLive.activeOrchestrationTeam?.name ?? "Team run")
                         .font(.locus(size: 12, weight: .bold))
                 }
                 Spacer()
@@ -575,7 +583,7 @@ struct TeamDispatchProgressView: View {
                     }
                 }
 
-                if let reason = model.teamRunLive.dispatcherValidationReason, !reason.isEmpty {
+                if let reason = teamRunLive.dispatcherValidationReason, !reason.isEmpty {
                     Label(reason, systemImage: "arrow.triangle.2.circlepath")
                         .font(.locus(size: 9, weight: .medium))
                         .foregroundStyle(LocusTheme.warning)
@@ -590,13 +598,13 @@ struct TeamDispatchProgressView: View {
                 VStack(alignment: .leading, spacing: 5) {
                     stageRow(
                         "Dispatcher connected",
-                        complete: model.teamRunLive.dispatcherActivity != nil
+                        complete: teamRunLive.dispatcherActivity != nil
                     )
                     stageRow(
-                        model.teamRunLive.dispatcherValidationReason == nil
+                        teamRunLive.dispatcherValidationReason == nil
                             ? "Create and validate one complete team plan"
                             : "Correct and revalidate the team plan",
-                        complete: model.teamRunLive.dispatcherActivity?.state == .completed
+                        complete: teamRunLive.dispatcherActivity?.state == .completed
                     )
                     stageRow("Show the plan for your approval", complete: false)
                 }
@@ -660,11 +668,11 @@ struct TeamDispatchProgressView: View {
     }
 
     private var dispatcherName: String {
-        model.teamRunLive.dispatcherActivity?.agentName ?? dispatcherProfile?.name ?? "Starting dispatcher…"
+        teamRunLive.dispatcherActivity?.agentName ?? dispatcherProfile?.name ?? "Starting dispatcher…"
     }
 
     private var dispatcherRoute: String {
-        if let activity = model.teamRunLive.dispatcherActivity, !activity.model.isEmpty {
+        if let activity = teamRunLive.dispatcherActivity, !activity.model.isEmpty {
             return [activity.provider, activity.model].filter { !$0.isEmpty }.joined(separator: " · ")
         }
         guard let profile = dispatcherProfile else { return "Preparing model route" }
@@ -673,27 +681,27 @@ struct TeamDispatchProgressView: View {
         case .localOllama:
             provider = "Local Ollama"
         case .providerAccount(let id):
-            provider = model.providerAccounts.first(where: { $0.id == id })?.displayName
+            provider = providerAccounts.providerAccounts.first(where: { $0.id == id })?.displayName
                 ?? "Configured provider"
         }
         return "\(provider) · \(profile.model)"
     }
 
     private var stageDetail: String {
-        if let output = model.teamRunLive.dispatcherActivity?.output, !output.isEmpty { return output }
-        if model.teamRunLive.dispatcherActivity == nil {
+        if let output = teamRunLive.dispatcherActivity?.output, !output.isEmpty { return output }
+        if teamRunLive.dispatcherActivity == nil {
             return "Opening the dispatcher route and preparing the team roster."
         }
         return "Creating assignments, dependencies, and the ordered coding sequence."
     }
 
     private var dispatcherProfile: AgentProfile? {
-        guard let id = model.teamRunLive.activeOrchestrationTeam?.dispatcherID else { return nil }
-        return model.agentProfiles.first(where: { $0.id == id })
+        guard let id = teamRunLive.activeOrchestrationTeam?.dispatcherID else { return nil }
+        return agentTeams.agentProfiles.first(where: { $0.id == id })
     }
 
     private var requestSummary: String {
-        if let request = model.runs.selectedOrchestrationRun?.request, !request.isEmpty {
+        if let request = runs.selectedOrchestrationRun?.request, !request.isEmpty {
             return request
         }
         return transcriptPresentation.snapshot.blocks.last(where: { $0.kind == .user })?.text ?? ""
@@ -710,6 +718,8 @@ struct TeamDispatchProgressView: View {
 /// ask for additional dispatch approval.
 struct TeamDispatchApprovalPromptView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var teamRunLive: TeamRunLiveModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
     let plan: DispatchPlan
 
     @State private var selection = 0
@@ -833,7 +843,7 @@ struct TeamDispatchApprovalPromptView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityIdentifier("teamDispatch.jobs")
 
-            if let budget = plan.budget ?? model.teamRunLive.activeOrchestrationTeam?.budget {
+            if let budget = plan.budget ?? teamRunLive.activeOrchestrationTeam?.budget {
                 HStack(spacing: 8) {
                     budgetPill("\(budget.maxJobs) jobs max")
                     budgetPill(
@@ -848,7 +858,7 @@ struct TeamDispatchApprovalPromptView: View {
                 }
             }
 
-            let policy = plan.swarmPolicy ?? model.teamRunLive.activeOrchestrationTeam?.resolvedSwarmPolicy
+            let policy = plan.swarmPolicy ?? teamRunLive.activeOrchestrationTeam?.resolvedSwarmPolicy
             if let policy, policy.delegationMode == .readOnlyChildren {
                 HStack(spacing: 8) {
                     budgetPill("Adaptive read-only children")
@@ -986,7 +996,7 @@ struct TeamDispatchApprovalPromptView: View {
 
     private func agentName(for job: DispatchJob) -> String {
         guard let id = UUID(uuidString: job.agentID) else { return job.agentID }
-        return model.agentProfiles.first(where: { $0.id == id })?.name ?? job.agentID
+        return agentTeams.agentProfiles.first(where: { $0.id == id })?.name ?? job.agentID
     }
 
     private func jobLabel(_ job: DispatchJob) -> String {

--- a/Locus/ProviderAccountsModel.swift
+++ b/Locus/ProviderAccountsModel.swift
@@ -6,8 +6,8 @@ import Foundation
 /// per-account ChatGPT plan state, the usage rollup, and the last reported
 /// Ollama host. Routing decisions — which account the session uses, provider
 /// switches — stay with the composition root and reach it through closures.
-/// AppModel wires it via configure(...) and bridges its publication; it
-/// never retains AppModel.
+/// AppModel wires it via configure(...), while views observe this model
+/// directly. It never retains AppModel.
 @MainActor
 final class ProviderAccountsModel: ObservableObject {
     @Published var models: [ModelInfo] = []

--- a/Locus/SessionSidebarView.swift
+++ b/Locus/SessionSidebarView.swift
@@ -132,6 +132,7 @@ enum SidebarIconMetrics {
 struct SessionSidebarView: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var sessionCatalog: SessionCatalogModel
+    @EnvironmentObject private var activityCenter: ActivityCenterModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var sessionToRename: SessionSummary?
     @State private var renameText = ""
@@ -488,15 +489,15 @@ struct SessionSidebarView: View {
     private var activityButton: some View {
         Button {
             withAnimation(LocusMotion.spatial) {
-                model.activity.toggleActivityCenter()
+                activityCenter.toggleActivityCenter()
             }
         } label: {
-            Image(systemName: model.activity.activityCenterPresented ? "bell.fill" : "bell")
+            Image(systemName: activityCenter.activityCenterPresented ? "bell.fill" : "bell")
                 .font(.locus(size: 12, weight: .semibold))
-                .foregroundStyle(model.activity.activityCenterPresented
+                .foregroundStyle(activityCenter.activityCenterPresented
                     ? LocusTheme.ink : LocusTheme.inkSoft)
                 .frame(width: 36, height: 36)
-                .background(model.activity.activityCenterPresented
+                .background(activityCenter.activityCenterPresented
                     ? LocusTheme.signal.opacity(0.9)
                     : LocusTheme.white.opacity(0.82))
                 .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
@@ -505,8 +506,8 @@ struct SessionSidebarView: View {
                         .stroke(LocusTheme.line, lineWidth: 1)
                 }
                 .overlay(alignment: .topTrailing) {
-                    if model.activity.activityNeedsAttentionCount > 0 {
-                        Text("\(model.activity.activityNeedsAttentionCount)")
+                    if activityCenter.activityNeedsAttentionCount > 0 {
+                        Text("\(activityCenter.activityNeedsAttentionCount)")
                             .font(.locus(size: 7, weight: .bold, design: .monospaced))
                             .foregroundStyle(Color.white)
                             .frame(minWidth: 14, minHeight: 14)
@@ -522,8 +523,8 @@ struct SessionSidebarView: View {
         .accessibilityLabel("Activities")
         .accessibilityIdentifier("sidebar.activity")
         .accessibilityValue(
-            model.activity.activityNeedsAttentionCount > 0
-                ? "\(model.activity.activityNeedsAttentionCount) needs attention"
+            activityCenter.activityNeedsAttentionCount > 0
+                ? "\(activityCenter.activityNeedsAttentionCount) needs attention"
                 : "No new activity"
         )
     }
@@ -1050,6 +1051,10 @@ private struct SidebarResizeHandle: View {
 
 struct TeamProgressPopover: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
+    @EnvironmentObject private var teamRunLive: TeamRunLiveModel
+    @EnvironmentObject private var runs: OrchestrationRunsModel
     let dismiss: () -> Void
 
     @ViewBuilder
@@ -1104,7 +1109,7 @@ struct TeamProgressPopover: View {
             Image(systemName: "person.2.fill")
                 .foregroundStyle(LocusTheme.signalDeep)
             VStack(alignment: .leading, spacing: 2) {
-                Text(model.selectedAgentTeam?.name ?? "Team")
+                Text(agentTeams.selectedAgentTeam?.name ?? "Team")
                     .font(.locus(size: 12, weight: .bold))
                 Text(progressStateTitle)
                     .font(.locus(size: 8, design: .monospaced))
@@ -1122,7 +1127,7 @@ struct TeamProgressPopover: View {
 
     @ViewBuilder
     private func dispatcherSection(now: Date) -> some View {
-        let activity = model.teamRunLive.dispatcherActivity
+        let activity = teamRunLive.dispatcherActivity
         let dispatcher = selectedDispatcher
         let startedAt = activity?.startedAt ?? model.activeWorkStartedAt
         let elapsed = startedAt.map { max(now.timeIntervalSince($0), 0) } ?? 0
@@ -1154,7 +1159,7 @@ struct TeamProgressPopover: View {
             }
             if model.orchestrationState == .dispatching,
                elapsed >= 30,
-               model.teamRunLive.agentActivities.isEmpty
+               teamRunLive.agentActivities.isEmpty
             {
                 Label(
                     "Still waiting for the dispatcher. No plan or delegated jobs have started.",
@@ -1181,11 +1186,11 @@ struct TeamProgressPopover: View {
             HStack {
                 sectionLabel("DELEGATED JOBS")
                 Spacer()
-                Text("\(completedJobs)/\(model.teamRunLive.agentActivities.count)")
+                Text("\(completedJobs)/\(teamRunLive.agentActivities.count)")
                     .font(.locus(size: 8, design: .monospaced))
                     .foregroundStyle(LocusTheme.muted)
             }
-            if model.teamRunLive.agentActivities.isEmpty {
+            if teamRunLive.agentActivities.isEmpty {
                 Text(model.orchestrationState == nil
                     ? "No run yet. Send a task with this team selected."
                     : "Jobs appear here after the dispatcher returns a plan.")
@@ -1193,7 +1198,7 @@ struct TeamProgressPopover: View {
                     .foregroundStyle(LocusTheme.muted)
                     .fixedSize(horizontal: false, vertical: true)
             } else {
-                ForEach(model.teamRunLive.agentActivities) { activity in
+                ForEach(teamRunLive.agentActivities) { activity in
                     HStack(spacing: 7) {
                         Image(systemName: dispatcherSymbol(activity.state))
                             .foregroundStyle(dispatcherColor(activity.state))
@@ -1238,8 +1243,8 @@ struct TeamProgressPopover: View {
 
     private var footer: some View {
         HStack(spacing: 12) {
-            Text("\(model.teamRunLive.teamModelCalls.formatted()) calls")
-            Text("\(model.teamRunLive.teamMeteredTokens.formatted()) hosted tokens")
+            Text("\(teamRunLive.teamModelCalls.formatted()) calls")
+            Text("\(teamRunLive.teamMeteredTokens.formatted()) hosted tokens")
             Spacer()
             if presentation?.canStop == true, let runID = model.orchestrationRunID {
                 Button("Stop", role: .destructive) {
@@ -1268,17 +1273,17 @@ struct TeamProgressPopover: View {
     }
 
     private var selectedDispatcher: AgentProfile? {
-        guard let id = model.selectedAgentTeam?.dispatcherID else { return nil }
-        return model.agentProfiles.first(where: { $0.id == id })
+        guard let id = agentTeams.selectedAgentTeam?.dispatcherID else { return nil }
+        return agentTeams.agentProfiles.first(where: { $0.id == id })
     }
 
     private var teamProfiles: [AgentProfile] {
-        guard let team = model.selectedAgentTeam else { return [] }
-        return team.memberIDs.compactMap { id in model.agentProfiles.first(where: { $0.id == id }) }
+        guard let team = agentTeams.selectedAgentTeam else { return [] }
+        return team.memberIDs.compactMap { id in agentTeams.agentProfiles.first(where: { $0.id == id }) }
     }
 
     private var completedJobs: Int {
-        model.teamRunLive.agentActivities.filter { $0.state == .completed }.count
+        teamRunLive.agentActivities.filter { $0.state == .completed }.count
     }
 
     private func activityTitle(_ activity: AgentActivity) -> String {
@@ -1294,7 +1299,7 @@ struct TeamProgressPopover: View {
 
     private var presentation: TeamRunPresentation? {
         guard let runID = model.orchestrationRunID else { return nil }
-        let durable = model.runs.orchestrationRuns.first(where: { $0.id == runID })
+        let durable = runs.orchestrationRuns.first(where: { $0.id == runID })
         return model.teamRunPresentation(for: runID, durable: durable)
     }
 
@@ -1318,7 +1323,7 @@ struct TeamProgressPopover: View {
         case .localOllama:
             provider = "Local Ollama"
         case .providerAccount(let id):
-            provider = model.providerAccounts.first(where: { $0.id == id })?.displayName
+            provider = providerAccounts.providerAccounts.first(where: { $0.id == id })?.displayName
                 ?? "Unavailable provider"
         }
         return "\(provider) · \(profile.model)"

--- a/Locus/Sheets.swift
+++ b/Locus/Sheets.swift
@@ -164,6 +164,7 @@ private struct PluginInstallReview: Identifiable {
 }
 
 private struct ExtensionsSettingsView: View {
+    @EnvironmentObject private var extensionsModel: ExtensionsModel
     private enum Tab: String, CaseIterable, Identifiable {
         case installed = "Installed"
         case marketplace = "Marketplace"
@@ -239,12 +240,12 @@ private struct ExtensionsSettingsView: View {
             .labelsHidden()
             .padding(14)
 
-            if let error = model.extensionsModel.extensionErrorMessage, !error.isEmpty {
+            if let error = extensionsModel.extensionErrorMessage, !error.isEmpty {
                 HStack(spacing: 7) {
                     Image(systemName: "exclamationmark.triangle.fill")
                     Text(error).lineLimit(2)
                     Spacer()
-                    Button("Dismiss") { model.extensionsModel.extensionErrorMessage = nil }
+                    Button("Dismiss") { extensionsModel.extensionErrorMessage = nil }
                         .buttonStyle(.locus())
                 }
                 .font(.locus(size: 9))
@@ -264,13 +265,13 @@ private struct ExtensionsSettingsView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .task {
-            await model.extensionsModel.refreshExtensions()
-            await model.extensionsModel.refreshExtensionCatalog()
+            await extensionsModel.refreshExtensions()
+            await extensionsModel.refreshExtensionCatalog()
         }
         .sheet(item: $review) { item in
             PluginTrustReviewView(item: item) { scope in
                 review = nil
-                Task { await model.extensionsModel.installPlugin(item.entry, trust: item.trust, scope: scope) }
+                Task { await extensionsModel.installPlugin(item.entry, trust: item.trust, scope: scope) }
             }
         }
         .sheet(isPresented: $editorPresented) {
@@ -295,12 +296,12 @@ private struct ExtensionsSettingsView: View {
         .sheet(item: $enableAfterProbe) { server in
             MCPEnableReviewView(server: server) { scope in
                 enableAfterProbe = nil
-                Task { await model.extensionsModel.setMCPServer(server.id, enabled: true, scope: scope) }
+                Task { await extensionsModel.setMCPServer(server.id, enabled: true, scope: scope) }
             }
         }
         .sheet(item: Binding(
-            get: { model.extensionsModel.mcpDeviceAuthorization },
-            set: { model.extensionsModel.mcpDeviceAuthorization = $0 }
+            get: { extensionsModel.mcpDeviceAuthorization },
+            set: { extensionsModel.mcpDeviceAuthorization = $0 }
         )) { prompt in
             MCPDeviceAuthorizationView(prompt: prompt)
                 .environmentObject(model)
@@ -310,7 +311,7 @@ private struct ExtensionsSettingsView: View {
     private var installedPane: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 10) {
-                if model.extensionsModel.extensions.plugins.isEmpty {
+                if extensionsModel.extensions.plugins.isEmpty {
                     ContentUnavailableView(
                         "No plugins installed",
                         systemImage: "puzzlepiece.extension",
@@ -318,7 +319,7 @@ private struct ExtensionsSettingsView: View {
                     )
                     .frame(maxWidth: .infinity, minHeight: 330)
                 }
-                ForEach(model.extensionsModel.extensions.plugins) { plugin in
+                ForEach(extensionsModel.extensions.plugins) { plugin in
                     VStack(alignment: .leading, spacing: 9) {
                         HStack {
                             VStack(alignment: .leading, spacing: 2) {
@@ -338,7 +339,7 @@ private struct ExtensionsSettingsView: View {
                             }
                             Spacer()
                             Button(plugin.enabledGlobal ? "Disable everywhere" : "Enable everywhere") {
-                                Task { await model.extensionsModel.setPlugin(plugin.id, enabled: !plugin.enabledGlobal, scope: "global") }
+                                Task { await extensionsModel.setPlugin(plugin.id, enabled: !plugin.enabledGlobal, scope: "global") }
                             }
                             .disabled(model.isBusy)
                         }
@@ -362,17 +363,17 @@ private struct ExtensionsSettingsView: View {
                             let workspaceEnabled = !plugin.disabledWorkspaces.contains(model.workspacePath)
                                 && (plugin.enabledGlobal || plugin.enabledWorkspaces.contains(model.workspacePath))
                             Button(workspaceEnabled ? "Disable for this workspace" : "Enable for this workspace") {
-                                Task { await model.extensionsModel.setPlugin(plugin.id, enabled: !workspaceEnabled, scope: "workspace") }
+                                Task { await extensionsModel.setPlugin(plugin.id, enabled: !workspaceEnabled, scope: "workspace") }
                             }
                             .disabled(model.isBusy)
                             if !(plugin.previousVersions ?? []).isEmpty {
-                                Button("Roll back") { Task { await model.extensionsModel.rollbackPlugin(plugin.id) } }
+                                Button("Roll back") { Task { await extensionsModel.rollbackPlugin(plugin.id) } }
                                     .disabled(model.isBusy)
                             }
                             if plugin.updateAvailable == true {
                                 Button("Review update") {
                                     Task {
-                                        if let (entry, trust) = await model.extensionsModel.inspectUpdate(for: plugin) {
+                                        if let (entry, trust) = await extensionsModel.inspectUpdate(for: plugin) {
                                             review = PluginInstallReview(entry: entry, trust: trust)
                                         }
                                     }
@@ -381,7 +382,7 @@ private struct ExtensionsSettingsView: View {
                             }
                             Spacer()
                             Button("Uninstall", role: .destructive) {
-                                Task { await model.extensionsModel.uninstallPlugin(plugin.id) }
+                                Task { await extensionsModel.uninstallPlugin(plugin.id) }
                             }
                             .disabled(model.isBusy)
                         }
@@ -400,7 +401,7 @@ private struct ExtensionsSettingsView: View {
             HStack {
                 Picker("Source", selection: $marketplaceID) {
                     Text("All sources").tag("")
-                    ForEach(model.extensionsModel.extensions.marketplaces) { source in
+                    ForEach(extensionsModel.extensions.marketplaces) { source in
                         Text(source.name).tag(source.id)
                     }
                 }
@@ -408,10 +409,10 @@ private struct ExtensionsSettingsView: View {
                 TextField("Search plugins", text: $search)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit {
-                        Task { await model.extensionsModel.refreshExtensionCatalog(query: search, marketplaceID: marketplaceID) }
+                        Task { await extensionsModel.refreshExtensionCatalog(query: search, marketplaceID: marketplaceID) }
                     }
                 Button("Search") {
-                    Task { await model.extensionsModel.refreshExtensionCatalog(query: search, marketplaceID: marketplaceID) }
+                    Task { await extensionsModel.refreshExtensionCatalog(query: search, marketplaceID: marketplaceID) }
                 }
             }
             HStack {
@@ -423,7 +424,7 @@ private struct ExtensionsSettingsView: View {
                 Button("Add source") {
                     let source = marketplaceSource
                     marketplaceSource = ""
-                    Task { await model.extensionsModel.addMarketplace(source: source, name: marketplaceName) }
+                    Task { await extensionsModel.addMarketplace(source: source, name: marketplaceName) }
                 }
                 .disabled(marketplaceSource.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
@@ -459,7 +460,7 @@ private struct ExtensionsSettingsView: View {
                                 Button("Find") {
                                     search = recommendation.name
                                     Task {
-                                        await model.extensionsModel.refreshExtensionCatalog(
+                                        await extensionsModel.refreshExtensionCatalog(
                                             query: recommendation.name,
                                             marketplaceID: marketplaceID
                                         )
@@ -472,7 +473,7 @@ private struct ExtensionsSettingsView: View {
                     }
                     .padding(.bottom, 6)
 
-                    ForEach(model.extensionsModel.extensionCatalog) { entry in
+                    ForEach(extensionsModel.extensionCatalog) { entry in
                         HStack(alignment: .top, spacing: 10) {
                             Image(systemName: "shippingbox")
                                 .frame(width: 22, height: 22)
@@ -491,7 +492,7 @@ private struct ExtensionsSettingsView: View {
                             Spacer()
                             Button(entry.installed ? "Review update" : "Review & install") {
                                 Task {
-                                    if let trust = await model.extensionsModel.inspectPlugin(entry) {
+                                    if let trust = await extensionsModel.inspectPlugin(entry) {
                                         review = PluginInstallReview(entry: entry, trust: trust)
                                     }
                                 }
@@ -501,7 +502,7 @@ private struct ExtensionsSettingsView: View {
                         .padding(11)
                         .locusCard(radius: 9)
                     }
-                    if model.extensionsModel.extensionCatalog.isEmpty {
+                    if extensionsModel.extensionCatalog.isEmpty {
                         ContentUnavailableView(
                             "No plugins found",
                             systemImage: "magnifyingglass",
@@ -515,7 +516,7 @@ private struct ExtensionsSettingsView: View {
         }
         .padding(.horizontal, 14)
         .onChange(of: marketplaceID) {
-            Task { await model.extensionsModel.refreshExtensionCatalog(query: search, marketplaceID: marketplaceID) }
+            Task { await extensionsModel.refreshExtensionCatalog(query: search, marketplaceID: marketplaceID) }
         }
     }
 
@@ -525,7 +526,7 @@ private struct ExtensionsSettingsView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("External tools from MCP servers")
                         .font(.locus(size: 11, weight: .semibold))
-                    if !model.extensionsModel.extensions.capabilities.stdio {
+                    if !extensionsModel.extensions.capabilities.stdio {
                         Text("This App Store build supports remote MCP servers and skills. Local command-based servers are unavailable.")
                             .font(.locus(size: 9))
                             .foregroundStyle(LocusTheme.muted)
@@ -540,7 +541,7 @@ private struct ExtensionsSettingsView: View {
             }
             ScrollView {
                 LazyVStack(spacing: 9) {
-                    if !model.extensionsModel.extensions.mcpPresets.isEmpty {
+                    if !extensionsModel.extensions.mcpPresets.isEmpty {
                         HStack {
                             Text("Recommended")
                                 .font(.locus(size: 11, weight: .semibold))
@@ -549,7 +550,7 @@ private struct ExtensionsSettingsView: View {
                                 .font(.locus(size: 8))
                                 .foregroundStyle(LocusTheme.muted)
                         }
-                        ForEach(model.extensionsModel.extensions.mcpPresets) { preset in
+                        ForEach(extensionsModel.extensions.mcpPresets) { preset in
                             HStack(alignment: .top, spacing: 10) {
                                 MCPLogo(
                                     name: preset.displayName,
@@ -590,7 +591,7 @@ private struct ExtensionsSettingsView: View {
                             Spacer()
                         }
                     }
-                    ForEach(model.extensionsModel.extensions.mcpServers) { server in
+                    ForEach(extensionsModel.extensions.mcpServers) { server in
                         VStack(alignment: .leading, spacing: 8) {
                             HStack(spacing: 10) {
                                 MCPLogo(
@@ -616,9 +617,9 @@ private struct ExtensionsSettingsView: View {
                                         .foregroundStyle(LocusTheme.muted)
                                 }
                                 Spacer()
-                                Button("Test") { Task { await model.extensionsModel.testMCPServer(server.id) } }
+                                Button("Test") { Task { await extensionsModel.testMCPServer(server.id) } }
                                     .disabled(model.isBusy)
-                                Button("Reconnect") { Task { await model.extensionsModel.reconnectMCPServer(server.id) } }
+                                Button("Reconnect") { Task { await extensionsModel.reconnectMCPServer(server.id) } }
                                     .disabled(model.isBusy)
                                 if server.origin == "user" {
                                     Button("Edit") {
@@ -631,7 +632,7 @@ private struct ExtensionsSettingsView: View {
                                 Text(error).font(.locus(size: 8)).foregroundStyle(LocusTheme.coral)
                             }
                             if server.presetID == "github",
-                               model.extensionsModel.githubConnectionCapability(for: server) == .tokenFallbackOnly {
+                               extensionsModel.githubConnectionCapability(for: server) == .tokenFallbackOnly {
                                 Label(
                                     "This build has no GitHub App client ID. Account sign-in is disabled; use a personal token instead.",
                                     systemImage: "exclamationmark.triangle.fill"
@@ -646,11 +647,11 @@ private struct ExtensionsSettingsView: View {
                                 }
                                 if server.auth == "oauth" || server.auth == "auto" {
                                     Button(server.hasCredentials == true ? "Reconnect account" : "Connect account") {
-                                        model.extensionsModel.authenticateMCPServer(server)
+                                        extensionsModel.authenticateMCPServer(server)
                                     }
                                     .disabled(
                                         server.presetID == "github"
-                                            && model.extensionsModel.githubConnectionCapability(for: server) == .tokenFallbackOnly
+                                            && extensionsModel.githubConnectionCapability(for: server) == .tokenFallbackOnly
                                     )
                                 } else if server.auth != "none" {
                                     Button(server.hasCredentials == true ? "Update credentials" : "Add credentials") {
@@ -664,7 +665,7 @@ private struct ExtensionsSettingsView: View {
                                 }
                                 if server.hasCredentials == true {
                                     Button("Forget credentials") {
-                                        Task { await model.extensionsModel.clearMCPCredentials(serverID: server.id) }
+                                        Task { await extensionsModel.clearMCPCredentials(serverID: server.id) }
                                     }
                                 }
                                 Spacer()
@@ -672,22 +673,22 @@ private struct ExtensionsSettingsView: View {
                                     && (server.enabledGlobal == true || server.enabledWorkspaces?.contains(model.workspacePath) == true)
                                 if let pluginID = server.pluginID {
                                     Button(workspaceEnabled ? "Disable plugin here" : "Enable plugin here") {
-                                        Task { await model.extensionsModel.setPlugin(pluginID, enabled: !workspaceEnabled, scope: "workspace") }
+                                        Task { await extensionsModel.setPlugin(pluginID, enabled: !workspaceEnabled, scope: "workspace") }
                                     }
                                 } else {
                                     Button(workspaceEnabled ? "Disable here" : "Enable here") {
-                                        Task { await model.extensionsModel.setMCPServer(server.id, enabled: !workspaceEnabled, scope: "workspace") }
+                                        Task { await extensionsModel.setMCPServer(server.id, enabled: !workspaceEnabled, scope: "workspace") }
                                     }
                                 }
                                 if server.origin == "user" {
                                     Button("Remove", role: .destructive) {
-                                        Task { await model.extensionsModel.removeMCPServer(server.id) }
+                                        Task { await extensionsModel.removeMCPServer(server.id) }
                                     }
                                 }
                             }
                             .font(.locus(size: 9))
 
-                            let tools = model.extensionsModel.extensionTools.filter { $0.serverID == server.id }
+                            let tools = extensionsModel.extensionTools.filter { $0.serverID == server.id }
                             if !tools.isEmpty {
                                 DisclosureGroup("Tool permissions") {
                                     ForEach(tools) { tool in
@@ -728,7 +729,7 @@ private struct ExtensionsSettingsView: View {
             }
             ScrollView {
                 LazyVStack(spacing: 8) {
-                    ForEach(model.extensionsModel.extensions.skills) { skill in
+                    ForEach(extensionsModel.extensions.skills) { skill in
                         HStack(spacing: 10) {
                             Image(systemName: "sparkles").foregroundStyle(LocusTheme.muted)
                             VStack(alignment: .leading, spacing: 2) {
@@ -750,7 +751,7 @@ private struct ExtensionsSettingsView: View {
                                 let enabledEverywhere = skill.enabledGlobal ?? skill.enabled
                                 Button(enabledEverywhere ? "Disable globally" : "Enable globally") {
                                     Task {
-                                        await model.extensionsModel.setSkill(
+                                        await extensionsModel.setSkill(
                                             skill.id,
                                             enabled: !enabledEverywhere,
                                             scope: "global"
@@ -762,7 +763,7 @@ private struct ExtensionsSettingsView: View {
                                         || skill.enabledWorkspaces?.contains(model.workspacePath) == true)
                                 Button(enabledHere ? "Disable here" : "Enable here") {
                                     Task {
-                                        await model.extensionsModel.setSkill(
+                                        await extensionsModel.setSkill(
                                             skill.id,
                                             enabled: !enabledHere,
                                             scope: "workspace"
@@ -771,7 +772,7 @@ private struct ExtensionsSettingsView: View {
                                 }
                                 if skill.source == "imported" {
                                     Button("Remove", role: .destructive) {
-                                        Task { await model.extensionsModel.removeSkill(skill.id) }
+                                        Task { await extensionsModel.removeSkill(skill.id) }
                                     }
                                 }
                             } else {
@@ -790,10 +791,10 @@ private struct ExtensionsSettingsView: View {
 
     @ViewBuilder
     private func policyButtons(serverID: String, tool: String?) -> some View {
-        Button("Use annotations") { Task { await model.extensionsModel.setMCPPolicy(serverID: serverID, tool: tool, mode: "annotations") } }
-        Button("Ask") { Task { await model.extensionsModel.setMCPPolicy(serverID: serverID, tool: tool, mode: "ask") } }
-        Button("Allow") { Task { await model.extensionsModel.setMCPPolicy(serverID: serverID, tool: tool, mode: "allow") } }
-        Button("Disabled") { Task { await model.extensionsModel.setMCPPolicy(serverID: serverID, tool: tool, mode: "disabled") } }
+        Button("Use annotations") { Task { await extensionsModel.setMCPPolicy(serverID: serverID, tool: tool, mode: "annotations") } }
+        Button("Ask") { Task { await extensionsModel.setMCPPolicy(serverID: serverID, tool: tool, mode: "ask") } }
+        Button("Allow") { Task { await extensionsModel.setMCPPolicy(serverID: serverID, tool: tool, mode: "allow") } }
+        Button("Disabled") { Task { await extensionsModel.setMCPPolicy(serverID: serverID, tool: tool, mode: "disabled") } }
     }
 
     private func policyTitle(_ value: String?) -> String {
@@ -819,7 +820,7 @@ private struct ExtensionsSettingsView: View {
         useTokenFallback: Bool = false
     ) {
         Task {
-            guard let server = await model.extensionsModel.materializeMCPPreset(preset, projectRef: projectRef) else {
+            guard let server = await extensionsModel.materializeMCPPreset(preset, projectRef: projectRef) else {
                 return
             }
             if useTokenFallback {
@@ -827,12 +828,12 @@ private struct ExtensionsSettingsView: View {
                 return
             }
             let probe: @MainActor () async -> Void = {
-                if await model.extensionsModel.testMCPServer(server.id) {
+                if await extensionsModel.testMCPServer(server.id) {
                     enableAfterProbe = server
                 }
             }
             if server.auth == "auto" || server.auth == "oauth" {
-                model.extensionsModel.authenticateMCPServer(server) { success in
+                extensionsModel.authenticateMCPServer(server) { success in
                     if success { Task { await probe() } }
                 }
             } else {
@@ -849,13 +850,14 @@ private struct ExtensionsSettingsView: View {
         panel.canChooseFiles = true
         panel.allowsMultipleSelection = false
         if panel.runModal() == .OK, let url = panel.url {
-            Task { await model.extensionsModel.importSkill(from: url.path) }
+            Task { await extensionsModel.importSkill(from: url.path) }
         }
     }
 }
 
 private struct MCPDeviceAuthorizationView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var extensionsModel: ExtensionsModel
     let prompt: MCPDeviceAuthorizationPrompt
 
     var body: some View {
@@ -888,7 +890,7 @@ private struct MCPDeviceAuthorizationView: View {
                 .fixedSize(horizontal: false, vertical: true)
             HStack {
                 Button("Cancel", role: .cancel) {
-                    model.extensionsModel.cancelMCPDeviceAuthorization()
+                    extensionsModel.cancelMCPDeviceAuthorization()
                 }
                 Spacer()
                 Button("Copy Code") {
@@ -986,6 +988,7 @@ private struct PluginTrustReviewView: View {
 private struct MCPPresetReviewView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var extensionsModel: ExtensionsModel
     let preset: ExtensionMCPPreset
     let connect: (String, Bool) -> Void
     @State private var projectRef = ""
@@ -1067,7 +1070,7 @@ private struct MCPPresetReviewView: View {
     }
 
     private var githubCapability: GitHubConnectionCapability {
-        model.extensionsModel.githubConnectionCapability()
+        extensionsModel.githubConnectionCapability()
     }
 }
 
@@ -1112,6 +1115,7 @@ private struct MCPEnableReviewView: View {
 
 private struct MCPServerEditorView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var extensionsModel: ExtensionsModel
     @Environment(\.dismiss) private var dismiss
     let server: ExtensionMCPServer?
     @State private var name = ""
@@ -1147,7 +1151,7 @@ private struct MCPServerEditorView: View {
                         .overlay(alignment: .topLeading) {
                             if arguments.isEmpty { Text("One argument per line").foregroundStyle(LocusTheme.muted).padding(5) }
                         }
-                    if !model.extensionsModel.extensions.capabilities.stdio {
+                    if !extensionsModel.extensions.capabilities.stdio {
                         Text("Local command servers are unavailable in this App Store build.")
                             .foregroundStyle(LocusTheme.coral)
                     }
@@ -1202,7 +1206,7 @@ private struct MCPServerEditorView: View {
                             "redirect_uri": "locus://mcp/oauth",
                         ]
                     }
-                    Task { await model.extensionsModel.saveMCPServer(body) }
+                    Task { await extensionsModel.saveMCPServer(body) }
                     dismiss()
                 }
                 .buttonStyle(.borderedProminent)
@@ -1233,6 +1237,7 @@ private struct MCPServerEditorView: View {
 
 private struct MCPCredentialView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var extensionsModel: ExtensionsModel
     @Environment(\.dismiss) private var dismiss
     let server: ExtensionMCPServer
     @State private var secret = ""
@@ -1259,7 +1264,7 @@ private struct MCPCredentialView: View {
                     } else {
                         values = ["headers": [fieldName: secret]]
                     }
-                    Task { await model.extensionsModel.setMCPCredentials(serverID: server.id, values: values) }
+                    Task { await extensionsModel.setMCPCredentials(serverID: server.id, values: values) }
                     dismiss()
                 }
                 .buttonStyle(.borderedProminent).tint(LocusTheme.ink)
@@ -1389,6 +1394,14 @@ enum SettingsPresentationContext {
 struct SettingsView: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var updates: AppUpdateController
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
+    @EnvironmentObject private var voiceControl: VoiceControlModel
+    @EnvironmentObject private var applicationContext: ApplicationContextService
+    @EnvironmentObject private var computerControl: ComputerControlService
+    @EnvironmentObject private var simulatorControl: SimulatorControlService
+#if !LOCUS_APP_STORE
+    @EnvironmentObject private var codexComponent: CodexComponentInstaller
+#endif
     @Environment(\.dismiss) private var dismiss
     @Environment(\.dismissWindow) private var dismissWindow
     @State private var draft = AppSettings()
@@ -2308,10 +2321,10 @@ struct SettingsView: View {
                         .accessibilityIdentifier("settings.voice.sendBehavior")
 
                         Button(
-                            model.voiceControl.isCapabilityTesting
+                            voiceControl.isCapabilityTesting
                                 ? "Stop and Play Back" : "Test Voice"
                         ) {
-                            model.voiceControl.startCapabilityTest()
+                            voiceControl.startCapabilityTest()
                         }
                         .disabled(
                             draft.resolvedVoiceSpeechEngine == .openAICompatible
@@ -2319,8 +2332,8 @@ struct SettingsView: View {
                         )
                         .accessibilityIdentifier("settings.voice.test")
 
-                        if !model.voiceControl.capabilityTestMessage.isEmpty {
-                            Text(model.voiceControl.capabilityTestMessage)
+                        if !voiceControl.capabilityTestMessage.isEmpty {
+                            Text(voiceControl.capabilityTestMessage)
                                 .font(.locus(size: 9, weight: .semibold))
                                 .foregroundStyle(LocusTheme.muted)
                                 .accessibilityIdentifier("settings.voice.testResult")
@@ -2751,7 +2764,7 @@ struct SettingsView: View {
                         .accessibilityIdentifier("settings.componentSize")
                 }
                 Button("Remove", role: .destructive) {
-                    Task { await model.codexComponent.remove() }
+                    Task { await codexComponent.remove() }
                 }
                 .accessibilityIdentifier("settings.removeComponent")
                 Text("Removing this frees the space now. Locus offers it again the next time you use a ChatGPT-plan account.")
@@ -2937,14 +2950,14 @@ struct SettingsView: View {
     private var accountsPage: some View {
         Form {
             Section("Provider accounts") {
-                if model.providerAccounts.isEmpty {
+                if providerAccounts.providerAccounts.isEmpty {
                     Text("No accounts yet — Locus runs on local Ollama until you add one.")
                         .font(.locus(size: 10))
                         .foregroundStyle(LocusTheme.muted)
                         .accessibilityIdentifier("settings.accounts.empty")
                 }
 
-                ForEach(model.providerAccounts) { account in
+                ForEach(providerAccounts.providerAccounts) { account in
                     HStack(spacing: 10) {
                         ProviderLogo(
                             kind: account.kind,
@@ -2955,7 +2968,7 @@ struct SettingsView: View {
                         .overlay(alignment: .bottomTrailing) {
                             Circle()
                                 .fill(
-                                    model.providerAccountsModel.accountStatus[account.id]?.isHealthy ?? account.isCredentialReady
+                                    providerAccounts.accountStatus[account.id]?.isHealthy ?? account.isCredentialReady
                                         ? LocusTheme.success
                                         : LocusTheme.coral
                                 )
@@ -3006,14 +3019,14 @@ struct SettingsView: View {
                         .foregroundStyle(LocusTheme.muted)
                 }
 
-                if model.providerAccountsModel.installedLocalModels.isEmpty {
+                if providerAccounts.installedLocalModels.isEmpty {
                     Text(model.isModelOnline
                         ? "No local models are installed."
                         : "Connect to Ollama to see installed models.")
                         .font(.locus(size: 9))
                         .foregroundStyle(LocusTheme.muted)
                 } else {
-                    ForEach(model.providerAccountsModel.installedLocalModels) { localModel in
+                    ForEach(providerAccounts.installedLocalModels) { localModel in
                         localModelRow(localModel)
                     }
                 }
@@ -3120,16 +3133,16 @@ struct SettingsView: View {
                         .fixedSize(horizontal: false, vertical: true)
                     LabeledContent("Accessibility text") {
                         permissionStatus(
-                            granted: model.computerControl.accessibilityGranted,
-                            grant: model.computerControl.requestAccessibility,
-                            settings: model.computerControl.openAccessibilitySettings
+                            granted: computerControl.accessibilityGranted,
+                            grant: computerControl.requestAccessibility,
+                            settings: computerControl.openAccessibilitySettings
                         )
                     }
                     LabeledContent("Window screenshots") {
                         permissionStatus(
-                            granted: model.computerControl.screenRecordingGranted,
-                            grant: model.computerControl.requestScreenRecording,
-                            settings: model.computerControl.openScreenRecordingSettings
+                            granted: computerControl.screenRecordingGranted,
+                            grant: computerControl.requestScreenRecording,
+                            settings: computerControl.openScreenRecordingSettings
                         )
                     }
                     LabeledContent("Live task attachment") {
@@ -3160,16 +3173,16 @@ struct SettingsView: View {
 
                     LabeledContent("Accessibility") {
                         permissionStatus(
-                            granted: model.computerControl.accessibilityGranted,
-                            grant: model.computerControl.requestAccessibility,
-                            settings: model.computerControl.openAccessibilitySettings
+                            granted: computerControl.accessibilityGranted,
+                            grant: computerControl.requestAccessibility,
+                            settings: computerControl.openAccessibilitySettings
                         )
                     }
                     LabeledContent("Screen Recording") {
                         permissionStatus(
-                            granted: model.computerControl.screenRecordingGranted,
-                            grant: model.computerControl.requestScreenRecording,
-                            settings: model.computerControl.openScreenRecordingSettings
+                            granted: computerControl.screenRecordingGranted,
+                            grant: computerControl.requestScreenRecording,
+                            settings: computerControl.openScreenRecordingSettings
                         )
                     }
                     Text("Screenshots are target-window scoped and exclude Locus. Before a screenshot is sent to a hosted provider, Locus names that provider and asks once per session. Local Ollama screenshots remain local.")
@@ -3206,43 +3219,43 @@ struct SettingsView: View {
 
                     LabeledContent("Xcode") {
                         settingsStatus(
-                            ready: model.simulatorControl.helperHealth.xcodePath != nil,
+                            ready: simulatorControl.helperHealth.xcodePath != nil,
                             readyText: "Ready",
                             missingText: "Full Xcode required"
                         )
                     }
                     LabeledContent("Signed bridge") {
                         settingsStatus(
-                            ready: model.simulatorControl.helperHealth.touchHelperPresent
-                                && model.simulatorControl.helperHealth.treeHelperPresent,
+                            ready: simulatorControl.helperHealth.touchHelperPresent
+                                && simulatorControl.helperHealth.treeHelperPresent,
                             readyText: "Present",
                             missingText: "Missing"
                         )
                     }
                     LabeledContent("Bridge compatibility") {
                         settingsStatus(
-                            ready: model.simulatorControl.nativeAvailable,
+                            ready: simulatorControl.nativeAvailable,
                             readyText: "Ready",
-                            missingText: model.simulatorControl.helperHealth.message
+                            missingText: simulatorControl.helperHealth.message
                         )
                     }
                     LabeledContent("iOS runtime") {
                         settingsStatus(
-                            ready: !model.simulatorControl.devices.isEmpty,
-                            readyText: "\(model.simulatorControl.devices.count) devices",
+                            ready: !simulatorControl.devices.isEmpty,
+                            readyText: "\(simulatorControl.devices.count) devices",
                             missingText: "No installed runtime"
                         )
                     }
                     LabeledContent("Live streaming") {
                         settingsStatus(
-                            ready: model.computerControl.screenRecordingGranted,
+                            ready: computerControl.screenRecordingGranted,
                             readyText: "Screen Recording granted",
                             missingText: "Screen Recording required"
                         )
                     }
                     LabeledContent("Keyboard controls") {
                         settingsStatus(
-                            ready: model.computerControl.accessibilityGranted,
+                            ready: computerControl.accessibilityGranted,
                             readyText: "Accessibility granted",
                             missingText: "Accessibility required"
                         )
@@ -3267,8 +3280,8 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
         .onAppear {
-            model.computerControl.refreshPermissionStatus()
-            model.applicationContext.refreshRunningApplications()
+            computerControl.refreshPermissionStatus()
+            applicationContext.refreshRunningApplications()
             model.refreshSimulatorDevices()
         }
     }
@@ -3304,16 +3317,16 @@ struct SettingsView: View {
     }
 
     private func accountDetail(_ account: ProviderAccount) -> String {
-        let status = model.providerAccountsModel.accountStatus[account.id]
+        let status = providerAccounts.accountStatus[account.id]
             ?? (account.hasKey ? .keySaved : .noKey)
         if account.kind == .chatGPT,
-           let window = model.providerAccountsModel.chatGPTUsageByAccount[account.id]?.rateLimits.rateLimits?.primary
+           let window = providerAccounts.chatGPTUsageByAccount[account.id]?.rateLimits.rateLimits?.primary
         {
             let reset = window.resetsAt.map {
                 "resets " + Date(timeIntervalSince1970: Double($0))
                     .formatted(.relative(presentation: .named))
             }
-            let activity = model.providerAccountsModel.chatGPTUsageByAccount[account.id]?
+            let activity = providerAccounts.chatGPTUsageByAccount[account.id]?
                 .activity.summary?.lifetimeTokens.map {
                 $0.formatted(.number.notation(.compactName)) + " activity tokens"
             }

--- a/Locus/UsageDashboardView.swift
+++ b/Locus/UsageDashboardView.swift
@@ -161,6 +161,8 @@ enum UsageWindow: String, CaseIterable, Identifiable {
 
 struct UsageDashboardView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
     @Environment(\.dismiss) private var dismiss
     @State private var window: UsageWindow = .month
 
@@ -168,7 +170,7 @@ struct UsageDashboardView: View {
         VStack(spacing: 0) {
             header
             Divider().overlay(LocusTheme.line)
-            if let summary = model.providerAccountsModel.usageSummary {
+            if let summary = providerAccounts.usageSummary {
                 content(summary)
             } else {
                 VStack(spacing: 10) {
@@ -184,11 +186,11 @@ struct UsageDashboardView: View {
         .frame(width: 780, height: 620)
         .background(LocusTheme.panel)
         .onAppear {
-            model.providerAccountsModel.refreshUsageSummary(since: window.since)
-            Task { await model.providerAccountsModel.refreshActiveChatGPTUsage() }
+            providerAccounts.refreshUsageSummary(since: window.since)
+            Task { await providerAccounts.refreshActiveChatGPTUsage() }
         }
         .onChange(of: window) {
-            model.providerAccountsModel.refreshUsageSummary(since: window.since)
+            providerAccounts.refreshUsageSummary(since: window.since)
         }
     }
 
@@ -231,7 +233,7 @@ struct UsageDashboardView: View {
     private func content(_ summary: UsageSummary) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                if let usage = model.providerAccountsModel.activeChatGPTUsage, usage.status == "signed_in" {
+                if let usage = providerAccounts.activeChatGPTUsage, usage.status == "signed_in" {
                     chatGPTPlanUsage(usage)
                 }
                 totals(summary)
@@ -534,6 +536,6 @@ struct UsageDashboardView: View {
     }
 
     private func agentName(_ agentID: String) -> String {
-        model.agentProfiles.first { $0.id.uuidString == agentID }?.name ?? "Removed agent"
+        agentTeams.agentProfiles.first { $0.id.uuidString == agentID }?.name ?? "Removed agent"
     }
 }

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -5,6 +5,10 @@ import UniformTypeIdentifiers
 
 struct WorkspaceView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var activityCenter: ActivityCenterModel
+    @EnvironmentObject private var gitWorkspace: GitWorkspaceModel
+    @EnvironmentObject private var landingFlow: LandingFlowModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var modelPickerPresented = false
     @State private var teamProgressPresented = false
@@ -25,7 +29,7 @@ struct WorkspaceView: View {
                 chatContent
                     .frame(width: proxy.size.width, height: proxy.size.height)
 
-                if model.activity.activityCenterPresented {
+                if activityCenter.activityCenterPresented {
                     ActivityCenterView()
                         .environmentObject(model)
                         .frame(
@@ -103,7 +107,7 @@ struct WorkspaceView: View {
                         .accessibilityHidden(true)
                     Text(URL(fileURLWithPath: model.workspacePath).lastPathComponent)
                         .accessibilityIdentifier("workspace.breadcrumb.path")
-                    if let branch = model.gitWorkspace.gitBranch {
+                    if let branch = gitWorkspace.gitBranch {
                         HStack(spacing: 3) {
                             Image(systemName: "arrow.triangle.branch")
                                 .font(.locus(size: 7))
@@ -122,7 +126,7 @@ struct WorkspaceView: View {
 
             Spacer()
 
-            if model.showTeamProgressInHeader, model.selectedAgentTeam != nil {
+            if model.showTeamProgressInHeader, agentTeams.selectedAgentTeam != nil {
                 Button {
                     teamProgressPresented.toggle()
                 } label: {
@@ -164,8 +168,8 @@ struct WorkspaceView: View {
                     .environmentObject(model)
             }
 
-            if model.activeTaskRecord != nil, model.landingFlow.taskHasChanges {
-                Button("Review & Land") { model.landingFlow.prepareReviewAndLand() }
+            if model.activeTaskRecord != nil, landingFlow.taskHasChanges {
+                Button("Review & Land") { landingFlow.prepareReviewAndLand() }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
                     .tint(LocusTheme.ink)
@@ -204,10 +208,10 @@ struct WorkspaceView: View {
                 .frame(maxWidth: 176)
             }
             .buttonStyle(.locus())
-            .help(model.agentTeamsModel.teamModeEnabled
+            .help(agentTeams.teamModeEnabled
                 ? "Active team: \(model.selectedTeamModelNames.joined(separator: ", "))"
                 : "Select model")
-            .accessibilityLabel(model.agentTeamsModel.teamModeEnabled
+            .accessibilityLabel(agentTeams.teamModeEnabled
                 ? "Active team, \(model.modelPickerLabel), \(runtimeHealthTitle)"
                 : "Select model, \(model.modelPickerLabel), \(runtimeHealthTitle)")
             .accessibilityIdentifier("workspace.modelPicker")
@@ -781,6 +785,7 @@ private struct PassiveChatBlockView: View {
 
 struct ReviewAndLandView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var landingFlow: LandingFlowModel
     @Environment(\.dismiss) private var dismiss
     @State private var destination = "local"
     @State private var branchName = ""
@@ -795,7 +800,7 @@ struct ReviewAndLandView: View {
     }
 
     private var checksAreCurrentAndPassing: Bool {
-        guard let check = model.landingFlow.landingCheckRun, let preflight = model.landingFlow.landingPreflight else {
+        guard let check = landingFlow.landingCheckRun, let preflight = landingFlow.landingPreflight else {
             return false
         }
         return check.passed && check.tree == preflight.tree
@@ -806,8 +811,8 @@ struct ReviewAndLandView: View {
     }
 
     private var canLand: Bool {
-        guard let preflight = model.landingFlow.landingPreflight, preflight.patchBytes > 0,
-              !model.landingFlow.isLandingOperationRunning else { return false }
+        guard let preflight = landingFlow.landingPreflight, preflight.patchBytes > 0,
+              !landingFlow.isLandingOperationRunning else { return false }
         if destination == "local" { return preflight.canApplyLocal }
         return branchProblem == nil
             && !commitMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -835,7 +840,7 @@ struct ReviewAndLandView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 14) {
                         stageHeader("1", "Review changes")
-                        if let preflight = model.landingFlow.landingPreflight {
+                        if let preflight = landingFlow.landingPreflight {
                             HStack {
                                 Text("\(preflight.paths.count) file\(preflight.paths.count == 1 ? "" : "s")")
                                 Text(ByteCountFormatter.string(
@@ -849,7 +854,7 @@ struct ReviewAndLandView: View {
                             .foregroundStyle(LocusTheme.muted)
 
                             ScrollView([.horizontal, .vertical]) {
-                                Text(model.landingFlow.landingPatch.isEmpty ? "No changes." : model.landingFlow.landingPatch)
+                                Text(landingFlow.landingPatch.isEmpty ? "No changes." : landingFlow.landingPatch)
                                     .font(.locus(size: 9, design: .monospaced))
                                     .textSelection(.enabled)
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -877,24 +882,24 @@ struct ReviewAndLandView: View {
                             .overlay { RoundedRectangle(cornerRadius: 8).stroke(LocusTheme.line) }
                             .accessibilityIdentifier("landing.checkCommands")
                         HStack {
-                            if model.landingFlow.activeLandingCheckRunID != nil {
+                            if landingFlow.activeLandingCheckRunID != nil {
                                 ProgressView().controlSize(.small)
                                 Text("Running checks…")
                                     .font(.locus(size: 9))
-                                Button("Stop") { model.landingFlow.stopLandingChecks() }
+                                Button("Stop") { landingFlow.stopLandingChecks() }
                                     .accessibilityIdentifier("landing.stopChecks")
                             } else {
-                                Button("Run Checks") { model.landingFlow.runLandingChecks(commands: commands) }
-                                    .disabled(commands.isEmpty || model.landingFlow.isLandingOperationRunning)
+                                Button("Run Checks") { landingFlow.runLandingChecks(commands: commands) }
+                                    .disabled(commands.isEmpty || landingFlow.isLandingOperationRunning)
                                     .accessibilityIdentifier("landing.runChecks")
                             }
                             Spacer()
                             if checksAreCurrentAndPassing {
                                 Label("Checks passed", systemImage: "checkmark.circle.fill")
                                     .foregroundStyle(LocusTheme.success)
-                            } else if let check = model.landingFlow.landingCheckRun {
+                            } else if let check = landingFlow.landingCheckRun {
                                 Label(
-                                    check.tree == model.landingFlow.landingPreflight?.tree
+                                    check.tree == landingFlow.landingPreflight?.tree
                                         ? "Checks did not pass" : "Checks are stale",
                                     systemImage: "exclamationmark.triangle.fill"
                                 )
@@ -906,7 +911,7 @@ struct ReviewAndLandView: View {
                         }
                         .font(.locus(size: 9, weight: .semibold))
 
-                        if let run = model.landingFlow.landingCheckRun {
+                        if let run = landingFlow.landingCheckRun {
                             VStack(alignment: .leading, spacing: 6) {
                                 ForEach(run.results) { result in
                                     DisclosureGroup {
@@ -941,13 +946,13 @@ struct ReviewAndLandView: View {
                         landingDestinationControl
 
                         if destination == "local" {
-                            if model.landingFlow.landingPreflight?.canApplyLocal == true {
+                            if landingFlow.landingPreflight?.canApplyLocal == true {
                                 Text("The complete patch will be applied unstaged to Local. This chat remains in its worktree.")
                                     .font(.locus(size: 9))
                                     .foregroundStyle(LocusTheme.muted)
                             } else {
                                 Label(
-                                    model.landingFlow.landingPreflight?.conflict.nilIfEmpty
+                                    landingFlow.landingPreflight?.conflict.nilIfEmpty
                                         ?? "The patch conflicts with Local. Both checkouts are unchanged.",
                                     systemImage: "exclamationmark.triangle.fill"
                                 )
@@ -960,7 +965,7 @@ struct ReviewAndLandView: View {
                                     .foregroundStyle(LocusTheme.success)
                                 HStack {
                                     Button("Publish") { model.publishLandedWorktree() }
-                                        .disabled(model.landingFlow.isLandingOperationRunning)
+                                        .disabled(landingFlow.isLandingOperationRunning)
                                     Button("Open Pull Request") { model.openLandedPullRequest() }
                                     Text(task.landingCommit?.prefix(10) ?? "")
                                         .font(.locus(size: 8, design: .monospaced))
@@ -1025,7 +1030,7 @@ struct ReviewAndLandView: View {
         .task {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(2))
-                await model.landingFlow.refreshLandingReview()
+                await landingFlow.refreshLandingReview()
             }
         }
         .alert("Land without passing current checks?", isPresented: $confirmOverride) {
@@ -1085,7 +1090,7 @@ struct ReviewAndLandView: View {
     }
 
     private func land(override: Bool) {
-        model.landingFlow.landActiveTask(
+        landingFlow.landActiveTask(
             destination: destination,
             branch: branchName,
             commitMessage: commitMessage,
@@ -1121,6 +1126,7 @@ struct ActivityActionButtonStyle: ButtonStyle {
 struct ActivityCenterView: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var sessionCatalog: SessionCatalogModel
+    @EnvironmentObject private var activityCenter: ActivityCenterModel
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1133,25 +1139,25 @@ struct ActivityCenterView: View {
                         .foregroundStyle(LocusTheme.muted)
                 }
                 Spacer()
-                if model.visibleActivityRuns.contains(where: { model.activity.activityIsUnseen($0) }) {
-                    Button("Mark All Seen") { model.activity.markAllActivitySeen() }
+                if activityCenter.visibleActivityRuns.contains(where: { activityCenter.activityIsUnseen($0) }) {
+                    Button("Mark All Seen") { activityCenter.markAllActivitySeen() }
                         .accessibilityIdentifier("activity.markAllSeen")
                 }
-                if model.visibleActivityRuns.contains(where: {
+                if activityCenter.visibleActivityRuns.contains(where: {
                     TeamRunState(rawValue: $0.state)?.isTerminal == true
                 }) {
-                    Button("Clear Finished") { model.activity.clearFinishedActivityRuns() }
+                    Button("Clear Finished") { activityCenter.clearFinishedActivityRuns() }
                         .accessibilityIdentifier("activity.clearFinished")
                 }
                 Button {
-                    Task { await model.activity.refreshActivityRuns() }
+                    Task { await activityCenter.refreshActivityRuns() }
                 } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
                 .accessibilityIdentifier("activity.refresh")
                 Button {
                     withAnimation(LocusMotion.spatial) {
-                        model.activity.toggleActivityCenter()
+                        activityCenter.toggleActivityCenter()
                     }
                 } label: {
                     Image(systemName: "xmark")
@@ -1166,7 +1172,7 @@ struct ActivityCenterView: View {
             .padding(.vertical, 14)
             .background(LocusTheme.paperDeep.opacity(0.55))
 
-            if model.visibleActivityRuns.isEmpty {
+            if activityCenter.visibleActivityRuns.isEmpty {
                 ContentUnavailableView(
                     "No Activity Yet",
                     systemImage: "waveform.path.ecg.rectangle",
@@ -1206,7 +1212,7 @@ struct ActivityCenterView: View {
         }
         .task {
             while !Task.isCancelled {
-                await model.activity.refreshActivityRuns()
+                await activityCenter.refreshActivityRuns()
                 try? await Task.sleep(for: .seconds(2))
             }
         }
@@ -1214,7 +1220,7 @@ struct ActivityCenterView: View {
     }
 
     private func runs(in group: ActivityGroup) -> [OrchestrationRun] {
-        let values = model.visibleActivityRuns.filter { activityGroup(for: $0) == group }
+        let values = activityCenter.visibleActivityRuns.filter { activityGroup(for: $0) == group }
         if group == .queued {
             return values.sorted {
                 ($0.queuePosition ?? .max, $0.createdAt)
@@ -1253,7 +1259,7 @@ struct ActivityCenterView: View {
                         Text(run.state.replacingOccurrences(of: "_", with: " ").uppercased())
                             .font(.locus(size: 7, weight: .bold, design: .monospaced))
                             .foregroundStyle(color(for: run))
-                        if model.activity.activityIsUnseen(run) {
+                        if activityCenter.activityIsUnseen(run) {
                             Text("NEW")
                                 .font(.locus(size: 7, weight: .bold, design: .monospaced))
                                 .foregroundStyle(LocusTheme.brandInk)
@@ -1308,7 +1314,7 @@ struct ActivityCenterView: View {
                     Button("Retry") { model.retryRun(run) }
                 }
                 if TeamRunState(rawValue: run.state)?.isTerminal == true {
-                    Button("Remove") { model.activity.dismissActivityRun(run) }
+                    Button("Remove") { activityCenter.dismissActivityRun(run) }
                         .help("Remove from Activity; the run timeline is preserved")
                         .accessibilityIdentifier("activity.remove.\(run.id)")
                 }
@@ -1391,6 +1397,7 @@ struct ActivityCenterView: View {
 
 private struct ScheduleRow: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var schedule: ScheduleModel
     let task: ScheduledTask
     @State private var confirmsDelete = false
 
@@ -1431,15 +1438,15 @@ private struct ScheduleRow: View {
             }
 
             HStack(spacing: 7) {
-                Button("Run Now") { model.schedule.runScheduleNow(task) }
+                Button("Run Now") { schedule.runScheduleNow(task) }
                 Button("Edit") { model.presentScheduleEditor(task: task) }
                 if task.enabled {
-                    Button("Pause") { model.schedule.setScheduleEnabled(task, enabled: false) }
+                    Button("Pause") { schedule.setScheduleEnabled(task, enabled: false) }
                 } else if task.rule.kind != .once || task.nextRunAt != nil {
-                    Button("Resume") { model.schedule.setScheduleEnabled(task, enabled: true) }
+                    Button("Resume") { schedule.setScheduleEnabled(task, enabled: true) }
                 }
                 if task.lastRunID != nil {
-                    Button("Latest Result") { model.schedule.openLatestRun(for: task) }
+                    Button("Latest Result") { schedule.openLatestRun(for: task) }
                 }
                 Spacer()
                 Button("Delete", role: .destructive) { confirmsDelete = true }
@@ -1455,7 +1462,7 @@ private struct ScheduleRow: View {
         .accessibilityIdentifier("schedule.row.\(task.id)")
         .alert("Delete \(task.name)?", isPresented: $confirmsDelete) {
             Button("Cancel", role: .cancel) {}
-            Button("Delete", role: .destructive) { model.schedule.deleteSchedule(task) }
+            Button("Delete", role: .destructive) { schedule.deleteSchedule(task) }
         } message: {
             Text("Its generated chats and run history will be kept.")
         }
@@ -1489,6 +1496,9 @@ private struct ScheduleRow: View {
 
 struct ScheduleEditorView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var schedule: ScheduleModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
     @State private var draft: ScheduleEditorDraft
     @State private var routeSelection: String
 
@@ -1508,12 +1518,12 @@ struct ScheduleEditorView: View {
                         .foregroundStyle(LocusTheme.muted)
                 }
                 Spacer()
-                Button("Cancel") { model.schedule.scheduleEditorDraft = nil }
+                Button("Cancel") { schedule.scheduleEditorDraft = nil }
                 Button(draft.id == nil ? "Create" : "Save") {
-                    Task { _ = await model.schedule.saveSchedule(draft) }
+                    Task { _ = await schedule.saveSchedule(draft) }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(model.schedule.isSavingSchedule)
+                .disabled(schedule.isSavingSchedule)
                 .accessibilityIdentifier("scheduleEditor.save")
             }
             .padding(18)
@@ -1564,19 +1574,19 @@ struct ScheduleEditorView: View {
                     if draft.runner == .team {
                         Picker("Team", selection: $draft.teamID) {
                             Text("Choose a team").tag(String?.none)
-                            ForEach(model.agentTeams) { team in
+                            ForEach(agentTeams.agentTeams) { team in
                                 Text(team.name).tag(Optional(team.id.uuidString))
                             }
                         }
                         .onChange(of: draft.teamID) { _, value in
                             draft.teamName = value.flatMap { id in
-                                model.agentTeams.first(where: { $0.id.uuidString == id })?.name
+                                agentTeams.agentTeams.first(where: { $0.id.uuidString == id })?.name
                             } ?? ""
                         }
                     }
                     Picker("Model account", selection: $routeSelection) {
                         Text("Local Ollama").tag("ollama")
-                        ForEach(model.providerAccounts) { account in
+                        ForEach(providerAccounts.providerAccounts) { account in
                             Text(account.displayName).tag(account.id.uuidString)
                         }
                     }
@@ -1661,13 +1671,13 @@ struct ScheduleEditorView: View {
 
     private var availableModels: [String] {
         if routeSelection == "ollama" {
-            let names = model.providerAccountsModel.installedLocalModels.map(\.name)
+            let names = providerAccounts.installedLocalModels.map(\.name)
             return names.isEmpty ? [draft.model].filter { !$0.isEmpty } : names
         }
         guard let id = UUID(uuidString: routeSelection),
-              let account = model.providerAccounts.first(where: { $0.id == id })
+              let account = providerAccounts.providerAccounts.first(where: { $0.id == id })
         else { return [draft.model].filter { !$0.isEmpty } }
-        let names = model.accountModels[id] ?? account.kind.curatedModels
+        let names = providerAccounts.accountModels[id] ?? account.kind.curatedModels
         return names.isEmpty ? [draft.model].filter { !$0.isEmpty } : names
     }
 
@@ -1676,7 +1686,7 @@ struct ScheduleEditorView: View {
             draft.provider = "ollama"
             draft.providerAccountID = nil
         } else if let id = UUID(uuidString: value),
-                  let account = model.providerAccounts.first(where: { $0.id == id }) {
+                  let account = providerAccounts.providerAccounts.first(where: { $0.id == id }) {
             draft.provider = account.kind == .chatGPT ? "chatgpt" : "remote"
             draft.providerAccountID = value
         }
@@ -1705,6 +1715,8 @@ struct ScheduleEditorView: View {
 /// its contents scroll, so a long route can never resize the app or its menu.
 private struct ModelPickerPopover: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var providerAccounts: ProviderAccountsModel
+    @EnvironmentObject private var agentTeams: AgentTeamsModel
     let dismiss: () -> Void
 
     var body: some View {
@@ -1730,7 +1742,7 @@ private struct ModelPickerPopover: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
-                    if let team = model.selectedAgentTeam {
+                    if let team = agentTeams.selectedAgentTeam {
                         teamSection(team)
                         Divider()
                     }
@@ -1761,7 +1773,7 @@ private struct ModelPickerPopover: View {
                 ) {
                     Task {
                         await model.refreshMetadata()
-                        await model.providerAccountsModel.refreshAccountCatalogs(force: true)
+                        await providerAccounts.refreshAccountCatalogs(force: true)
                     }
                 }
                 pickerAction(
@@ -1812,7 +1824,7 @@ private struct ModelPickerPopover: View {
                 }
                 .accessibilityIdentifier("workspace.modelPicker.manageTeam")
                 Button("Switch to Solo") {
-                    model.agentTeamsModel.selectAgentTeam(nil)
+                    agentTeams.selectAgentTeam(nil)
                 }
                 .accessibilityIdentifier("workspace.modelPicker.switchToSolo")
             }
@@ -1823,7 +1835,7 @@ private struct ModelPickerPopover: View {
 
     private func routeSection(_ section: ModelPickerSection) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            sectionLabel(model.agentTeamsModel.teamModeEnabled ? "SOLO · \(section.title)" : section.title.uppercased())
+            sectionLabel(agentTeams.teamModeEnabled ? "SOLO · \(section.title)" : section.title.uppercased())
             if let message = section.emptyMessage {
                 Text(message)
                     .font(.locus(size: 9))
@@ -1831,7 +1843,7 @@ private struct ModelPickerPopover: View {
             }
             ForEach(section.models, id: \.self) { name in
                 Button {
-                    if model.agentTeamsModel.teamModeEnabled { model.agentTeamsModel.selectAgentTeam(nil) }
+                    if agentTeams.teamModeEnabled { agentTeams.selectAgentTeam(nil) }
                     model.selectModel(account: section.account, model: name)
                     dismiss()
                 } label: {
@@ -1886,6 +1898,8 @@ private struct ModelPickerPopover: View {
 
 private struct TeamActivityPanel: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var teamRunLive: TeamRunLiveModel
+    @EnvironmentObject private var landingFlow: LandingFlowModel
     @State private var expanded = true
 
     var body: some View {
@@ -1924,7 +1938,7 @@ private struct TeamActivityPanel: View {
             if expanded {
                 ScrollView(.vertical) {
                     VStack(alignment: .leading, spacing: 7) {
-                        ForEach(model.teamRunLive.agentActivities) { activity in
+                        ForEach(teamRunLive.agentActivities) { activity in
                             AgentActivityRow(
                                 activity: activity,
                                 thinkingVisibility: model.thinkingVisibility
@@ -1948,18 +1962,18 @@ private struct TeamActivityPanel: View {
     private func taskActions(_ task: TaskRecord) -> some View {
         HStack(spacing: 8) {
             Label(
-                model.landingFlow.taskHasChanges
-                    ? "\(ByteCountFormatter.string(fromByteCount: Int64(model.landingFlow.taskPatchBytes), countStyle: .file)) ready"
+                landingFlow.taskHasChanges
+                    ? "\(ByteCountFormatter.string(fromByteCount: Int64(landingFlow.taskPatchBytes), countStyle: .file)) ready"
                     : "Private checkout",
                 systemImage: "arrow.triangle.branch"
             )
             .font(.locus(size: 8, design: .monospaced))
             .foregroundStyle(LocusTheme.muted)
             Spacer()
-            Button("Review & Land") { model.landingFlow.prepareReviewAndLand() }
-                .disabled(model.isBusy || !model.landingFlow.taskHasChanges)
+            Button("Review & Land") { landingFlow.prepareReviewAndLand() }
+                .disabled(model.isBusy || !landingFlow.taskHasChanges)
             Button("Copy Patch") { model.copyActiveTaskPatch() }
-                .disabled(model.isBusy || !model.landingFlow.taskHasChanges)
+                .disabled(model.isBusy || !landingFlow.taskHasChanges)
             Menu {
                 Button("Open Checkout") { model.openActiveTaskCheckout() }
                 Button("Reveal in Finder") { model.revealActiveTaskCheckout() }
@@ -2075,6 +2089,7 @@ private struct AgentActivityRow: View {
 
 private struct WorkStatusStrip: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var teamRunLive: TeamRunLiveModel
     @ObservedObject var streamingReply: StreamingReplyState
 
     var body: some View {
@@ -2098,9 +2113,9 @@ private struct WorkStatusStrip: View {
                         Text("~\(model.estimatedStreamingTokens.formatted()) streamed tokens")
                     }
                     if model.orchestrationState != nil {
-                        Text("\(model.teamRunLive.teamModelCalls.formatted()) team calls")
-                        if model.teamRunLive.teamMeteredTokens > 0 {
-                            Text("\(model.teamRunLive.teamMeteredTokens.formatted()) hosted tokens")
+                        Text("\(teamRunLive.teamModelCalls.formatted()) team calls")
+                        if teamRunLive.teamMeteredTokens > 0 {
+                            Text("\(teamRunLive.teamMeteredTokens.formatted()) hosted tokens")
                         }
                     }
                     if let info = model.sessionInfo {
@@ -2260,6 +2275,8 @@ struct TranscriptFollowState: Equatable {
 private struct ConversationView: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var transcriptPresentation: TranscriptPresentationModel
+    @EnvironmentObject private var schedule: ScheduleModel
+    @EnvironmentObject private var runs: OrchestrationRunsModel
     let streamingReply: StreamingReplyState
     @StateObject private var scrollCoordinator = TranscriptScrollCoordinator()
     /// Owned here, outside the lazy list, so recycling a row cannot take the
@@ -2608,7 +2625,7 @@ private struct ConversationView: View {
                 .equatable()
             }
             if sourceBlock.kind == .user, let runID = sourceBlock.runID {
-                if model.runKind(for: runID) == "team" {
+                if runKind(for: runID) == "team" {
                     TeamRunBoardView(runID: runID, request: sourceBlock.text)
                         .environmentObject(model)
                         .id("team-board-\(runID)")
@@ -2632,6 +2649,15 @@ private struct ConversationView: View {
                     .allowsHitTesting(false)
             }
         }
+    }
+
+    private func runKind(for runID: String) -> String {
+        if model.turnDispatchedTeamRunID == runID { return "team" }
+        if runs.selectedOrchestrationRun?.id == runID {
+            return runs.selectedOrchestrationRun?.runKind ?? "solo"
+        }
+        if let kind = runs.runDetailsByID[runID]?.runKind { return kind }
+        return runs.orchestrationRuns.first(where: { $0.id == runID })?.runKind ?? "solo"
     }
 
     private func scrollToCurrentMatch(_ proxy: ScrollViewProxy) {

--- a/LocusTests/ActivityCenterModelTests.swift
+++ b/LocusTests/ActivityCenterModelTests.swift
@@ -101,13 +101,4 @@ final class ActivityCenterModelTests: XCTestCase {
         XCTAssertEqual(defaults.stringArray(forKey: "Locus.dismissedActivityRunIDs"), ["run-done"])
     }
 
-    func testAppModelRepublishesActivityChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.activity.activityCenterPresented = true
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/AgentInstructionsModelTests.swift
+++ b/LocusTests/AgentInstructionsModelTests.swift
@@ -117,13 +117,4 @@ final class AgentInstructionsModelTests: XCTestCase {
         XCTAssertNoBackendTraffic()
     }
 
-    func testAppModelRepublishesAgentInstructionsChanges() {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.agentInstructions.agentInstructionsDraft = "# bridge check"
-        wait(for: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/AgentTeamsModelTests.swift
+++ b/LocusTests/AgentTeamsModelTests.swift
@@ -123,13 +123,4 @@ final class AgentTeamsModelTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: AgentTeamStore.consentKey))
     }
 
-    func testAppModelRepublishesTeamChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.soloSwarmEnabled.toggle()
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/AppModelObservationBoundaryTests.swift
+++ b/LocusTests/AppModelObservationBoundaryTests.swift
@@ -1,0 +1,182 @@
+import Combine
+import XCTest
+
+@testable import Locus
+
+@MainActor
+final class AppModelObservationBoundaryTests: XCTestCase {
+    private struct FeatureEvent {
+        let name: String
+        let emit: () -> Void
+    }
+
+    func testFeaturePublicationsStayAtTheirDirectObservationBoundary() async {
+        let app = AppModel(startImmediately: false)
+        let catalogBuilds = app.sessionCatalog.snapshotBuildCountForTesting
+        let transcriptBuilds = app.transcriptPresentation.snapshotBuildCountForTesting
+        var appPublications = 0
+        let subscription = app.objectWillChange.sink { appPublications += 1 }
+        let events = featureEvents(for: app)
+
+        for event in events {
+            let publicationsBeforeEvent = appPublications
+            event.emit()
+            // Provider and application-context events retain side effects on
+            // the next main-actor turn. Give those observations time to run so
+            // this proves they do not republish AppModel either.
+            await Task.yield()
+            await Task.yield()
+
+            XCTAssertEqual(
+                appPublications,
+                publicationsBeforeEvent,
+                "\(event.name) must be observed directly"
+            )
+            XCTAssertEqual(
+                app.sessionCatalog.snapshotBuildCountForTesting,
+                catalogBuilds,
+                "\(event.name) must not rebuild the session catalog"
+            )
+            XCTAssertEqual(
+                app.transcriptPresentation.snapshotBuildCountForTesting,
+                transcriptBuilds,
+                "\(event.name) must not rebuild transcript presentation"
+            )
+        }
+
+        XCTAssertEqual(events.count, 20, "Keep this table complete as feature ownership grows")
+        withExtendedLifetime(subscription) {}
+    }
+
+    func testAdvisoryRepeatedFeaturePublicationFixture() {
+        let app = AppModel(startImmediately: false)
+        let catalogBuilds = app.sessionCatalog.snapshotBuildCountForTesting
+        let transcriptBuilds = app.transcriptPresentation.snapshotBuildCountForTesting
+        var appPublications = 0
+        let subscription = app.objectWillChange.sink { appPublications += 1 }
+
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0..<100 {
+                app.gitWorkspace.objectWillChange.send()
+                app.providerAccountsModel.objectWillChange.send()
+                app.agentTeamsModel.objectWillChange.send()
+                app.activity.objectWillChange.send()
+                app.simulatorControl.objectWillChange.send()
+            }
+        }
+
+        XCTAssertEqual(appPublications, 0)
+        XCTAssertEqual(app.sessionCatalog.snapshotBuildCountForTesting, catalogBuilds)
+        XCTAssertEqual(app.transcriptPresentation.snapshotBuildCountForTesting, transcriptBuilds)
+        add(XCTAttachment(string: "AppModel publications: \(appPublications)"))
+        withExtendedLifetime(subscription) {}
+    }
+
+    private func featureEvents(for app: AppModel) -> [FeatureEvent] {
+        var events = [
+            FeatureEvent(name: "provider accounts") { app.providerAccountsModel.objectWillChange.send() },
+            FeatureEvent(name: "voice control") { app.voiceControl.objectWillChange.send() },
+            FeatureEvent(name: "agent teams") { app.agentTeamsModel.objectWillChange.send() },
+            FeatureEvent(name: "live team run") { app.teamRunLive.objectWillChange.send() },
+            FeatureEvent(name: "landing flow") { app.landingFlow.objectWillChange.send() },
+            FeatureEvent(name: "run history") { app.runs.objectWillChange.send() },
+            FeatureEvent(name: "evaluations") { app.evaluations.objectWillChange.send() },
+            FeatureEvent(name: "knowledge") { app.knowledge.objectWillChange.send() },
+            FeatureEvent(name: "activity") { app.activity.objectWillChange.send() },
+            FeatureEvent(name: "schedule") { app.schedule.objectWillChange.send() },
+            FeatureEvent(name: "background services") { app.backgroundServicesModel.objectWillChange.send() },
+            FeatureEvent(name: "extensions") { app.extensionsModel.objectWillChange.send() },
+            FeatureEvent(name: "Git") { app.gitWorkspace.objectWillChange.send() },
+            FeatureEvent(name: "workspace files") { app.workspaceFiles.objectWillChange.send() },
+            FeatureEvent(name: "agent instructions") { app.agentInstructions.objectWillChange.send() },
+            FeatureEvent(name: "application context") { app.applicationContext.objectWillChange.send() },
+            FeatureEvent(name: "toasts") { app.toastCenter.objectWillChange.send() },
+            FeatureEvent(name: "computer control") { app.computerControl.objectWillChange.send() },
+            FeatureEvent(name: "simulator control") { app.simulatorControl.objectWillChange.send() },
+        ]
+#if !LOCUS_APP_STORE
+        events.append(FeatureEvent(name: "component installer") {
+            app.codexComponent.objectWillChange.send()
+        })
+#else
+        // The direct-download-only installer is deliberately absent from MAS,
+        // but the table's shape remains deterministic in both configurations.
+        events.append(FeatureEvent(name: "component installer unavailable in MAS") {})
+#endif
+        return events
+    }
+}
+
+final class AppModelObservationBoundaryStructureTests: XCTestCase {
+    func testAppModelHasNoFeatureRepublishingBridges() throws {
+        let appModelSources = try sourceFiles(in: "Locus").filter {
+            $0.lastPathComponent.hasPrefix("AppModel")
+        }
+        let source = try appModelSources.map { try String(contentsOf: $0, encoding: .utf8) }
+            .joined(separator: "\n")
+
+        XCTAssertEqual(
+            matches(of: #"objectWillChange\s*\.\s*send\s*\("#, in: source),
+            [],
+            "AppModel must not republish child feature changes"
+        )
+        XCTAssertEqual(
+            matches(of: #"private\s+var\s+\w*[Bb]ridge\w*\s*:\s*AnyCancellable"#, in: source),
+            [],
+            "Feature bridge storage must not return to AppModel"
+        )
+    }
+
+    func testReactiveViewsDoNotReachThroughAppModelFeatureFacades() throws {
+        let allowedCompositionFile = "AppFeatureEnvironment.swift"
+        let patterns = [
+            "providerAccountsModel", "voiceControl", "codexComponent", "agentTeamsModel",
+            "teamRunLive", "landingFlow", "runs", "evaluations", "knowledge", "activity",
+            "schedule", "backgroundServicesModel", "extensionsModel", "gitWorkspace",
+            "workspaceFiles", "agentInstructions", "applicationContext", "toastCenter",
+            "computerControl", "simulatorControl", "models", "localModels",
+            "installedLocalModels", "providerAccounts", "accountModels", "accountStatus",
+            "accountModelCatalogs", "primaryAgentBehavior", "teamRoutingConsentAccountIDs",
+            "selectedAgentTeam", "teamModeEnabled", "agentProfiles", "agentTeams",
+            "globalAgentConcurrency", "selectedAgentTeamID", "soloSwarmEnabled",
+            "visibleActivityRuns", "taskHasChanges", "orchestrationRuns",
+            "selectedOrchestrationRun", "runDetailsByID", "orchestrationEvents",
+            "isLoadingOrchestrationRuns",
+        ].map { #"model\.\#($0)\b"# }
+
+        for file in try sourceFiles(in: "Locus")
+            where file.lastPathComponent != allowedCompositionFile {
+            let source = try String(contentsOf: file, encoding: .utf8)
+            guard source.contains(": View") else { continue }
+            for pattern in patterns {
+                XCTAssertEqual(
+                    matches(of: pattern, in: source),
+                    [],
+                    "Reactive feature access escaped the direct boundary in \(file.lastPathComponent)"
+                )
+            }
+        }
+    }
+
+    private func sourceFiles(in directory: String) throws -> [URL] {
+        let repository = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let root = repository.appendingPathComponent(directory, isDirectory: true)
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: nil
+        ) else {
+            throw CocoaError(.fileReadUnknown)
+        }
+        return enumerator.compactMap { $0 as? URL }.filter { $0.pathExtension == "swift" }
+    }
+
+    private func matches(of pattern: String, in source: String) -> [String] {
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return [pattern] }
+        let range = NSRange(source.startIndex..., in: source)
+        return expression.matches(in: source, range: range).compactMap {
+            Range($0.range, in: source).map { String(source[$0]) }
+        }
+    }
+}

--- a/LocusTests/BackgroundServicesModelTests.swift
+++ b/LocusTests/BackgroundServicesModelTests.swift
@@ -92,13 +92,4 @@ final class BackgroundServicesModelTests: XCTestCase {
         XCTAssertEqual(toasts.first, "Stopped vite")
     }
 
-    func testAppModelRepublishesBackgroundServiceChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.backgroundServicesModel.applyBackgroundServicesForTesting([])
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/EvaluationsModelTests.swift
+++ b/LocusTests/EvaluationsModelTests.swift
@@ -108,13 +108,4 @@ final class EvaluationsModelTests: XCTestCase {
         XCTAssertEqual(toasts, [])
     }
 
-    func testAppModelRepublishesEvaluationChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.evaluations.objectWillChange.send()
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/ExtensionsModelTests.swift
+++ b/LocusTests/ExtensionsModelTests.swift
@@ -85,13 +85,4 @@ final class ExtensionsModelTests: XCTestCase {
         XCTAssertEqual(Set(runtime.keys), ["access_token", "headers"])
     }
 
-    func testAppModelRepublishesExtensionsChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.extensionsModel.objectWillChange.send()
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/OrchestrationRunsModelTests.swift
+++ b/LocusTests/OrchestrationRunsModelTests.swift
@@ -80,13 +80,4 @@ final class OrchestrationRunsModelTests: XCTestCase {
         XCTAssertEqual(toasts, [])
     }
 
-    func testAppModelRepublishesRunChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.runs.objectWillChange.send()
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/ProviderAccountsModelTests.swift
+++ b/LocusTests/ProviderAccountsModelTests.swift
@@ -84,13 +84,4 @@ final class ProviderAccountsModelTests: XCTestCase {
         XCTAssertNoBackendTraffic()
     }
 
-    func testAppModelRepublishesProviderAccountChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.providerAccounts = [ProviderAccount(kind: .chatGPT, name: "Bridged")]
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/ScheduleModelTests.swift
+++ b/LocusTests/ScheduleModelTests.swift
@@ -119,13 +119,4 @@ final class ScheduleModelTests: XCTestCase {
         XCTAssertNoBackendTraffic()
     }
 
-    func testAppModelRepublishesScheduleChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.schedule.scheduleEditorDraft = ScheduleEditorDraft()
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/TeamRunLiveModelTests.swift
+++ b/LocusTests/TeamRunLiveModelTests.swift
@@ -86,13 +86,4 @@ final class TeamRunLiveModelTests: XCTestCase {
         XCTAssertTrue(model.shouldShowTeamDispatchApproval)
     }
 
-    func testAppModelRepublishesLiveRunChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.teamRunLive.objectWillChange.send()
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/ToastCenterTests.swift
+++ b/LocusTests/ToastCenterTests.swift
@@ -39,13 +39,4 @@ final class ToastCenterTests: XCTestCase {
         XCTAssertNotNil(center.toast, "a cancelled dismissal must leave the toast visible")
     }
 
-    func testAppModelRepublishesToastChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.showToast("Bridged")
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }

--- a/LocusTests/TranscriptFollowTests.swift
+++ b/LocusTests/TranscriptFollowTests.swift
@@ -94,9 +94,7 @@ final class TranscriptFollowTests: XCTestCase {
 
     private func mount(_ model: AppModel, size: NSSize) -> NSView {
         let host = NSHostingView(rootView: FollowProbeRoot()
-            .environmentObject(model)
-            .environmentObject(model.sessionCatalog)
-            .environmentObject(model.transcriptPresentation)
+            .appFeatureEnvironment(from: model)
             .environmentObject(AppUpdateController(startImmediately: false)))
         host.frame = NSRect(origin: .zero, size: size)
         let window = NSWindow(

--- a/LocusTests/TranscriptRelayoutTests.swift
+++ b/LocusTests/TranscriptRelayoutTests.swift
@@ -99,9 +99,7 @@ final class TranscriptRelayoutTests: XCTestCase {
 
     private func mount(_ model: AppModel, size: NSSize) -> NSView {
         let host = NSHostingView(rootView: RelayoutProbeRoot()
-            .environmentObject(model)
-            .environmentObject(model.sessionCatalog)
-            .environmentObject(model.transcriptPresentation)
+            .appFeatureEnvironment(from: model)
             .environmentObject(AppUpdateController(startImmediately: false)))
         host.frame = NSRect(origin: .zero, size: size)
         let window = NSWindow(

--- a/LocusTests/WorkspaceKnowledgeModelTests.swift
+++ b/LocusTests/WorkspaceKnowledgeModelTests.swift
@@ -107,13 +107,4 @@ final class WorkspaceKnowledgeModelTests: XCTestCase {
         XCTAssertTrue(request.url?.query?.contains("workspace=") ?? false)
     }
 
-    func testAppModelRepublishesKnowledgeChanges() async throws {
-        let app = AppModel(startImmediately: false)
-        let republished = expectation(description: "AppModel.objectWillChange fired")
-        republished.assertForOverFulfill = false
-        let cancellable = app.objectWillChange.sink { _ in republished.fulfill() }
-        app.knowledge.objectWillChange.send()
-        await fulfillment(of: [republished], timeout: 1.0)
-        cancellable.cancel()
-    }
 }


### PR DESCRIPTION
## Summary

- inject authoritative feature models through one scene-level observation boundary
- migrate reactive SwiftUI consumers away from AppModel child facades
- remove child-to-AppModel publication forwarding while preserving capability side effects
- add deterministic boundary, rebuild, structural, and advisory publication guards

## Verification

- project generation is byte-for-byte stable
- design-system audit passed
- protocol manifest check passed
- shared iOS wire types type-check passed
- focused observation-boundary and transcript tests passed
- full Swift unit suite passed locally excluding the two signing-dependent wallet XPC tests; the signed macOS 26 run stalled during XPC teardown, so the protected wallet CI job is authoritative
- focused rail and accessibility UI tests passed; the team-plan fixture failure reproduces on the unchanged baseline under macOS 26
- direct-download Release and App Store ReleaseMAS builds passed

## Notes

No backend contract, persistence key, navigation behavior, or user-facing appearance changes.