### PR TITLE
Make the Agents surfaces say what the system does

### DIFF
--- a/Locus/AgentOverviewModel.swift
+++ b/Locus/AgentOverviewModel.swift
@@ -8,8 +8,12 @@ import Foundation
 struct AgentOverview: Equatable {
     enum Status: Equatable {
         case active
+        /// The person paused it. Nothing is wrong.
         case paused
-        case needsAttention
+        /// Locus stopped it after a failure and will not restart it by itself.
+        case stopped
+        /// Still listening, but the last event did not get through.
+        case failing
         case fired
         /// The chats survived but their trigger was deleted or never loaded.
         case missingTrigger
@@ -18,7 +22,8 @@ struct AgentOverview: Equatable {
             switch self {
             case .active: "Active"
             case .paused: "Paused"
-            case .needsAttention: "Needs attention"
+            case .stopped: "Stopped"
+            case .failing: "Last event failed"
             case .fired: "Fired"
             case .missingTrigger: "No trigger"
             }
@@ -27,16 +32,25 @@ struct AgentOverview: Equatable {
         var detail: String {
             switch self {
             case .active: "Listening for matching events"
-            case .paused: "Events are recorded but no chat starts"
-            case .needsAttention: "The last delivery or poll failed"
+            case .paused: "You paused this agent. Events are recorded but no chat starts."
+            case .stopped: "Locus stopped this agent after a failure. Resume to start listening again."
+            case .failing: "The last event did not get through. The agent is still listening."
             case .fired: "This one-shot alert already fired; re-arm to watch again"
             case .missingTrigger: "The trigger behind these chats no longer exists"
             }
         }
 
+        /// Whether the agent has stopped acting on events. Paused is deliberate
+        /// and quiet; stopped and missing are not, and lead the fleet list.
         var isWarning: Bool {
-            self == .needsAttention || self == .missingTrigger
+            switch self {
+            case .stopped, .failing, .missingTrigger: true
+            case .active, .paused, .fired: false
+            }
         }
+
+        /// Only a stopped agent needs a person to switch it back on.
+        var needsResume: Bool { self == .stopped }
     }
 
     struct Chat: Identifiable, Equatable {
@@ -44,6 +58,10 @@ struct AgentOverview: Equatable {
         let isCurrent: Bool
         let isRunning: Bool
         let startedAt: Date?
+        /// Every delivery is dispatched into the trigger's one target chat, so
+        /// exactly one of an agent's chats receives events and the rest are
+        /// side conversations a person started.
+        var isEventTarget = false
 
         var id: String { session.id }
     }
@@ -115,6 +133,11 @@ struct AgentOverview: Equatable {
     let priceState: String?
 
     var currentChat: Chat? { chats.first(where: \.isCurrent) }
+    /// The chat every event lands in, when it still exists.
+    var eventChat: Chat? { chats.first(where: \.isEventTarget) }
+    /// The agent has chats but its event chat is gone — deleting it leaves the
+    /// trigger pointing at nothing, which no amount of resuming repairs.
+    var hasLostEventChat: Bool { trigger != nil && eventChat == nil }
     var runningChatCount: Int { chats.filter(\.isRunning).count }
     var isPriceAlert: Bool { trigger?.triggerKind == .price }
     var canRearm: Bool { isPriceAlert && trigger?.runtimeState.fired == true }
@@ -141,12 +164,14 @@ struct AgentOverview: Equatable {
                 if lhs.mtime != rhs.mtime { return lhs.mtime > rhs.mtime }
                 return lhs.id < rhs.id
             }
+        let targetSessionID = trigger?.targetSessionID.nilIfEmpty
         let chats = ownChats.map { session in
             Chat(
                 session: session,
                 isCurrent: session.id == currentSessionID,
                 isRunning: runningSessionIDs.contains(session.id),
-                startedAt: startedAt[session.id]
+                startedAt: startedAt[session.id],
+                isEventTarget: session.id == targetSessionID
             )
         }
         let name = trigger?.name.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
@@ -221,16 +246,52 @@ struct AgentOverview: Equatable {
             eventCount: ownDeliveries.count,
             failedEventCount: failedCount,
             lastEventAt: lastEventAt,
-            lastError: trigger?.lastError?.nilIfEmpty ?? connection?.lastError?.nilIfEmpty,
+            lastError: (trigger?.lastError?.nilIfEmpty ?? connection?.lastError?.nilIfEmpty)
+                .map(humanizedError),
             priceState: trigger.flatMap { priceState(for: $0, now: now) }
         )
     }
 
+    /// The backend records only `enabled` and a free-text `last_error`, but the
+    /// pair carries four distinct meanings. A disabled trigger with an error is
+    /// one Locus switched off itself (`pause_event_trigger` on a dispatch
+    /// failure); a disabled trigger without one is a deliberate pause.
     static func status(for trigger: EventTrigger?) -> Status {
         guard let trigger else { return .missingTrigger }
-        if let error = trigger.lastError, !error.isEmpty { return .needsAttention }
+        if let error = trigger.lastError, !error.isEmpty {
+            return trigger.enabled ? .failing : .stopped
+        }
         if trigger.triggerKind == .price, trigger.runtimeState.fired == true { return .fired }
         return trigger.enabled ? .active : .paused
+    }
+
+    /// Dispatch failures are re-raised as the agent's status line, so the raw
+    /// HTTP detail from the backend would otherwise be what a person reads.
+    /// Translate the ones Locus itself produces and leave anything else alone
+    /// beyond sentence-casing it.
+    static func humanizedError(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return trimmed }
+        let known: [String: String] = [
+            "target chat not found":
+                "This agent's chat was deleted, so events have nowhere to go.",
+            "the target chat workspace is unavailable":
+                "The agent's workspace folder is missing or was moved.",
+            "the target chat checkout is unavailable":
+                "The agent's worktree checkout is missing.",
+            "the target chat model is unavailable":
+                "The model this agent runs on is no longer available.",
+            "the agent provider is not supported":
+                "The model provider this agent runs on is no longer supported.",
+            "this configuration does not own a dedicated agent":
+                "This configuration has no agent chat of its own.",
+            "capability is disabled: event_triggers":
+                "Event agents are turned off in this build of Locus.",
+        ]
+        if let match = known[trimmed.lowercased()] { return match }
+        guard let first = trimmed.first else { return trimmed }
+        let sentence = first.uppercased() + trimmed.dropFirst()
+        return sentence.hasSuffix(".") ? sentence : sentence + "."
     }
 
     static func summary(trigger: EventTrigger?, connection: ConnectorConnection?) -> String {

--- a/Locus/AppModel+AgentChats.swift
+++ b/Locus/AppModel+AgentChats.swift
@@ -1,24 +1,41 @@
 import Foundation
 
 /// An event-trigger editor the Configure Agent sheet opens once it exists.
+/// A nil `trigger` asks for a new agent of `triggerKind` rather than an edit.
 struct PendingEventTriggerEdit: Equatable {
-    let trigger: EventTrigger
+    let trigger: EventTrigger?
     let targetSessionID: String
-    let isDedicatedAgent: Bool
+    var isDedicatedAgent = false
+    var triggerKind: EventTriggerKind = .event
 }
 
 /// Chats that belong to a persistent agent. An agent's chats are ordinary
 /// sessions tagged with its trigger, so "new chat" in Agents mode means the
 /// agent's next chat rather than a fresh workspace conversation.
 extension AppModel {
-    /// The sidebar's New chat button and ⌘N share this: Ask mode starts a
-    /// workspace chat, Agents mode starts the selected agent's next chat.
+    /// The sidebar's primary button and ⌘N share this. Each destination creates
+    /// the thing it is about: Ask makes a chat in the workspace, Agents makes an
+    /// agent. Chatting with an existing agent is a per-agent action, reached
+    /// from that agent's row or from the Agent panel, because it needs to name
+    /// which agent it belongs to.
     func newChatForSidebarDestination() {
         if sidebarDestination == .agents {
-            newAgentChat()
+            presentNewAgent()
         } else {
             newSession()
         }
+    }
+
+    /// Opens Configure Agent straight into an empty trigger editor. The first
+    /// field there is the kind, so a person who wanted a price alert is one
+    /// control away rather than back at the sheet's creation cards.
+    func presentNewAgent(kind: EventTriggerKind = .event) {
+        configureAgentPendingTriggerEdit = PendingEventTriggerEdit(
+            trigger: nil,
+            targetSessionID: currentSessionID,
+            triggerKind: kind
+        )
+        presentConfigureAgent(draftText: draftText)
     }
 
     /// Starts another chat for an agent. Without a trigger id it uses the

--- a/Locus/AppModel+RunQueueAndActivity.swift
+++ b/Locus/AppModel+RunQueueAndActivity.swift
@@ -125,7 +125,10 @@ extension AppModel {
             eventAutomations.presentEditor(
                 trigger: edit.trigger,
                 targetSessionID: edit.targetSessionID,
-                isDedicatedAgent: edit.isDedicatedAgent
+                isDedicatedAgent: edit.isDedicatedAgent,
+                naturalLanguageRequest: edit.trigger == nil
+                    ? configureAgentDraftSuggestion : "",
+                triggerKind: edit.trigger == nil ? edit.triggerKind : nil
             )
         }
         guard let draft = configureAgentPendingScheduleDraft else { return }

--- a/Locus/AppModel+UITestFixtures.swift
+++ b/Locus/AppModel+UITestFixtures.swift
@@ -755,9 +755,43 @@ extension AppModel {
             lastRunID: nil,
             lastError: nil
         )
+        // A third agent Locus switched off itself after a dispatch failure, so
+        // the stopped state and its recovery are visible and assertable.
+        let stoppedChat = SessionSummary(
+            id: "seed-stopped-chat",
+            name: "seed-stopped-chat.jsonl",
+            preview: "Watch the deploy channel",
+            mtime: now - 21_600,
+            size: 210,
+            title: "Deploy Watch",
+            cwd: workspace,
+            agentTriggerID: "seed-stopped-agent",
+            agentName: "Deploy Watch"
+        )
+        sessions.append(stoppedChat)
+        var stoppedFilters = EventTriggerFilters()
+        stoppedFilters.commandPrefixes = ["/deploy"]
+        let stoppedAgent = EventTrigger(
+            id: "seed-stopped-agent",
+            name: "Deploy Watch",
+            connectionID: connection.id,
+            targetSessionID: stoppedChat.id,
+            instruction: "Summarize each deploy notice and flag failed steps.",
+            mode: .work,
+            triggerKind: .event,
+            filters: stoppedFilters,
+            runtimeState: PriceTriggerState(),
+            actionConnectionIDs: [],
+            enabled: false,
+            createdAt: now - 259_200,
+            updatedAt: now - 21_600,
+            lastEventAt: now - 21_600,
+            lastRunID: nil,
+            lastError: "the target chat model is unavailable"
+        )
         eventAutomations.seedForUITesting(
             connections: [connection, priceFeed],
-            triggers: [trigger, priceAlert],
+            triggers: [trigger, priceAlert, stoppedAgent],
             deliveries: deliveries
         )
         // Set last: the destination change is what swaps the open Overview

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -953,7 +953,10 @@ final class AppModel: ObservableObject {
                 self?.sidebarDestination = .agents
                 self?.resume(session)
             },
-            showMessage: { [weak self] message in self?.showToast(message) }
+            showMessage: { [weak self] message in self?.showToast(message) },
+            notifyPaused: { [weak self] body in
+                self?.notifyNeedsAttentionIfInactive(body: body)
+            }
         )
         providerAccountsModel.configure(
             backend: backend,

--- a/Locus/EventAutomationModel.swift
+++ b/Locus/EventAutomationModel.swift
@@ -34,6 +34,7 @@ final class EventAutomationModel: ObservableObject {
     private var agentProviderRoute: (() -> [String: String])?
     private var openAgentSession: ((SessionSummary) -> Void)?
     private var showMessage: ((String) -> Void)?
+    private var notifyPaused: ((String) -> Void)?
 
     init(credentials: ConnectorCredentialStore = .shared) {
         self.credentials = credentials
@@ -54,7 +55,8 @@ final class EventAutomationModel: ObservableObject {
         refreshSessions: @escaping () async -> Void,
         agentProviderRoute: @escaping () -> [String: String],
         openAgentSession: @escaping (SessionSummary) -> Void,
-        showMessage: @escaping (String) -> Void
+        showMessage: @escaping (String) -> Void,
+        notifyPaused: @escaping (String) -> Void = { _ in }
     ) {
         self.backend = backend
         self.onQueuedRun = onQueuedRun
@@ -64,6 +66,7 @@ final class EventAutomationModel: ObservableObject {
         self.agentProviderRoute = agentProviderRoute
         self.openAgentSession = openAgentSession
         self.showMessage = showMessage
+        self.notifyPaused = notifyPaused
     }
 
     /// UI-test fixtures need agents without a backend. The stored arrays are
@@ -117,9 +120,11 @@ final class EventAutomationModel: ObservableObject {
             let (loadedConnections, loadedTriggers, loadedDeliveries) = try await (
                 connectionResponse, triggerResponse, deliveryResponse
             )
+            let previous = triggers
             connections = loadedConnections.connections
             triggers = loadedTriggers.triggers
             deliveries = loadedDeliveries.deliveries
+            announceAgentsStoppedByLocus(previous: previous, current: triggers)
             lastError = nil
             restartNativeRuntimeIfNeeded()
             onCapabilityChanged?()
@@ -129,6 +134,29 @@ final class EventAutomationModel: ObservableObject {
             guard !Task.isCancelled else { return }
             lastError = error.localizedDescription
             if announceFailure { showMessage?("Could not load event automations: \(error.localizedDescription)") }
+        }
+    }
+
+    /// A failed dispatch disables the trigger in the backend and records why.
+    /// Nothing restarts it, so a person who is not looking at the Agent panel
+    /// would never learn their agent stopped. Schedules already announce this;
+    /// event agents now do too.
+    private func announceAgentsStoppedByLocus(
+        previous: [EventTrigger],
+        current: [EventTrigger]
+    ) {
+        guard !previous.isEmpty else { return }
+        let wasStopped = Set(
+            previous.filter { !$0.enabled && $0.lastError?.isEmpty == false }.map(\.id)
+        )
+        for trigger in current
+        where !trigger.enabled
+            && trigger.lastError?.isEmpty == false
+            && !wasStopped.contains(trigger.id)
+        {
+            let reason = AgentOverview.humanizedError(trigger.lastError ?? "")
+            showMessage?("\(trigger.name) was stopped: \(reason)")
+            notifyPaused?("\(trigger.name) was stopped: \(reason)")
         }
     }
 

--- a/Locus/EventAutomationsView.swift
+++ b/Locus/EventAutomationsView.swift
@@ -99,7 +99,7 @@ struct ConfigureAgentView: View {
                 .background(LocusTheme.signal.opacity(0.16))
                 .clipShape(RoundedRectangle(cornerRadius: 11, style: .continuous))
             VStack(alignment: .leading, spacing: 3) {
-                Text("Configure Agent")
+                Text("Manage Agents")
                     .font(.locus(size: 17, weight: .bold))
                 Text("Choose what starts the work, where it runs, and what it may do.")
                     .font(.locus(size: 9))
@@ -1121,6 +1121,7 @@ private struct PriceSecretDraft: Identifiable, Hashable {
 private struct EventTriggerEditorView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var draft: EventTriggerEditorDraft
+    @State private var connectionSheet: ConnectorKind?
     @ObservedObject var automation: EventAutomationModel
     let sessions: [SessionSummary]
 
@@ -1145,9 +1146,21 @@ private struct EventTriggerEditorView: View {
                     Task { if await automation.saveTrigger(draft) { dismiss() } }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(automation.isSaving)
+                .disabled(automation.isSaving || missingRequirement != nil)
+                .help(missingRequirement ?? (draft.id == nil
+                    ? "Start listening for these events"
+                    : "Save this agent"))
+                .accessibilityIdentifier("eventTrigger.save")
             }
-            .padding(18)
+            if let missingRequirement {
+                Text(missingRequirement)
+                    .font(.locus(size: 8, weight: .medium))
+                    .foregroundStyle(LocusTheme.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 18)
+                    .padding(.bottom, 12)
+                    .accessibilityIdentifier("eventTrigger.requirement")
+            }
             Divider()
             Form {
                 Section("What starts it") {
@@ -1165,7 +1178,8 @@ private struct EventTriggerEditorView: View {
                     }
                     TextField("Name", text: $draft.name)
                     Picker("Connection", selection: $draft.connectionID) {
-                        Text("Choose a connection").tag("")
+                        Text(eligibleConnections.isEmpty
+                            ? "No sources connected yet" : "Choose a connection").tag("")
                         ForEach(eligibleConnections) { connection in
                             Text(connection.displayName).tag(connection.id)
                         }
@@ -1180,11 +1194,29 @@ private struct EventTriggerEditorView: View {
                             draft.actionConnectionIDs = [value]
                         }
                     }
+                    Menu {
+                        ForEach(addableConnectorKinds) { kind in
+                            Button {
+                                connectionSheet = kind
+                            } label: {
+                                Label(kind.title, systemImage: kind.symbol)
+                            }
+                            .accessibilityIdentifier("eventTrigger.addSource.\(kind.rawValue)")
+                        }
+                    } label: {
+                        Label(
+                            eligibleConnections.isEmpty ? "Connect a source…" : "Add a source…",
+                            systemImage: "plus"
+                        )
+                        .font(.locus(size: 9, weight: .semibold))
+                    }
+                    .menuStyle(.borderlessButton)
+                    .accessibilityIdentifier("eventTrigger.addSource")
                     sourceFilters
                 }
                 Section("What it does") {
                     Picker("Destination", selection: $draft.targetSessionID) {
-                        Text("Dedicated agent task")
+                        Text("Its own agent chat")
                             .tag(EventTriggerEditorDraft.dedicatedAgentChat)
                         Text("Choose an existing chat").tag("")
                         ForEach(sessions.filter { !$0.isArchived }) { session in
@@ -1192,16 +1224,33 @@ private struct EventTriggerEditorView: View {
                         }
                     }
                     if draft.targetSessionID == EventTriggerEditorDraft.dedicatedAgentChat {
-                        Text("Creates a persistent task conversation in Agents. It keeps its own agent identity while retaining access to the selected chat’s workspace, so future context and AGENTS.md settings can attach to it.")
+                        Text("Creates one lasting conversation in Agents that every matching event arrives in. It keeps its own agent identity while retaining access to the selected chat’s workspace, so future context and AGENTS.md settings can attach to it.")
                             .font(.locus(size: 8))
                             .foregroundStyle(LocusTheme.muted)
                     }
                     Picker("Mode", selection: $draft.mode) {
                         ForEach(WorkMode.allCases) { mode in Text(mode.title).tag(mode) }
                     }
-                    TextEditor(text: $draft.instruction)
-                        .font(.locus(size: 10))
-                        .frame(minHeight: 110)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Instruction")
+                            .font(.locus(size: 9, weight: .semibold))
+                            .foregroundStyle(LocusTheme.textSecondary)
+                        TextEditor(text: $draft.instruction)
+                            .font(.locus(size: 10))
+                            .frame(minHeight: 110)
+                            .overlay(alignment: .topLeading) {
+                                if draft.instruction.isEmpty {
+                                    Text("What should this agent do with each event?")
+                                        .font(.locus(size: 10))
+                                        .foregroundStyle(LocusTheme.muted)
+                                        .padding(.leading, 5)
+                                        .padding(.top, 8)
+                                        .allowsHitTesting(false)
+                                }
+                            }
+                            .accessibilityLabel("Instruction")
+                            .accessibilityIdentifier("eventTrigger.instruction")
+                    }
                     Text("This saved instruction is trusted configuration. Incoming bodies and JSON values are untrusted data and cannot alter permissions or this trigger.")
                         .font(.locus(size: 8))
                         .foregroundStyle(LocusTheme.muted)
@@ -1227,6 +1276,18 @@ private struct EventTriggerEditorView: View {
             .padding(.horizontal, 12)
         }
         .frame(width: 680, height: 700)
+        .sheet(item: $connectionSheet) { kind in
+            ConnectorSetupView(kind: kind, automation: automation)
+        }
+        .onChange(of: automation.connections.map(\.id)) { oldValue, newValue in
+            // A source connected from inside the editor is almost certainly the
+            // one this agent wants, so select it rather than making the person
+            // find it in the picker they just left.
+            guard draft.connectionID.isEmpty,
+                  let added = Set(newValue).subtracting(oldValue).first,
+                  eligibleConnections.contains(where: { $0.id == added }) else { return }
+            draft.connectionID = added
+        }
         .accessibilityIdentifier("eventAutomations.editor")
     }
 
@@ -1318,6 +1379,38 @@ private struct EventTriggerEditorView: View {
             Text("Choose a connection to configure deterministic filters.")
                 .foregroundStyle(LocusTheme.muted)
         }
+    }
+
+    /// Which sources can start this kind of agent. Price alerts read a feed or
+    /// a signed relay; everything else ingests from a messaging source.
+    private var addableConnectorKinds: [ConnectorKind] {
+        draft.triggerKind == .price ? [.priceFeed, .webhook] : [.gmail, .telegram, .webhook]
+    }
+
+    /// The first unmet requirement, phrased as the next thing to do. Saving
+    /// used to be offered unconditionally and then fail in a toast.
+    private var missingRequirement: String? {
+        if draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Name this agent so you can find it later."
+        }
+        if draft.connectionID.isEmpty {
+            return eligibleConnections.isEmpty
+                ? "Connect a source first — this agent has nothing to listen to."
+                : "Choose the source this agent listens to."
+        }
+        if draft.targetSessionID.isEmpty {
+            return "Choose where this agent's events arrive."
+        }
+        if draft.instruction.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Write what this agent should do with each event."
+        }
+        if draft.triggerKind == .price {
+            guard let threshold = draft.filters.priceCondition?.thresholdDecimal,
+                  threshold > 0 else {
+                return "Add a positive price threshold."
+            }
+        }
+        return nil
     }
 
     private var eligibleConnections: [ConnectorConnection] {

--- a/Locus/InspectorAgentTab.swift
+++ b/Locus/InspectorAgentTab.swift
@@ -156,7 +156,7 @@ private struct AgentDetailView: View {
                         title: "New chat",
                         symbol: "plus",
                         prominent: true,
-                        help: "Start another chat with this agent",
+                        help: "Start a side conversation with this agent. It does not receive events.",
                         identifier: "agentOverview.newChat"
                     ) {
                         model.newAgentChat(triggerID: overview.triggerID)
@@ -174,9 +174,10 @@ private struct AgentDetailView: View {
                     AgentActionButton(
                         title: trigger.enabled ? "Pause" : "Resume",
                         symbol: trigger.enabled ? "pause" : "play",
+                        prominent: overview.status.needsResume,
                         help: trigger.enabled
                             ? "Keep recording events without starting chats"
-                            : "Start chats for matching events again",
+                            : "Start chats for matching events again, and clear the error",
                         identifier: "agentOverview.toggle"
                     ) {
                         automation.setTrigger(trigger, enabled: !trigger.enabled)
@@ -213,6 +214,8 @@ private struct AgentDetailView: View {
                 model.presentConfigureAgent(draftText: "")
             }
             .accessibilityIdentifier("agentOverview.menu.manage")
+            Button("New Agent…") { model.presentNewAgent() }
+                .accessibilityIdentifier("agentOverview.menu.newAgent")
             if let path = overview.chats.compactMap(\.session.workspacePath).first {
                 Button("Reveal Workspace in Finder") {
                     NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
@@ -262,11 +265,18 @@ private struct AgentDetailView: View {
                 Text(overview.status.isWarning ? overview.status.detail : "Last error")
                     .font(.locus(size: 9, weight: .semibold))
                     .foregroundStyle(LocusTheme.ink)
+                    .fixedSize(horizontal: false, vertical: true)
                 Text(error)
                     .font(.locus(size: 8))
                     .foregroundStyle(LocusTheme.textSecondary)
                     .lineLimit(4)
                     .fixedSize(horizontal: false, vertical: true)
+                if overview.hasLostEventChat {
+                    Text("Its chat cannot be restored. Delete this agent and configure a new one.")
+                        .font(.locus(size: 8))
+                        .foregroundStyle(LocusTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             Spacer(minLength: 0)
         }
@@ -454,15 +464,22 @@ private struct AgentDetailView: View {
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.locus())
-                    .help("Start another chat with this agent")
+                    .help("Start a side conversation with this agent. It does not receive events.")
                     .accessibilityLabel("New chat with \(overview.name)")
                     .accessibilityIdentifier("agentOverview.chats.new")
                 }
             }
+            if let eventChat = overview.eventChat, overview.chats.count > 1 {
+                Text("Events arrive in \(eventChat.session.displayTitle). Other chats are side conversations.")
+                    .font(.locus(size: 8))
+                    .foregroundStyle(LocusTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("agentOverview.chats.explainer")
+            }
             if overview.chats.isEmpty {
                 Text(overview.trigger == nil
                     ? "No chats survived for this agent."
-                    : "No chats yet. New chat gives this agent its first conversation; matching events also start one.")
+                    : "No chats yet. Every event arrives in this agent's event chat; New chat starts a side conversation that does not receive events.")
                     .font(.locus(size: 9))
                     .foregroundStyle(LocusTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -544,7 +561,7 @@ private struct AgentFleetView: View {
     @ObservedObject var automation: EventAutomationModel
 
     private var activeCount: Int { entries.filter { $0.status == .active }.count }
-    private var attentionCount: Int { entries.filter { $0.status.isWarning }.count }
+    private var stoppedCount: Int { entries.filter { $0.status.needsResume }.count }
 
     var body: some View {
         ScrollView {
@@ -594,18 +611,19 @@ private struct AgentFleetView: View {
                     title: "New agent",
                     symbol: "plus",
                     prominent: true,
-                    help: "Configure a new agent",
+                    help: "Configure an agent that wakes on email, messages, webhooks, or a price",
                     identifier: "agentOverview.fleet.create"
                 ) {
-                    model.presentConfigureAgent(draftText: model.draftText)
+                    model.presentNewAgent()
                 }
                 AgentActionButton(
-                    title: "Manage",
-                    symbol: "gearshape.2",
-                    help: "Open Configure Agent",
+                    title: "Sources",
+                    symbol: "point.3.connected.trianglepath.dotted",
+                    help: "Connect Gmail, Telegram, a webhook, or a price feed",
                     identifier: "agentOverview.fleet.manage"
                 ) {
                     model.presentConfigureAgent(draftText: "")
+                    model.configureAgentTab = .sources
                 }
                 Spacer(minLength: 0)
             }
@@ -618,7 +636,9 @@ private struct AgentFleetView: View {
     private var fleetSummary: String {
         guard !entries.isEmpty else { return "Persistent agents that wake on events" }
         var parts = ["\(entries.count) configured", "\(activeCount) active"]
-        if attentionCount > 0 { parts.append("\(attentionCount) need attention") }
+        if stoppedCount > 0 {
+            parts.append("\(stoppedCount) stopped by Locus")
+        }
         return parts.joined(separator: " · ")
     }
 
@@ -665,7 +685,7 @@ private struct AgentGlyph: View {
         switch status {
         case .active, .fired: LocusTheme.signalDeep
         case .paused: LocusTheme.muted
-        case .needsAttention, .missingTrigger: LocusTheme.warning
+        case .stopped, .failing, .missingTrigger: LocusTheme.warning
         }
     }
 
@@ -687,7 +707,8 @@ private struct AgentStatusPill: View {
         switch status {
         case .active: LocusTheme.success
         case .paused: LocusTheme.muted
-        case .needsAttention, .missingTrigger: LocusTheme.warning
+        case .stopped, .missingTrigger: LocusTheme.warning
+        case .failing: LocusTheme.coral
         case .fired: LocusTheme.blue
         }
     }
@@ -843,10 +864,23 @@ private struct AgentChatRow: View {
                     .frame(width: 6, height: 6)
                     .accessibilityHidden(true)
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(chat.session.displayTitle)
-                        .font(.locus(size: 10, weight: chat.isCurrent ? .semibold : .medium))
-                        .foregroundStyle(LocusTheme.ink)
-                        .lineLimit(1)
+                    HStack(spacing: 5) {
+                        Text(chat.session.displayTitle)
+                            .font(.locus(size: 10, weight: chat.isCurrent ? .semibold : .medium))
+                            .foregroundStyle(LocusTheme.ink)
+                            .lineLimit(1)
+                        if chat.isEventTarget {
+                            Text("EVENTS")
+                                .font(.locus(size: 7, weight: .bold))
+                                .tracking(0.4)
+                                .foregroundStyle(LocusTheme.signalDeep)
+                                .padding(.horizontal, 5)
+                                .frame(height: 15)
+                                .background(LocusTheme.signal.opacity(0.16))
+                                .clipShape(Capsule())
+                                .accessibilityHidden(true)
+                        }
+                    }
                     HStack(spacing: 4) {
                         if chat.isRunning {
                             if let startedAt = chat.startedAt {
@@ -861,6 +895,7 @@ private struct AgentChatRow: View {
                             Text("· Open now")
                         }
                     }
+                    .lineLimit(1)
                     .font(.locus(size: 8))
                     .foregroundStyle(chat.isRunning ? LocusTheme.success : LocusTheme.textSecondary)
                 }
@@ -879,8 +914,12 @@ private struct AgentChatRow: View {
             .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
         }
         .buttonStyle(.locus())
-        .help(chat.isCurrent ? "This chat is open" : "Open \(chat.session.displayTitle)")
-        .accessibilityLabel(chat.session.displayTitle)
+        .help(chat.isEventTarget
+            ? "Every event this agent receives arrives here"
+            : (chat.isCurrent ? "This chat is open" : "Open \(chat.session.displayTitle)"))
+        .accessibilityLabel(chat.isEventTarget
+            ? "\(chat.session.displayTitle), receives events"
+            : chat.session.displayTitle)
         .accessibilityValue(chat.isRunning ? "Running" : (chat.isCurrent ? "Open" : "Idle"))
         .accessibilityIdentifier("agentOverview.chat.\(chat.session.id)")
     }

--- a/Locus/LocusApp.swift
+++ b/Locus/LocusApp.swift
@@ -103,7 +103,11 @@ struct LocusApp: App {
             }
 
             CommandGroup(replacing: .newItem) {
-                Button("New Session") { model.newChatForSidebarDestination() }
+                // The label follows the destination: ⌘N makes a chat in Ask and
+                // an agent in Agents, so a fixed title would misdescribe one.
+                Button(model.sidebarDestination == .agents ? "New Agent" : "New Session") {
+                    model.newChatForSidebarDestination()
+                }
                     .keyboardShortcut("n", modifiers: .command)
                 Button("New Chat Folder…") {
                     model.globalNewFolderName = ""

--- a/Locus/SessionSidebarView.swift
+++ b/Locus/SessionSidebarView.swift
@@ -147,6 +147,7 @@ struct SessionSidebarView: View {
     @State private var folderEditor: ChatFolderEditorRequest?
     @State private var folderEditorName = ""
     @State private var collapsedAgentIDs: Set<String> = []
+    @State private var agentToDelete: EventTrigger?
     @State private var searchExpanded = false
     @FocusState private var searchFocused: Bool
 
@@ -368,6 +369,23 @@ struct SessionSidebarView: View {
             )
         }
         .confirmationDialog(
+            "Delete \(agentToDelete?.name ?? "this agent")?",
+            isPresented: Binding(
+                get: { agentToDelete != nil },
+                set: { if !$0 { agentToDelete = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete Agent", role: .destructive) {
+                if let agentToDelete { model.eventAutomations.deleteTrigger(agentToDelete) }
+                agentToDelete = nil
+            }
+            .accessibilityIdentifier("agent.delete.confirm")
+            Button("Cancel", role: .cancel) { agentToDelete = nil }
+        } message: {
+            Text("It stops listening for events. Its chats stay where they are.")
+        }
+        .confirmationDialog(
             "Delete \(folderToDelete?.name ?? "this folder")?",
             isPresented: Binding(
                 get: { folderToDelete != nil },
@@ -471,10 +489,9 @@ struct SessionSidebarView: View {
             HStack(spacing: 7) {
                 secondaryButton(
                     symbol: "gearshape.2",
-                    title: model.sidebarDestination == .agents ? "Manage Agents" : "Configure Agent",
-                    help: "Configure schedules, incoming events, and price conditions",
-                    accessibilityLabel: model.sidebarDestination == .agents
-                        ? "Manage Agents" : "Configure Agent",
+                    title: "Manage Agents",
+                    help: "Agents, their sources, and the events they have handled",
+                    accessibilityLabel: "Manage Agents",
                     identifier: "sidebar.configureAgent"
                 ) {
                     model.presentConfigureAgent(draftText: model.draftText)
@@ -487,16 +504,18 @@ struct SessionSidebarView: View {
         .padding(.bottom, 12)
     }
 
-    /// One button, one label, in both destinations. In Agents mode a new chat
-    /// belongs to the selected agent, so it starts that agent's next chat.
+    /// Each destination creates the object it is about: a chat in Ask, an agent
+    /// in Agents. Chatting with a particular agent lives on that agent's row,
+    /// where which agent it belongs to is unambiguous.
     private var primaryCreationButton: some View {
-        Button {
+        let isAgents = model.sidebarDestination == .agents
+        return Button {
             model.newChatForSidebarDestination()
         } label: {
             HStack(spacing: SidebarMetrics.iconGap) {
                 Image(systemName: "plus")
                     .frame(width: SidebarMetrics.iconColumn)
-                Text("New chat")
+                Text(isAgents ? "New agent" : "New chat")
                 Spacer(minLength: 4)
                 Text("⌘N")
                     .font(.locus(size: 8, design: .monospaced))
@@ -511,12 +530,11 @@ struct SessionSidebarView: View {
             .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
         }
         .buttonStyle(.locus())
-        .help(model.sidebarDestination == .agents
-            ? "Start a new chat with the selected agent (⌘N)"
+        .help(isAgents
+            ? "Configure an agent that wakes on email, messages, webhooks, or a price (⌘N)"
             : "Start a new chat (⌘N)")
-        .accessibilityLabel("New chat")
-        .accessibilityValue(model.sidebarDestination == .agents ? "Agent chat" : "Chat")
-        .accessibilityIdentifier("sidebar.newSession")
+        .accessibilityLabel(isAgents ? "New agent" : "New chat")
+        .accessibilityIdentifier(isAgents ? "sidebar.newAgent" : "sidebar.newSession")
     }
 
     private var activityButton: some View {
@@ -833,6 +851,12 @@ struct SessionSidebarView: View {
         }
     }
 
+    /// Distinct agents, which is what the footer's label promises — several
+    /// chats can belong to one agent.
+    private func agentCount(snapshot: SessionCatalogSnapshot) -> Int {
+        Set(snapshot.agentSessions.compactMap { $0.agentTriggerID?.nilIfEmpty }).count
+    }
+
     private func agentGroups(snapshot: SessionCatalogSnapshot) -> [AgentSidebarGroupModel] {
         Dictionary(grouping: snapshot.agentSessions) { session in
             session.agentTriggerID ?? session.id
@@ -853,6 +877,8 @@ struct SessionSidebarView: View {
 
     private func agentGroupRow(_ agent: AgentSidebarGroupModel) -> some View {
         let expanded = !collapsedAgentIDs.contains(agent.id)
+        let trigger = model.eventAutomations.triggers.first { $0.id == agent.id }
+        let status = AgentOverview.status(for: trigger)
         return Button {
             withAnimation(LocusMotion.spatial) {
                 if expanded {
@@ -869,13 +895,20 @@ struct SessionSidebarView: View {
                     .frame(width: 9)
                 Image(locusSymbol: LocusSymbol.robot)
                     .font(.locus(size: 12, weight: .semibold))
-                    .foregroundStyle(LocusTheme.signalDeep)
+                    .foregroundStyle(status.isWarning ? LocusTheme.warning : LocusTheme.signalDeep)
                     .frame(width: 21, height: 21)
                     .accessibilityHidden(true)
                 Text(agent.name)
                     .font(.locus(size: 10, weight: .semibold))
                     .foregroundStyle(LocusTheme.ink)
                     .lineLimit(1)
+                if status != .active {
+                    Image(systemName: agentStatusSymbol(status))
+                        .font(.locus(size: 8, weight: .semibold))
+                        .foregroundStyle(status.isWarning ? LocusTheme.warning : LocusTheme.muted)
+                        .help(status.detail)
+                        .accessibilityHidden(true)
+                }
                 Spacer(minLength: 4)
                 Text("\(agent.tasks.count)")
                     .font(.locus(size: 8, weight: .semibold, design: .monospaced))
@@ -887,9 +920,44 @@ struct SessionSidebarView: View {
             .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
         }
         .buttonStyle(.locus())
+        .contextMenu {
+            Button("New Chat with \(agent.name)") {
+                model.newAgentChat(triggerID: agent.id)
+            }
+            .accessibilityIdentifier("agent.\(agent.id).newChat")
+            if let trigger {
+                Button("Edit Agent…") {
+                    model.editAgentTrigger(trigger, isDedicatedAgent: true)
+                }
+                .accessibilityIdentifier("agent.\(agent.id).edit")
+                Button(trigger.enabled ? "Pause Agent" : "Resume Agent") {
+                    model.eventAutomations.setTrigger(trigger, enabled: !trigger.enabled)
+                }
+                .accessibilityIdentifier("agent.\(agent.id).toggle")
+                Divider()
+                Button("Delete Agent…", role: .destructive) {
+                    agentToDelete = trigger
+                }
+                .accessibilityIdentifier("agent.\(agent.id).delete")
+            }
+        }
+        .help(status.detail)
         .accessibilityLabel("\(agent.name) agent")
-        .accessibilityValue("\(agent.tasks.count) tasks, \(expanded ? "expanded" : "collapsed")")
+        .accessibilityValue(
+            "\(status.title), \(agent.tasks.count) \(agent.tasks.count == 1 ? "chat" : "chats"), "
+                + (expanded ? "expanded" : "collapsed")
+        )
         .accessibilityIdentifier("agent.\(agent.id)")
+    }
+
+    private func agentStatusSymbol(_ status: AgentOverview.Status) -> String {
+        switch status {
+        case .active: "circle"
+        case .paused: "pause.circle.fill"
+        case .stopped, .missingTrigger: "exclamationmark.triangle.fill"
+        case .failing: "exclamationmark.circle.fill"
+        case .fired: "checkmark.circle.fill"
+        }
     }
 
     private func emptyState(snapshot: SessionCatalogSnapshot) -> some View {
@@ -949,7 +1017,7 @@ struct SessionSidebarView: View {
                     Text("Agents")
                         .font(.locus(size: 10, weight: .semibold))
                     Spacer()
-                    Text("\(snapshot.agentSessions.count)")
+                    Text("\(agentCount(snapshot: snapshot))")
                         .font(.locus(size: 8, design: .monospaced))
                         .foregroundStyle(LocusTheme.muted)
                 }
@@ -960,7 +1028,10 @@ struct SessionSidebarView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel("Agents")
-                .accessibilityValue("\(snapshot.agentSessions.count) chats")
+                .accessibilityValue(
+                    "\(agentCount(snapshot: snapshot)) agents, "
+                        + "\(snapshot.agentSessions.count) chats"
+                )
             }
 
             HStack {

--- a/LocusTests/AgentOverviewTests.swift
+++ b/LocusTests/AgentOverviewTests.swift
@@ -173,13 +173,32 @@ final class AgentOverviewTests: XCTestCase {
         XCTAssertEqual(overview.instruction, "")
     }
 
-    func testStatusPrecedenceIsErrorThenFiredThenPaused() {
+    func testStatusSeparatesAPersonPausingFromLocusStoppingTheAgent() {
         XCTAssertEqual(AgentOverview.status(for: nil), .missingTrigger)
+        // enabled, no error: listening.
+        XCTAssertEqual(AgentOverview.status(for: trigger()), .active)
+        // disabled, no error: someone pressed Pause.
         XCTAssertEqual(AgentOverview.status(for: trigger(enabled: false)), .paused)
+        // disabled with an error: a dispatch failure switched it off.
         XCTAssertEqual(
             AgentOverview.status(for: trigger(enabled: false, lastError: "poll failed")),
-            .needsAttention
+            .stopped
         )
+        // enabled with an error: one event failed, the agent still listens.
+        XCTAssertEqual(
+            AgentOverview.status(for: trigger(lastError: "poll failed")),
+            .failing
+        )
+
+        XCTAssertTrue(AgentOverview.Status.stopped.needsResume)
+        XCTAssertFalse(AgentOverview.Status.paused.needsResume)
+        XCTAssertFalse(AgentOverview.Status.failing.needsResume)
+        // A deliberate pause is not a problem to be flagged; the rest are.
+        XCTAssertFalse(AgentOverview.Status.paused.isWarning)
+        XCTAssertTrue(AgentOverview.Status.stopped.isWarning)
+        XCTAssertTrue(AgentOverview.Status.failing.isWarning)
+        XCTAssertFalse(AgentOverview.Status.fired.isWarning)
+
         var fired = PriceTriggerState()
         fired.fired = true
         XCTAssertEqual(
@@ -191,6 +210,68 @@ final class AgentOverviewTests: XCTestCase {
             .active,
             "only price alerts fire"
         )
+    }
+
+    func testBackendDispatchDetailsAreTranslatedBeforeTheyBecomeAStatusLine() {
+        XCTAssertEqual(
+            AgentOverview.humanizedError("target chat not found"),
+            "This agent's chat was deleted, so events have nowhere to go."
+        )
+        XCTAssertEqual(
+            AgentOverview.humanizedError("the target chat model is unavailable"),
+            "The model this agent runs on is no longer available."
+        )
+        // Anything Locus does not recognize is still shown, as a sentence.
+        XCTAssertEqual(AgentOverview.humanizedError("gmail token expired"), "Gmail token expired.")
+        XCTAssertEqual(AgentOverview.humanizedError("Already fine."), "Already fine.")
+        XCTAssertEqual(AgentOverview.humanizedError("   "), "")
+    }
+
+    func testOnlyTheTriggersTargetChatIsMarkedAsReceivingEvents() {
+        let overview = AgentOverview.resolve(
+            triggerID: "weather",
+            trigger: trigger(),
+            connections: [gmail],
+            sessions: [session("chat-new", age: 60), session("chat-old", age: 7_200)],
+            deliveries: [],
+            currentSessionID: "chat-old",
+            runningSessionIDs: [],
+            now: now
+        )
+
+        // `trigger()` targets "chat-new".
+        XCTAssertEqual(overview.eventChat?.id, "chat-new")
+        XCTAssertEqual(overview.chats.filter(\.isEventTarget).map(\.id), ["chat-new"])
+        XCTAssertFalse(overview.hasLostEventChat)
+
+        // Delete that chat and the agent has nowhere to put events.
+        let orphaned = AgentOverview.resolve(
+            triggerID: "weather",
+            trigger: trigger(),
+            connections: [gmail],
+            sessions: [session("chat-old", age: 7_200)],
+            deliveries: [],
+            currentSessionID: "",
+            runningSessionIDs: [],
+            now: now
+        )
+        XCTAssertNil(orphaned.eventChat)
+        XCTAssertTrue(orphaned.hasLostEventChat)
+        XCTAssertFalse(orphaned.chats.isEmpty, "the side conversations survive")
+
+        // Chats without a trigger cannot claim to receive anything.
+        let noTrigger = AgentOverview.resolve(
+            triggerID: "weather",
+            trigger: nil,
+            connections: [],
+            sessions: [session("chat-new", age: 60)],
+            deliveries: [],
+            currentSessionID: "",
+            runningSessionIDs: [],
+            now: now
+        )
+        XCTAssertNil(noTrigger.eventChat)
+        XCTAssertFalse(noTrigger.hasLostEventChat)
     }
 
     func testRecentEventsAreNewestFirstCappedAndCounted() {
@@ -357,8 +438,12 @@ final class AgentOverviewTests: XCTestCase {
             runningSessionIDs: [],
             now: now
         )
-        XCTAssertEqual(overview.status, .needsAttention)
-        XCTAssertEqual(overview.lastError, "Gmail token expired")
+        XCTAssertEqual(overview.status, .failing, "the trigger is still enabled")
+        XCTAssertEqual(
+            overview.lastError,
+            "Gmail token expired.",
+            "the raw backend detail is sentence-cased before it is shown"
+        )
         XCTAssertEqual(overview.facts[0].value, "Missing connection")
         XCTAssertTrue(overview.facts[0].isWarning)
         XCTAssertEqual(overview.facts.map(\.label), ["Source", "Runs as", "May act through", "Created"])
@@ -397,7 +482,7 @@ final class AgentOverviewTests: XCTestCase {
         XCTAssertEqual(entries[1].chatCount, 2)
         XCTAssertEqual(entries[1].runningChatCount, 1)
         XCTAssertEqual(entries[1].latestChat?.id, "r1")
-        XCTAssertEqual(entries[0].status, .needsAttention)
+        XCTAssertEqual(entries[0].status, .failing)
         XCTAssertNil(entries[3].lastEventAt)
         XCTAssertNil(entries[4].lastEventAt)
         XCTAssertEqual(entries[2].summary, "Gmail · Incoming Event · Work")
@@ -592,14 +677,39 @@ final class AgentOverviewTests: XCTestCase {
     }
 
     @MainActor
-    func testNewChatInAgentsModeWithoutAnyAgentOpensConfigureAgent() {
+    func testThePrimaryActionCreatesTheThingEachDestinationIsAbout() {
         let model = AppModel(startImmediately: false)
-        model.sessions = [session("plain", triggerID: nil, name: nil, age: 5)]
-        model.sidebarDestination = .agents
-        XCTAssertFalse(model.configureAgentPresented)
+        model.sessions = [session("chat-new", age: 60)]
+        model.currentSessionID = "chat-new"
 
+        // Agents mode: ⌘N opens an empty agent, not another chat.
+        model.sidebarDestination = .agents
         model.newChatForSidebarDestination()
-        XCTAssertTrue(model.configureAgentPresented, "with no agent to chat with, New chat leads to making one")
+        XCTAssertTrue(model.configureAgentPresented)
+        XCTAssertEqual(model.configureAgentTab, .configurations)
+        XCTAssertEqual(
+            model.configureAgentPendingTriggerEdit,
+            PendingEventTriggerEdit(
+                trigger: nil,
+                targetSessionID: "chat-new",
+                isDedicatedAgent: false,
+                triggerKind: .event
+            )
+        )
+
+        // Mounting the sheet turns that request into a fresh editor draft.
+        model.mountPendingConfigureAgentEditor()
+        XCTAssertNil(model.configureAgentPendingTriggerEdit)
+        let draft = model.eventAutomations.editorDraft
+        XCTAssertNil(draft?.id, "a new agent, not an edit")
+        XCTAssertEqual(draft?.triggerKind, .event)
+        XCTAssertEqual(draft?.targetSessionID, EventTriggerEditorDraft.dedicatedAgentChat)
+
+        // A price agent can be requested directly.
+        model.dismissConfigureAgent()
+        model.presentNewAgent(kind: .price)
+        model.mountPendingConfigureAgentEditor()
+        XCTAssertEqual(model.eventAutomations.editorDraft?.triggerKind, .price)
     }
 }
 

--- a/LocusTests/ExtensionsModelTests.swift
+++ b/LocusTests/ExtensionsModelTests.swift
@@ -43,13 +43,16 @@ final class ExtensionsModelTests: XCTestCase {
         let model = makeModel()
         model.ingest("extensions_changed", [:])
         model.ingest("mcp_status", [:])
+        // Wait for the end of the refresh, not its start. The stub records a
+        // request when it begins loading, so waiting on the path alone can
+        // observe the request before its response has been handled — which is
+        // what made this test fail on a loaded runner and pass locally.
         try await waitUntil(
-            BackendStub.requestPaths.contains("/api/extensions"),
+            model.extensionErrorMessage != nil,
             timeoutMessage: "refresh never fired"
         )
         // Two rapid events coalesce into one debounced refresh.
         XCTAssertEqual(BackendStub.requestPaths.filter { $0 == "/api/extensions" }.count, 1)
-        XCTAssertNotNil(model.extensionErrorMessage, "an unstubbed refresh surfaces its error")
     }
 
     func testMCPAuthRequiredSurfacesErrorAndToast() {

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -1791,11 +1791,14 @@ final class LocusUITests: XCTestCase {
 
         agents.click()
         XCTAssertTrue(waitUntil { agents.isSelected })
-        // The creation button keeps its identity in Agents mode: New chat
-        // there starts the selected agent's next chat.
-        XCTAssertTrue(waitUntil { newChat.value as? String == "Agent chat" })
-        XCTAssertEqual(newChat.label, "New chat")
+        // Each destination creates the object it is about, so the primary
+        // button becomes New agent rather than another chat.
+        let newAgent = anyElement("sidebar.newAgent")
+        XCTAssertTrue(newAgent.waitForExistence(timeout: 3))
+        XCTAssertEqual(newAgent.label, "New agent")
+        XCTAssertFalse(anyElement("sidebar.newSession").exists)
         XCTAssertFalse(anyElement("sidebar.newTask").exists)
+        // One name for the sheet, in both destinations.
         XCTAssertEqual(configureAgent.label, "Manage Agents")
 
         configureAgent.click()
@@ -1817,11 +1820,11 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(anyElement("inspector.tab.agent").exists)
         XCTAssertTrue(anyElement("inspector.tab.plan").exists, "Overview stays open beside the agent")
 
-        // Agents mode keeps the Ask-mode controls: New chat with its plus
-        // glyph, Manage Agents with the Configure Agent glyph.
-        let newChat = anyElement("sidebar.newSession")
-        XCTAssertTrue(newChat.exists)
-        XCTAssertEqual(newChat.label, "New chat")
+        // Agents mode creates agents; chatting with one is a per-agent action.
+        let newAgent = anyElement("sidebar.newAgent")
+        XCTAssertTrue(newAgent.exists)
+        XCTAssertEqual(newAgent.label, "New agent")
+        XCTAssertFalse(anyElement("sidebar.newSession").exists)
         XCTAssertFalse(anyElement("sidebar.newTask").exists)
         let manage = anyElement("sidebar.configureAgent")
         XCTAssertTrue(manage.exists)
@@ -1846,8 +1849,17 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(anyElement("agentOverview.stats.chats").exists)
         XCTAssertTrue(anyElement("agentOverview.source").exists)
         XCTAssertTrue(anyElement("agentOverview.instruction").exists)
-        XCTAssertTrue(anyElement("agentOverview.chat.seed-agent-chat").exists)
-        XCTAssertTrue(anyElement("agentOverview.chat.seed-agent-chat-older").exists)
+        // Exactly one chat receives events, and the panel says which.
+        let eventChat = anyElement("agentOverview.chat.seed-agent-chat")
+        XCTAssertTrue(eventChat.exists)
+        XCTAssertTrue(
+            eventChat.label.contains("receives events"),
+            "the event chat is named as such, not left to guesswork"
+        )
+        let sideChat = anyElement("agentOverview.chat.seed-agent-chat-older")
+        XCTAssertTrue(sideChat.exists)
+        XCTAssertFalse(sideChat.label.contains("receives events"))
+        XCTAssertTrue(anyElement("agentOverview.chats.explainer").exists)
         XCTAssertTrue(anyElement("agentOverview.event.seed-delivery-done").exists)
         XCTAssertTrue(anyElement("agentOverview.event.seed-delivery-failed.retry").exists)
 
@@ -1857,13 +1869,46 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(anyElement("plan.context").waitForExistence(timeout: 3))
         XCTAssertTrue(waitForDisappearance(anyElement("inspector.rail.agent")))
         XCTAssertTrue(waitForDisappearance(anyElement("inspector.tab.agent")))
-        XCTAssertEqual(anyElement("sidebar.configureAgent").label, "Configure Agent")
+        // The sheet has one name in both destinations now.
+        XCTAssertEqual(anyElement("sidebar.configureAgent").label, "Manage Agents")
         XCTAssertEqual(anyElement("sidebar.newSession").label, "New chat")
 
         anyElement("sidebar.mode.agents").click()
         XCTAssertTrue(anyElement("agentOverview.identity").waitForExistence(timeout: 3))
         XCTAssertTrue(anyElement("inspector.tab.agent").exists)
         XCTAssertTrue(anyElement("inspector.rail.agent").exists)
+    }
+
+    func testAStoppedAgentReadsDifferentlyFromAPausedOneInSidebarAndFleet() {
+        relaunchWithAgentFixture("fleet")
+
+        // The fixture's third agent was switched off by Locus after a failure.
+        let stopped = anyElement("agent.seed-stopped-agent")
+        XCTAssertTrue(stopped.waitForExistence(timeout: Self.launchContentTimeout))
+        let spoken = stopped.label + " " + (stopped.value as? String ?? "")
+        XCTAssertTrue(spoken.contains("Stopped"), "Locus stopping an agent is not the same as pausing it")
+        XCTAssertTrue(spoken.contains("chat"), "an agent's conversations are chats, not tasks")
+
+        // The fleet ranks it above the healthy agents and repeats the state.
+        let fleetRow = anyElement("agentOverview.fleet.seed-stopped-agent")
+        XCTAssertTrue(fleetRow.waitForExistence(timeout: 3))
+        XCTAssertTrue(fleetRow.label.contains("Stopped"))
+        XCTAssertLessThan(
+            fleetRow.frame.minY,
+            anyElement("agentOverview.fleet.seed-agent").frame.minY,
+            "an agent that needs a person comes first"
+        )
+        let summary = anyElement("agentOverview.fleet.summary")
+        XCTAssertTrue(
+            (summary.label + " " + (summary.value as? String ?? "")).contains("stopped by Locus")
+        )
+
+        // Per-agent actions live on the agent, where which agent is unambiguous.
+        stopped.rightClick()
+        XCTAssertTrue(
+            app.menuItems["agent.seed-stopped-agent.newChat"].waitForExistence(timeout: 3)
+                || app.descendants(matching: .any)["agent.seed-stopped-agent.newChat"].exists
+        )
     }
 
     func testAskAgentsDestinationKeepsConversationWorkControlsAvailable() {
@@ -1888,8 +1933,8 @@ final class LocusUITests: XCTestCase {
 
         agents.click()
         XCTAssertTrue(waitUntil { agents.isSelected })
-        let newChat = anyElement("sidebar.newSession")
-        XCTAssertTrue(waitUntil { newChat.value as? String == "Agent chat" })
+        XCTAssertTrue(anyElement("sidebar.newAgent").waitForExistence(timeout: 3))
+        XCTAssertFalse(anyElement("sidebar.newSession").exists)
         XCTAssertFalse(anyElement("sidebar.newTask").exists)
         XCTAssertTrue(app.textViews["composer.input"].exists)
         XCTAssertTrue(anyElement("composer.context").exists)
@@ -1897,8 +1942,8 @@ final class LocusUITests: XCTestCase {
 
         ask.click()
         XCTAssertTrue(waitUntil { ask.isSelected })
-        XCTAssertTrue(waitUntil { newChat.value as? String == "Chat" })
-        XCTAssertFalse(anyElement("sidebar.newTask").exists)
+        XCTAssertTrue(anyElement("sidebar.newSession").waitForExistence(timeout: 3))
+        XCTAssertFalse(anyElement("sidebar.newAgent").exists)
     }
 
     func testWorkspaceActionsSitBesideModelPickerAndRailMoreMenuRestoresTabs() {
@@ -3064,9 +3109,11 @@ final class LocusUITests: XCTestCase {
         return XCTWaiter().wait(for: [gone], timeout: timeout) == .completed
     }
 
-    private func relaunchWithAgentFixture() {
+    /// `variant` "1" opens on an agent's chat; "fleet" leaves an ordinary chat
+    /// selected so the Agent panel shows every configured agent.
+    private func relaunchWithAgentFixture(_ variant: String = "1") {
         app.terminate()
-        app.launchEnvironment["LOCUS_UI_TESTING_AGENT_FIXTURE"] = "1"
+        app.launchEnvironment["LOCUS_UI_TESTING_AGENT_FIXTURE"] = variant
         app.launch()
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
     }


### PR DESCRIPTION
Phase 1 of an audit of the agent side. Three read-only explorers mapped the backend state machine, every user-facing surface, and the vocabulary; this lands the findings where the interface was asserting things the system does not do, plus the naming question you raised.

## The naming decision

**Neither "New chat" nor "New task": in Agents mode the primary button is now "New agent", and ⌘N creates one.**

The button created a conversation that never receives an event, so both names misled. Its help text promised "the selected agent", but the sidebar has no selection — `agentSession(for:in:)` silently picked whichever agent chat was modified last. And "task" already names six unrelated things here. Each destination now creates the object it is about: a chat in Ask, an agent in Agents. Chatting with a particular agent moved to that agent's row and the Agent panel, where the agent is unambiguous.

## What was untrue, and now is not

**Which chat receives events.** Every delivery is dispatched into `trigger.target_session_id`, but nothing said so, and the empty state read "matching events also start one". The event chat now carries an `EVENTS` badge in the panel, the section explains the two kinds of chat once, and an agent whose event chat was deleted says so instead of looking healthy.

**Stopped versus paused.** A dispatch failure calls `pause_event_trigger`, so Locus disables the trigger itself. `status(for:)` checked `lastError` before `enabled`, collapsing both into "Needs attention" with a Resume button. The four `enabled`/`lastError` combinations now mean four things: active, paused by you, stopped by Locus, and failing but still listening. Resume becomes the prominent action on a stopped agent.

**Silence when an agent stops.** `ScheduleModel` announces an automatic pause; `EventAutomationModel` had no equivalent, so an agent could stop working with no notification at all. It now raises the same toast and inactive-app notification when a refresh sees a trigger newly stopped.

**Backend text as status.** Because the dispatch failure re-raises its HTTP detail into `last_error`, strings like "the target chat checkout is unavailable" became the agent's status line. Those are translated now, and anything unrecognized is at least sentence-cased.

## First run

The trigger editor had a dead end: with no sources connected the picker offered only "Choose a connection", yet Activate was enabled and always failed in a toast. It can now connect a source without leaving the editor (and selects it), names the next missing requirement above the form, and blocks the save until it would succeed. The instruction field — the point of the whole feature — gained a label and a placeholder.

## Smaller corrections

The sidebar footer counted agent chats under a label that said "Agents"; it counts agents. An agent's chats are called chats, not tasks, in the accessibility value. The agent row gained a status glyph and a context menu with New Chat, Edit, Pause/Resume, and Delete. The destination option that creates the event-receiving chat is no longer called a "task". One sheet has one name, "Manage Agents", everywhere. The fleet's two buttons that went to the same place now go to different ones.

## Verification

Full unit suite (1027 tests) and five agent UI tests pass, including a new one covering a system-stopped agent. Design-system audit, protocol manifest, and project generation are clean. Checked visually in light and dark at 280pt and 340pt inspector widths.

## Not in this PR

Phase 2 makes schedules first-class agents (they are configured beside agents but never appear in Agents mode), stops an edit silently re-pointing an agent's model to whatever the app is currently using, and guards deletion of an agent's event chat, which today bricks the agent. Deferred after that: the source/connection/connector and delivery/event/run vocabulary, agent markers in the Activity Center, price-alert first-quote behaviour, and documentation, which does not mention this feature at all.