### PR TITLE
feat: schedules are agents with one dedicated chat

### DIFF
--- a/Locus/AgentOverviewModel.swift
+++ b/Locus/AgentOverviewModel.swift
@@ -1,10 +1,124 @@
 import Foundation
 
-/// One persistent agent, projected for the inspector's Agent tab: its trigger
-/// and source, the chats it owns, and the events that reached it. Assembled
-/// from state the app already holds — the automation model, the session
-/// catalog, and the worker table — so the tab needs no backend call of its
-/// own and the projection is testable as a pure function.
+/// The record that wakes an agent. Event and price agents are triggers;
+/// scheduled agents are schedules. Both own one dedicated chat that every
+/// event or run continues, and both can be paused by a person or stopped by
+/// Locus after a failure.
+enum AgentDefinition: Equatable {
+    case trigger(EventTrigger)
+    case schedule(ScheduledTask)
+
+    var id: String {
+        switch self {
+        case .trigger(let trigger): trigger.id
+        case .schedule(let task): task.id
+        }
+    }
+
+    var name: String {
+        switch self {
+        case .trigger(let trigger): trigger.name
+        case .schedule(let task): task.name
+        }
+    }
+
+    var enabled: Bool {
+        switch self {
+        case .trigger(let trigger): trigger.enabled
+        case .schedule(let task): task.enabled
+        }
+    }
+
+    var lastError: String? {
+        switch self {
+        case .trigger(let trigger): trigger.lastError
+        case .schedule(let task): task.lastError
+        }
+    }
+
+    var mode: WorkMode {
+        switch self {
+        case .trigger(let trigger): trigger.mode
+        case .schedule(let task): task.mode
+        }
+    }
+
+    var createdAt: Double {
+        switch self {
+        case .trigger(let trigger): trigger.createdAt
+        case .schedule(let task): task.createdAt
+        }
+    }
+
+    /// When the agent last did something: the last event for a trigger, the
+    /// last run for a schedule.
+    var lastActivityAt: Double? {
+        switch self {
+        case .trigger(let trigger): trigger.lastEventAt
+        case .schedule(let task): task.lastRunAt
+        }
+    }
+
+    var trigger: EventTrigger? {
+        if case .trigger(let trigger) = self { return trigger }
+        return nil
+    }
+
+    var schedule: ScheduledTask? {
+        if case .schedule(let task) = self { return task }
+        return nil
+    }
+
+    var isSchedule: Bool { schedule != nil }
+
+    /// The words this kind of agent is described in. A schedule has runs on a
+    /// cadence; a trigger has events from a source.
+    var vocabulary: Vocabulary { isSchedule ? .runs : .events }
+
+    /// Whichever record carries this agent id, or nothing once it is deleted.
+    static func resolve(
+        agentID: String?,
+        triggers: [EventTrigger],
+        schedules: [ScheduledTask]
+    ) -> AgentDefinition? {
+        guard let agentID, !agentID.isEmpty else { return nil }
+        if let trigger = triggers.first(where: { $0.id == agentID }) { return .trigger(trigger) }
+        if let task = schedules.first(where: { $0.id == agentID }) { return .schedule(task) }
+        return nil
+    }
+
+    /// "Incoming Event", "Price Alert", or "Schedule".
+    var kindTitle: String {
+        switch self {
+        case .trigger(let trigger): trigger.triggerKind.title
+        case .schedule: "Schedule"
+        }
+    }
+}
+
+/// What an agent's arrivals are called. A schedule's chat receives runs on a
+/// cadence; a trigger's receives events from a source. Every surface that
+/// names them reads from here, so the two kinds never borrow each other's
+/// words.
+struct Vocabulary: Equatable {
+    let arrival: String
+    let arrivals: String
+    let record: String
+    let badge: String
+
+    static let events = Vocabulary(
+        arrival: "event", arrivals: "events", record: "trigger", badge: "EVENTS"
+    )
+    static let runs = Vocabulary(
+        arrival: "run", arrivals: "runs", record: "schedule", badge: "RUNS"
+    )
+}
+
+/// One persistent agent, projected for the inspector's Agent tab: what wakes
+/// it, the chats it owns, and the events or runs that reached it. Assembled
+/// from state the app already holds — the automation and schedule models, the
+/// session catalog, and the worker table — so the tab needs no backend call of
+/// its own and the projection is testable as a pure function.
 struct AgentOverview: Equatable {
     enum Status: Equatable {
         case active
@@ -12,10 +126,11 @@ struct AgentOverview: Equatable {
         case paused
         /// Locus stopped it after a failure and will not restart it by itself.
         case stopped
-        /// Still listening, but the last event did not get through.
+        /// Still listening, but the last event or run did not get through.
         case failing
         case fired
-        /// The chats survived but their trigger was deleted or never loaded.
+        /// The chats survived but their trigger or schedule was deleted or
+        /// never loaded.
         case missingTrigger
 
         var title: String {
@@ -23,20 +138,34 @@ struct AgentOverview: Equatable {
             case .active: "Active"
             case .paused: "Paused"
             case .stopped: "Stopped"
-            case .failing: "Last event failed"
+            case .failing: "Last run failed"
             case .fired: "Fired"
             case .missingTrigger: "No trigger"
             }
         }
 
-        var detail: String {
+        func title(for vocabulary: Vocabulary = .events) -> String {
+            self == .failing ? "Last \(vocabulary.arrival) failed" : title
+        }
+
+        func detail(for vocabulary: Vocabulary = .events) -> String {
             switch self {
-            case .active: "Listening for matching events"
-            case .paused: "You paused this agent. Events are recorded but no chat starts."
-            case .stopped: "Locus stopped this agent after a failure. Resume to start listening again."
-            case .failing: "The last event did not get through. The agent is still listening."
+            case .active:
+                vocabulary == .runs ? "Running on schedule" : "Listening for matching events"
+            case .paused:
+                vocabulary == .runs
+                    ? "You paused this agent. It skips its scheduled runs until you resume it."
+                    : "You paused this agent. Events are recorded but no chat starts."
+            case .stopped:
+                vocabulary == .runs
+                    ? "Locus stopped this agent after a failure. Resume to run on schedule again."
+                    : "Locus stopped this agent after a failure. Resume to start listening again."
+            case .failing:
+                vocabulary == .runs
+                    ? "The last run did not get through. The agent is still scheduled."
+                    : "The last event did not get through. The agent is still listening."
             case .fired: "This one-shot alert already fired; re-arm to watch again"
-            case .missingTrigger: "The trigger behind these chats no longer exists"
+            case .missingTrigger: "The \(vocabulary.record) behind these chats no longer exists"
             }
         }
 
@@ -58,51 +187,82 @@ struct AgentOverview: Equatable {
         let isCurrent: Bool
         let isRunning: Bool
         let startedAt: Date?
-        /// Every delivery is dispatched into the trigger's one target chat, so
-        /// exactly one of an agent's chats receives events and the rest are
-        /// side conversations a person started.
+        /// Every event or run continues the agent's one dedicated chat, so
+        /// exactly one of an agent's chats receives them and the rest are side
+        /// conversations a person started.
         var isEventTarget = false
 
         var id: String { session.id }
     }
 
+    /// One thing that reached the agent: an event delivery for a trigger, or
+    /// an occurrence for a schedule. Both render through the same row.
     struct Event: Identifiable, Equatable {
-        let delivery: EventDelivery
+        let id: String
+        let title: String
+        let stateTitle: String
+        let isFailed: Bool
+        let isInFlight: Bool
+        /// A run whose slot passed because the one before it was still going.
+        /// Neither a success nor a failure, and it is drawn as neither.
+        var isSkipped = false
+        let canRetry: Bool
+        let observedPrice: String?
+        let receivedAt: Date
+        let sessionID: String?
+        let error: String?
+        let attempt: Int
+        let sourceSymbol: String
+        /// Retry acts on the delivery; schedule occurrences have no retry.
+        let delivery: EventDelivery?
 
-        var id: String { delivery.id }
-
-        var title: String {
+        init(delivery: EventDelivery) {
             let subject = delivery.event.subject.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !subject.isEmpty { return subject }
             let text = delivery.event.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !text.isEmpty { return String(text.prefix(120)) }
-            return delivery.event.eventType.isEmpty ? "Event" : delivery.event.eventType
+            let fallback = delivery.event.eventType.isEmpty ? "Event" : delivery.event.eventType
+            id = delivery.id
+            title = !subject.isEmpty ? subject : (!text.isEmpty ? String(text.prefix(120)) : fallback)
+            // Delivery states are backend strings; the terminal ones are stable
+            // (`TERMINAL_STATES` in runstore), the rest describe dispatch.
+            stateTitle = delivery.state.replacingOccurrences(of: "_", with: " ").capitalized
+            isFailed = delivery.error != nil
+                || ["failed", "interrupted", "cancelled"].contains(delivery.state)
+            isInFlight = ["pending", "claiming", "queued", "dispatching", "running"]
+                .contains(delivery.state)
+            canRetry = ["failed", "interrupted", "cancelled"].contains(delivery.state)
+            observedPrice = delivery.event.eventType == "price.quote"
+                ? delivery.event.data["price"]?.string : nil
+            receivedAt = Date(timeIntervalSince1970: delivery.receivedAt)
+            sessionID = delivery.sessionID
+            error = delivery.error
+            attempt = delivery.attempt
+            sourceSymbol = delivery.source.symbol
+            self.delivery = delivery
         }
 
-        /// Delivery states are backend strings; the terminal ones are stable
-        /// (`TERMINAL_STATES` in runstore), the rest describe dispatch.
-        var stateTitle: String {
-            delivery.state.replacingOccurrences(of: "_", with: " ").capitalized
+        init(occurrence: ScheduleOccurrence) {
+            let when = Date(timeIntervalSince1970: occurrence.scheduledFor)
+            id = occurrence.id
+            title = (occurrence.trigger == "manual" ? "Run now" : "Scheduled run")
+                + " · " + when.formatted(date: .abbreviated, time: .shortened)
+            let skipped = occurrence.state == "skipped"
+            isSkipped = skipped
+            stateTitle = occurrence.state.replacingOccurrences(of: "_", with: " ").capitalized
+            // An overlap with the run before it is a normal outcome, not a
+            // failure: the agent kept working, this slot simply passed.
+            isFailed = !skipped
+                && (occurrence.error != nil
+                    || ["failed", "interrupted", "cancelled"].contains(occurrence.state))
+            isInFlight = ["claiming", "queued", "dispatching", "running"].contains(occurrence.state)
+            canRetry = false
+            observedPrice = nil
+            receivedAt = when
+            sessionID = occurrence.sessionID
+            error = occurrence.error
+            attempt = 1
+            sourceSymbol = "calendar.badge.clock"
+            delivery = nil
         }
-
-        var isFailed: Bool {
-            delivery.error != nil || ["failed", "interrupted", "cancelled"].contains(delivery.state)
-        }
-
-        var isInFlight: Bool {
-            ["pending", "claiming", "queued", "dispatching", "running"].contains(delivery.state)
-        }
-
-        var canRetry: Bool {
-            ["failed", "interrupted", "cancelled"].contains(delivery.state)
-        }
-
-        var observedPrice: String? {
-            guard delivery.event.eventType == "price.quote" else { return nil }
-            return delivery.event.data["price"]?.string
-        }
-
-        var receivedAt: Date { Date(timeIntervalSince1970: delivery.receivedAt) }
     }
 
     struct Fact: Identifiable, Equatable {
@@ -113,9 +273,9 @@ struct AgentOverview: Equatable {
         var id: String { label }
     }
 
-    let triggerID: String
+    let agentID: String
     let name: String
-    let trigger: EventTrigger?
+    let definition: AgentDefinition?
     let connection: ConnectorConnection?
     let status: Status
     /// "Gmail · Incoming Event · Work" — the one-line identity under the name.
@@ -132,20 +292,27 @@ struct AgentOverview: Equatable {
     /// The live side of a price alert: last quote, side, and when it fired.
     let priceState: String?
 
+    var trigger: EventTrigger? { definition?.trigger }
+    var schedule: ScheduledTask? { definition?.schedule }
+    /// Whether this agent's arrivals are called events or runs.
+    var vocabulary: Vocabulary { definition?.vocabulary ?? .events }
     var currentChat: Chat? { chats.first(where: \.isCurrent) }
-    /// The chat every event lands in, when it still exists.
+    /// The chat every event or run lands in, when it still exists.
     var eventChat: Chat? { chats.first(where: \.isEventTarget) }
     /// The agent has chats but its event chat is gone — deleting it leaves the
     /// trigger pointing at nothing, which no amount of resuming repairs.
-    var hasLostEventChat: Bool { trigger != nil && eventChat == nil }
+    var hasLostEventChat: Bool { definition != nil && eventChat == nil }
     var runningChatCount: Int { chats.filter(\.isRunning).count }
     var isPriceAlert: Bool { trigger?.triggerKind == .price }
     var canRearm: Bool { isPriceAlert && trigger?.runtimeState.fired == true }
+    var canRunNow: Bool { schedule != nil }
 
     static let recentEventLimit = 8
 
     // MARK: Resolution
 
+    /// Trigger-only entry point kept for callers and tests that predate
+    /// scheduled agents.
     static func resolve(
         triggerID: String,
         trigger: EventTrigger?,
@@ -158,8 +325,37 @@ struct AgentOverview: Equatable {
         startedAt: [String: Date] = [:],
         now: Date = Date()
     ) -> AgentOverview {
+        resolve(
+            agentID: triggerID,
+            definition: trigger.map(AgentDefinition.trigger),
+            connections: connections,
+            actionConnections: actionConnections,
+            sessions: sessions,
+            deliveries: deliveries,
+            currentSessionID: currentSessionID,
+            runningSessionIDs: runningSessionIDs,
+            startedAt: startedAt,
+            now: now
+        )
+    }
+
+    static func resolve(
+        agentID: String,
+        definition: AgentDefinition?,
+        connections: [ConnectorConnection],
+        actionConnections: [ConnectorConnection] = [],
+        sessions: [SessionSummary],
+        deliveries: [EventDelivery],
+        occurrences: [ScheduleOccurrence] = [],
+        currentSessionID: String,
+        runningSessionIDs: Set<String>,
+        startedAt: [String: Date] = [:],
+        now: Date = Date()
+    ) -> AgentOverview {
+        let trigger = definition?.trigger
+        let schedule = definition?.schedule
         let ownChats = sessions
-            .filter { $0.agentTriggerID == triggerID }
+            .filter { $0.agentTriggerID == agentID }
             .sorted { lhs, rhs in
                 if lhs.mtime != rhs.mtime { return lhs.mtime > rhs.mtime }
                 return lhs.id < rhs.id
@@ -171,26 +367,43 @@ struct AgentOverview: Equatable {
                 isCurrent: session.id == currentSessionID,
                 isRunning: runningSessionIDs.contains(session.id),
                 startedAt: startedAt[session.id],
-                isEventTarget: session.id == targetSessionID
+                isEventTarget: session.isAgentEventChat || session.id == targetSessionID
             )
         }
-        let name = trigger?.name.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        let name = definition?.name.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
             ?? ownChats.compactMap { $0.agentName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty }.first
             ?? ownChats.first?.displayTitle
             ?? "Agent"
         let connection = trigger.flatMap { trigger in
             connections.first { $0.id == trigger.connectionID }
         }
-        let ownDeliveries = deliveries
-            .filter { $0.triggerID == triggerID }
-            .sorted { $0.receivedAt > $1.receivedAt }
-        let events = ownDeliveries.prefix(recentEventLimit).map(Event.init)
-        let failedCount = ownDeliveries.filter { Event(delivery: $0).isFailed }.count
-        let lastEventAt = trigger?.lastEventAt.map { Date(timeIntervalSince1970: $0) }
-            ?? ownDeliveries.first.map { Date(timeIntervalSince1970: $0.receivedAt) }
 
-        let status = status(for: trigger)
-        let workspaceName = ownChats.compactMap(\.workspacePath).first
+        // Every event or run that reached the agent, newest first. The panel
+        // shows a handful, but the counts describe the whole history.
+        let allEvents: [Event]
+        let lastEventAt: Date?
+        if schedule != nil {
+            allEvents = occurrences
+                .filter { $0.scheduleID == agentID }
+                .sorted { $0.scheduledFor > $1.scheduledFor }
+                .map(Event.init(occurrence:))
+            lastEventAt = schedule?.lastRunAt.map { Date(timeIntervalSince1970: $0) }
+                ?? allEvents.first?.receivedAt
+        } else {
+            allEvents = deliveries
+                .filter { $0.triggerID == agentID }
+                .sorted { $0.receivedAt > $1.receivedAt }
+                .map(Event.init(delivery:))
+            lastEventAt = trigger?.lastEventAt.map { Date(timeIntervalSince1970: $0) }
+                ?? allEvents.first?.receivedAt
+        }
+        let events = Array(allEvents.prefix(recentEventLimit))
+        let eventCount = allEvents.count
+        let failedCount = allEvents.filter(\.isFailed).count
+
+        let status = status(for: definition)
+        let workspaceName = (ownChats.compactMap(\.workspacePath).first ?? schedule?.workspaceRoot)
+            .flatMap { $0.nilIfEmpty }
             .map { URL(fileURLWithPath: $0).lastPathComponent }
 
         var facts: [Fact] = []
@@ -220,49 +433,88 @@ struct AgentOverview: Equatable {
                 value: actions.isEmpty ? "Nothing — ingestion only" : actions.joined(separator: ", ")
             ))
         }
+        if let schedule {
+            facts.append(Fact(label: "Runs as", value: schedule.mode.title))
+            facts.append(Fact(
+                label: "Runner",
+                value: schedule.runner == .team
+                    ? (schedule.teamName?.nilIfEmpty ?? "Team") : "Solo"
+            ))
+            facts.append(Fact(label: "Environment", value: schedule.executionEnvironment.title))
+            facts.append(Fact(
+                label: "Model",
+                value: schedule.model.nilIfEmpty ?? "Not set",
+                isWarning: schedule.model.nilIfEmpty == nil
+            ))
+            facts.append(Fact(
+                label: "Next run",
+                value: schedule.nextRunDate.map {
+                    AgentOverviewFormatting.absolute($0, now: now)
+                } ?? (schedule.enabled ? "Not scheduled" : "Paused")
+            ))
+        }
         if let workspaceName {
             facts.append(Fact(label: "Workspace", value: workspaceName))
         }
-        if let trigger {
+        if let definition {
             facts.append(Fact(
                 label: "Created",
-                value: Date(timeIntervalSince1970: trigger.createdAt)
+                value: Date(timeIntervalSince1970: definition.createdAt)
                     .formatted(date: .abbreviated, time: .omitted)
             ))
         }
 
+        let filters: [String]
+        if let trigger {
+            filters = filterChips(for: trigger.filters, kind: trigger.triggerKind)
+        } else if let schedule {
+            filters = scheduleChips(for: schedule, now: now)
+        } else {
+            filters = []
+        }
+        let instruction = (trigger?.instruction ?? schedule?.prompt ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
         return AgentOverview(
-            triggerID: triggerID,
+            agentID: agentID,
             name: name,
-            trigger: trigger,
+            definition: definition,
             connection: connection,
             status: status,
-            summary: summary(trigger: trigger, connection: connection),
-            instruction: trigger?.instruction.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
-            filters: trigger.map { filterChips(for: $0.filters, kind: $0.triggerKind) } ?? [],
+            summary: summary(definition: definition, connection: connection),
+            instruction: instruction,
+            filters: filters,
             facts: facts,
             chats: chats,
-            events: Array(events),
-            eventCount: ownDeliveries.count,
+            events: events,
+            eventCount: eventCount,
             failedEventCount: failedCount,
             lastEventAt: lastEventAt,
-            lastError: (trigger?.lastError?.nilIfEmpty ?? connection?.lastError?.nilIfEmpty)
+            lastError: (definition?.lastError?.nilIfEmpty ?? connection?.lastError?.nilIfEmpty)
                 .map(humanizedError),
             priceState: trigger.flatMap { priceState(for: $0, now: now) }
         )
     }
 
     /// The backend records only `enabled` and a free-text `last_error`, but the
-    /// pair carries four distinct meanings. A disabled trigger with an error is
-    /// one Locus switched off itself (`pause_event_trigger` on a dispatch
-    /// failure); a disabled trigger without one is a deliberate pause.
-    static func status(for trigger: EventTrigger?) -> Status {
-        guard let trigger else { return .missingTrigger }
-        if let error = trigger.lastError, !error.isEmpty {
-            return trigger.enabled ? .failing : .stopped
+    /// pair carries four distinct meanings. A disabled record with an error is
+    /// one Locus switched off itself (a dispatch failure pauses the trigger or
+    /// schedule); a disabled record without one is a deliberate pause.
+    static func status(for definition: AgentDefinition?) -> Status {
+        guard let definition else { return .missingTrigger }
+        if let error = definition.lastError, !error.isEmpty {
+            return definition.enabled ? .failing : .stopped
         }
-        if trigger.triggerKind == .price, trigger.runtimeState.fired == true { return .fired }
-        return trigger.enabled ? .active : .paused
+        if let trigger = definition.trigger,
+           trigger.triggerKind == .price,
+           trigger.runtimeState.fired == true {
+            return .fired
+        }
+        return definition.enabled ? .active : .paused
+    }
+
+    static func status(for trigger: EventTrigger?) -> Status {
+        status(for: trigger.map(AgentDefinition.trigger))
     }
 
     /// Dispatch failures are re-raised as the agent's status line, so the raw
@@ -279,6 +531,8 @@ struct AgentOverview: Equatable {
                 "The agent's workspace folder is missing or was moved.",
             "the target chat checkout is unavailable":
                 "The agent's worktree checkout is missing.",
+            "the agent's checkout is unavailable":
+                "The agent's worktree checkout is missing.",
             "the target chat model is unavailable":
                 "The model this agent runs on is no longer available.",
             "the agent provider is not supported":
@@ -287,6 +541,10 @@ struct AgentOverview: Equatable {
                 "This configuration has no agent chat of its own.",
             "capability is disabled: event_triggers":
                 "Event agents are turned off in this build of Locus.",
+            "the scheduled workspace is no longer available":
+                "The agent's workspace folder is missing or was moved.",
+            "scheduled worktrees require a git repository":
+                "Worktree runs need the workspace to be a Git repository.",
         ]
         if let match = known[trimmed.lowercased()] { return match }
         guard let first = trimmed.first else { return trimmed }
@@ -294,11 +552,20 @@ struct AgentOverview: Equatable {
         return sentence.hasSuffix(".") ? sentence : sentence + "."
     }
 
+    static func summary(definition: AgentDefinition?, connection: ConnectorConnection?) -> String {
+        guard let definition else { return "Persistent agent" }
+        switch definition {
+        case .trigger(let trigger):
+            return [connection?.kind.title ?? "No source", trigger.triggerKind.title, trigger.mode.title]
+                .joined(separator: " · ")
+        case .schedule(let task):
+            return ["Schedule", AgentOverviewFormatting.rule(task.rule), task.mode.title]
+                .joined(separator: " · ")
+        }
+    }
+
     static func summary(trigger: EventTrigger?, connection: ConnectorConnection?) -> String {
-        guard let trigger else { return "Persistent agent" }
-        var parts = [connection?.kind.title ?? "No source", trigger.triggerKind.title]
-        parts.append(trigger.mode.title)
-        return parts.joined(separator: " · ")
+        summary(definition: trigger.map(AgentDefinition.trigger), connection: connection)
     }
 
     /// Human-readable filter chips. Every populated filter becomes one chip so
@@ -341,6 +608,27 @@ struct AgentOverview: Equatable {
         return chips
     }
 
+    /// The equivalent for a schedule: its cadence, when it next fires, and
+    /// anything about where it runs that a person would want to know.
+    static func scheduleChips(for task: ScheduledTask, now: Date) -> [String] {
+        var chips: [String] = []
+        if let next = task.nextRunDate, task.enabled {
+            chips.append("Next \(AgentOverviewFormatting.upcoming(next, now: now))")
+        } else if !task.enabled {
+            chips.append("Paused")
+        }
+        if task.executionEnvironment == .worktree {
+            chips.append("Runs in a worktree")
+        }
+        if task.timezone != TimeZone.current.identifier, !task.timezone.isEmpty {
+            chips.append(task.timezone)
+        }
+        if chips.isEmpty {
+            chips.append("No further runs")
+        }
+        return chips
+    }
+
     static func priceDescription(_ condition: PriceCondition) -> String {
         let symbol = condition.displaySymbol.nilIfEmpty
             ?? condition.providerSymbol.nilIfEmpty
@@ -375,9 +663,9 @@ struct AgentOverview: Equatable {
 }
 
 /// One row of the fleet list shown when no single agent is selected: every
-/// trigger the backend knows, whether or not it has started a chat yet.
+/// trigger and schedule the backend knows, whether or not it has a chat yet.
 struct AgentFleetEntry: Identifiable, Equatable {
-    let trigger: EventTrigger
+    let definition: AgentDefinition
     let connection: ConnectorConnection?
     let status: AgentOverview.Status
     let chatCount: Int
@@ -385,31 +673,37 @@ struct AgentFleetEntry: Identifiable, Equatable {
     let latestChat: SessionSummary?
     let lastEventAt: Date?
 
-    var id: String { trigger.id }
-    var summary: String { AgentOverview.summary(trigger: trigger, connection: connection) }
+    var id: String { definition.id }
+    var name: String { definition.name }
+    var trigger: EventTrigger? { definition.trigger }
+    var summary: String { AgentOverview.summary(definition: definition, connection: connection) }
 }
 
 enum AgentFleet {
     static func entries(
         triggers: [EventTrigger],
         connections: [ConnectorConnection],
+        schedules: [ScheduledTask] = [],
         sessions: [SessionSummary],
         runningSessionIDs: Set<String>
     ) -> [AgentFleetEntry] {
-        let chatsByTrigger = Dictionary(grouping: sessions.filter(\.isAgentChat)) {
+        let chatsByAgent = Dictionary(grouping: sessions.filter(\.isAgentChat)) {
             $0.agentTriggerID ?? ""
         }
-        return triggers
-            .map { trigger in
-                let chats = (chatsByTrigger[trigger.id] ?? []).sorted { $0.mtime > $1.mtime }
+        let definitions = triggers.map(AgentDefinition.trigger) + schedules.map(AgentDefinition.schedule)
+        return definitions
+            .map { definition in
+                let chats = (chatsByAgent[definition.id] ?? []).sorted { $0.mtime > $1.mtime }
                 return AgentFleetEntry(
-                    trigger: trigger,
-                    connection: connections.first { $0.id == trigger.connectionID },
-                    status: AgentOverview.status(for: trigger),
+                    definition: definition,
+                    connection: definition.trigger.flatMap { trigger in
+                        connections.first { $0.id == trigger.connectionID }
+                    },
+                    status: AgentOverview.status(for: definition),
                     chatCount: chats.count,
                     runningChatCount: chats.filter { runningSessionIDs.contains($0.id) }.count,
                     latestChat: chats.first,
-                    lastEventAt: trigger.lastEventAt.map { Date(timeIntervalSince1970: $0) }
+                    lastEventAt: definition.lastActivityAt.map { Date(timeIntervalSince1970: $0) }
                 )
             }
             .sorted { lhs, rhs in
@@ -418,7 +712,7 @@ enum AgentFleet {
                 let left = lhs.lastEventAt ?? .distantPast
                 let right = rhs.lastEventAt ?? .distantPast
                 if left != right { return left > right }
-                return lhs.trigger.name.localizedCaseInsensitiveCompare(rhs.trigger.name) == .orderedAscending
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
     }
 }
@@ -440,6 +734,21 @@ enum AgentOverviewFormatting {
         return date.formatted(date: .abbreviated, time: .omitted)
     }
 
+    /// The forward-looking twin of `relative`: "in 4m", "in 3h", "in 2d",
+    /// then a date. A past date reads as overdue rather than negative.
+    static func upcoming(_ date: Date, now: Date = Date()) -> String {
+        let seconds = date.timeIntervalSince(now)
+        if seconds < 0 { return "overdue" }
+        if seconds < 60 { return "in under a minute" }
+        let minutes = Int(seconds / 60)
+        if minutes < 60 { return "in \(minutes)m" }
+        let hours = minutes / 60
+        if hours < 24 { return "in \(hours)h" }
+        let days = hours / 24
+        if days < 7 { return "in \(days)d" }
+        return date.formatted(date: .abbreviated, time: .omitted)
+    }
+
     /// The companion to `relative`: a clock time for today, a date otherwise,
     /// short enough for a stat tile's caption.
     static func absolute(_ date: Date, now: Date = Date(), calendar: Calendar = .current) -> String {
@@ -447,6 +756,38 @@ enum AgentOverviewFormatting {
             return date.formatted(date: .omitted, time: .shortened)
         }
         return date.formatted(date: .abbreviated, time: .omitted)
+    }
+
+    /// A schedule's cadence in words. Times are written as saved (HH:mm),
+    /// which keeps the output stable across locales and lets tests pin it.
+    static func rule(_ rule: ScheduleRule) -> String {
+        let time = String(format: "%02d:%02d", rule.hour ?? 0, rule.minute ?? 0)
+        switch rule.kind {
+        case .once:
+            if let at = rule.at {
+                return "Once on " + Date(timeIntervalSince1970: at)
+                    .formatted(date: .abbreviated, time: .shortened)
+            }
+            return "Once"
+        case .daily:
+            return "Daily at \(time)"
+        case .weekdays:
+            return "Weekdays at \(time)"
+        case .weekly:
+            return "Weekly on \(weekdayName(rule.weekday ?? 0)) at \(time)"
+        case .interval:
+            let every = max(rule.every ?? 1, 1)
+            let unit = rule.unit ?? .hours
+            let noun = every == 1 ? String(unit.rawValue.dropLast()) : unit.rawValue
+            return every == 1 ? "Every \(noun)" : "Every \(every) \(noun)"
+        }
+    }
+
+    /// Schedules store Monday-based weekdays (0 = Monday), the Python
+    /// convention the backend evaluates against.
+    static func weekdayName(_ mondayBased: Int) -> String {
+        let names = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+        return names[max(0, min(mondayBased, names.count - 1))]
     }
 
     static func chatCount(_ count: Int) -> String {

--- a/Locus/AppModel+AgentChats.swift
+++ b/Locus/AppModel+AgentChats.swift
@@ -38,28 +38,128 @@ extension AppModel {
         presentConfigureAgent(draftText: draftText)
     }
 
-    /// Starts another chat for an agent. Without a trigger id it uses the
+    /// The trigger or schedule behind an agent id, whichever kind it is.
+    func agentDefinition(for agentID: String?) -> AgentDefinition? {
+        AgentDefinition.resolve(
+            agentID: agentID,
+            triggers: eventAutomations.triggers,
+            schedules: schedule.scheduledTasks
+        )
+    }
+
+    /// Whether both stores have answered. Until each has, a missing
+    /// definition says nothing about whether the agent still exists — one
+    /// store having loaded tells us nothing about the other's kind.
+    private var agentDefinitionsLoaded: Bool {
+        eventAutomations.hasLoaded && schedule.hasLoaded
+    }
+
+    /// Starts a side conversation for an agent. Without an id it uses the
     /// current chat's agent, then the most recent agent; with no agents at
-    /// all it opens Configure Agent, which is where one is made.
+    /// all it opens Manage Agents, which is where one is made.
     func newAgentChat(triggerID: String? = nil) {
         let snapshot = sessionCatalog.snapshot
         guard let agent = agentSession(for: triggerID, in: snapshot) else {
             presentConfigureAgent(draftText: draftText)
             return
         }
-        // Chats outlive their trigger. Once the trigger list has loaded, a
-        // missing trigger means the backend would refuse the chat anyway.
-        let triggers = eventAutomations.triggers
-        if !triggers.isEmpty, !triggers.contains(where: { $0.id == agent.agentTriggerID }) {
-            showToast("This agent's trigger was deleted. Configure a new agent to start chats.")
+        // Chats outlive their agent. Once the definitions are in, a missing
+        // one means the backend would refuse the chat anyway.
+        if agentDefinition(for: agent.agentTriggerID) == nil, agentDefinitionsLoaded {
+            showToast("This agent was deleted. Configure a new agent to start chats.")
             return
         }
         let number = snapshot.sessions.filter {
             $0.agentTriggerID == agent.agentTriggerID
         }.count + 1
         Task { @MainActor [weak self] in
-            await self?.eventAutomations.createTask(for: agent, name: "Chat \(number)")
+            await self?.openAgentSideChat(for: agent, name: "Chat \(number)")
         }
+    }
+
+    /// Opens a side chat once it is known which kind of agent owns it. The two
+    /// kinds have different endpoints, so guessing before both stores have
+    /// answered would post a schedule's chat to the trigger route.
+    private func openAgentSideChat(for agent: SessionSummary, name: String) async {
+        var definition = agentDefinition(for: agent.agentTriggerID)
+        if definition == nil, !agentDefinitionsLoaded {
+            await eventAutomations.refresh(announceFailure: false)
+            await schedule.refreshScheduledTasks(announceFailure: false)
+            definition = agentDefinition(for: agent.agentTriggerID)
+        }
+        guard let definition else {
+            showToast("This agent was deleted. Configure a new agent to start chats.")
+            return
+        }
+        if let task = definition.schedule {
+            await createScheduleChat(task, name: name)
+            return
+        }
+        await eventAutomations.createTask(for: agent, name: name)
+    }
+
+    /// A schedule's side chat comes from its own endpoint; it shares the
+    /// agent's identity, workspace, and model but never receives a run.
+    func createScheduleChat(_ task: ScheduledTask, name: String) async {
+        do {
+            let response: AgentTargetSessionResponse = try await backend.post(
+                "/api/schedules/\(task.id)/tasks",
+                body: ["name": name],
+                as: AgentTargetSessionResponse.self
+            )
+            await refreshMetadata()
+            sidebarDestination = .agents
+            resume(response.session)
+            showToast("New chat opened in \(task.name)")
+        } catch {
+            showToast("Could not start a chat for this agent: \(error.localizedDescription)")
+        }
+    }
+
+    /// The per-agent actions, routed by kind so the sidebar row and the Agent
+    /// panel do not each need to know which store an agent lives in.
+    func editAgent(_ definition: AgentDefinition) {
+        switch definition {
+        case .trigger(let trigger):
+            editAgentTrigger(trigger, isDedicatedAgent: true)
+        case .schedule(let task):
+            presentScheduleEditor(task: task)
+        }
+    }
+
+    func setAgentEnabled(_ definition: AgentDefinition, enabled: Bool) {
+        switch definition {
+        case .trigger(let trigger):
+            eventAutomations.setTrigger(trigger, enabled: enabled)
+        case .schedule(let task):
+            schedule.setScheduleEnabled(task, enabled: enabled)
+        }
+    }
+
+    func deleteAgent(_ definition: AgentDefinition) {
+        switch definition {
+        case .trigger(let trigger):
+            eventAutomations.deleteTrigger(trigger)
+        case .schedule(let task):
+            schedule.deleteSchedule(task)
+        }
+    }
+
+    /// Only schedules can be run on demand; an event agent waits for events.
+    func runAgentNow(_ definition: AgentDefinition) {
+        if case .schedule(let task) = definition {
+            schedule.runScheduleNow(task)
+        }
+    }
+
+    /// The agent whose events land in this chat, if that agent still exists.
+    /// Deleting the chat would strand the agent, so callers refuse.
+    func agentOwningEventChat(_ session: SessionSummary) -> AgentDefinition? {
+        if let trigger = eventAutomations.triggers.first(where: { $0.targetSessionID == session.id }) {
+            return .trigger(trigger)
+        }
+        guard session.isAgentEventChat else { return nil }
+        return agentDefinition(for: session.agentTriggerID)
     }
 
     /// Any existing chat of the agent, which is what the backend's task

--- a/Locus/AppModel+ChatOrganization.swift
+++ b/Locus/AppModel+ChatOrganization.swift
@@ -234,6 +234,17 @@ extension AppModel {
             showToast("Wait for this chat to stop before deleting it")
             return
         }
+        // Deleting the chat an agent's events land in strands the agent: every
+        // later dispatch fails and pauses it, and even resuming fails because
+        // the backend validates the target first. The backend refuses too;
+        // this keeps the explanation in the app's own words.
+        if let owner = agentOwningEventChat(session) {
+            showToast(
+                "This chat receives \(owner.name)'s \(owner.vocabulary.arrivals)."
+                    + " Delete the agent first."
+            )
+            return
+        }
         guard !isBusy, !hasPendingPermission, !pendingSessionReset else {
             showToast("Finish the active run before deleting a chat")
             return

--- a/Locus/AppModel+UITestFixtures.swift
+++ b/Locus/AppModel+UITestFixtures.swift
@@ -459,6 +459,8 @@ extension AppModel {
         if let variant = ProcessInfo.processInfo.environment["LOCUS_UI_TESTING_AGENT_FIXTURE"],
            !variant.isEmpty {
             seedAgentFixture(workspace: workspace, selectsAgentChat: variant != "fleet")
+            // "schedule" lands on the scheduled agent's chat so its panel shows.
+            if variant == "schedule" { currentSessionID = "seed-schedule-chat" }
         }
         seedSessionOverviewUITest(workspace: workspace)
         if ProcessInfo.processInfo.environment["LOCUS_UI_TESTING_LANDING"] == "1" {
@@ -591,7 +593,10 @@ extension AppModel {
             title: "Chat 2",
             cwd: workspace,
             agentTriggerID: triggerID,
-            agentName: "Inbox Triage"
+            agentName: "Inbox Triage",
+            agentPrimary: true,
+            model: "qwen3:8b",
+            provider: "ollama"
         )
         let olderChat = SessionSummary(
             id: "seed-agent-chat-older",
@@ -793,6 +798,80 @@ extension AppModel {
             connections: [connection, priceFeed],
             triggers: [trigger, priceAlert, stoppedAgent],
             deliveries: deliveries
+        )
+
+        // A scheduled agent: one dedicated chat its runs continue, plus the
+        // occurrences that reached it, so the schedule kind is on screen.
+        let scheduleID = "seed-schedule"
+        let scheduleChat = SessionSummary(
+            id: "seed-schedule-chat",
+            name: "seed-schedule-chat.jsonl",
+            preview: "Review the workspace and summarize what changed.",
+            mtime: now - 3_600,
+            size: 900,
+            title: "Morning Review",
+            cwd: workspace,
+            agentTriggerID: scheduleID,
+            agentName: "Morning Review",
+            agentPrimary: true,
+            model: "qwen3:8b",
+            provider: "ollama"
+        )
+        sessions.append(scheduleChat)
+        let morningReview = ScheduledTask(
+            id: scheduleID,
+            name: "Morning Review",
+            prompt: "Review the workspace and summarize what changed since yesterday.",
+            workspaceRoot: workspace,
+            mode: .work,
+            executionEnvironment: .local,
+            runner: .solo,
+            teamID: nil,
+            teamName: nil,
+            provider: "ollama",
+            providerAccountID: nil,
+            model: "qwen3:8b",
+            timezone: TimeZone.current.identifier,
+            rule: ScheduleRule(kind: .weekdays, hour: 9, minute: 0),
+            enabled: true,
+            nextRunAt: now + 43_200,
+            createdAt: now - 604_800,
+            updatedAt: now - 3_600,
+            lastRunAt: now - 3_600,
+            lastRunID: "seed-schedule-run-2",
+            lastError: nil
+        )
+        let occurrences = [
+            ScheduleOccurrence(
+                id: "seed-schedule-occurrence-2",
+                scheduleID: scheduleID,
+                scheduleName: "Morning Review",
+                scheduledFor: now - 3_600,
+                trigger: "due",
+                state: "queued",
+                sessionID: scheduleChat.id,
+                runID: "seed-schedule-run-2",
+                error: nil,
+                createdAt: now - 3_600,
+                updatedAt: now - 3_500
+            ),
+            ScheduleOccurrence(
+                id: "seed-schedule-occurrence-1",
+                scheduleID: scheduleID,
+                scheduleName: "Morning Review",
+                scheduledFor: now - 90_000,
+                trigger: "due",
+                state: "skipped",
+                sessionID: scheduleChat.id,
+                runID: nil,
+                error: "Skipped: the previous run in this agent's chat was still in progress.",
+                createdAt: now - 90_000,
+                updatedAt: now - 89_900
+            ),
+        ]
+        schedule.seedForUITesting(
+            tasks: [morningReview],
+            occurrences: [scheduleID: occurrences]
         )
         // Set last: the destination change is what swaps the open Overview
         // for the Agent tab, exactly as choosing Agents in the sidebar does.

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -1202,6 +1202,14 @@ final class AppModel: ObservableObject {
         account?.id.uuidString == settings.activeAccountID && model == selectedModel
     }
 
+    /// The model an agent created or repointed right now would run on: what
+    /// `agentProviderRoute` actually sends, without the picker's decoration.
+    /// A team is not an agent route, so its members never appear here.
+    var agentRouteModel: String {
+        guard let account = activeAccount else { return selectedModel }
+        return routedModel(for: account)
+    }
+
     /// The closed picker's label. With an account it leads with the account's
     /// short name, because the model name alone no longer says where it runs.
     var modelPickerLabel: String {

--- a/Locus/EventAutomationModel.swift
+++ b/Locus/EventAutomationModel.swift
@@ -18,6 +18,9 @@ final class EventAutomationModel: ObservableObject {
     @Published private(set) var isRefreshing = false
     @Published private(set) var isSaving = false
     @Published private(set) var lastError: String?
+    /// Whether the trigger list has ever loaded. Until it has, an agent that
+    /// is not in `triggers` may simply not have arrived yet.
+    @Published private(set) var hasLoaded = false
 
     private var backend: BackendService?
     private let credentials: ConnectorCredentialStore
@@ -79,6 +82,7 @@ final class EventAutomationModel: ObservableObject {
         self.connections = connections
         self.triggers = triggers
         self.deliveries = deliveries
+        hasLoaded = true
     }
 
     func start() {
@@ -123,6 +127,7 @@ final class EventAutomationModel: ObservableObject {
             let previous = triggers
             connections = loadedConnections.connections
             triggers = loadedTriggers.triggers
+            hasLoaded = true
             deliveries = loadedDeliveries.deliveries
             announceAgentsStoppedByLocus(previous: previous, current: triggers)
             lastError = nil
@@ -170,9 +175,10 @@ final class EventAutomationModel: ObservableObject {
         if let trigger {
             var draft = EventTriggerEditorDraft(trigger: trigger)
             if isDedicatedAgent {
-                // Editing an existing agent must pass through the stable target
-                // endpoint again so its model route and top-level placement are
-                // repaired along with the trigger configuration.
+                // Editing an existing agent passes through the stable target
+                // endpoint again so its chat is recovered and its placement
+                // repaired. The route it runs on is left alone unless the
+                // person asks for the current one.
                 draft.targetSessionID = EventTriggerEditorDraft.dedicatedAgentChat
                 draft.templateSessionID = targetSessionID
             }
@@ -261,8 +267,15 @@ final class EventAutomationModel: ObservableObject {
                     "template_session_id": draft.templateSessionID,
                     "name": name,
                 ]
-                for (key, value) in agentProviderRoute?() ?? [:] where !value.isEmpty {
-                    targetBody[key] = value
+                // A new agent takes the app's current route. An existing one
+                // keeps the route its chat already records — sending the
+                // current route on every edit re-pointed the agent's model,
+                // however unrelated the edit — unless the person asked for the
+                // current model, which is also how a broken route is repaired.
+                if draft.id == nil || draft.adoptCurrentRoute {
+                    for (key, value) in agentProviderRoute?() ?? [:] where !value.isEmpty {
+                        targetBody[key] = value
+                    }
                 }
                 let response: AgentTargetSessionResponse = try await backend.post(
                     "/api/event-triggers/target-session",

--- a/Locus/EventAutomationsView.swift
+++ b/Locus/EventAutomationsView.swift
@@ -47,7 +47,8 @@ struct ConfigureAgentView: View {
             EventTriggerEditorView(
                 draft: draft,
                 automation: automation,
-                sessions: sessionCatalog.snapshot.sessions
+                sessions: sessionCatalog.snapshot.sessions,
+                currentModel: app.agentRouteModel
             )
         }
         .sheet(item: $automation.webhookSetup) { setup in
@@ -1124,15 +1125,18 @@ private struct EventTriggerEditorView: View {
     @State private var connectionSheet: ConnectorKind?
     @ObservedObject var automation: EventAutomationModel
     let sessions: [SessionSummary]
+    let currentModel: String
 
     init(
         draft: EventTriggerEditorDraft,
         automation: EventAutomationModel,
-        sessions: [SessionSummary]
+        sessions: [SessionSummary],
+        currentModel: String
     ) {
         _draft = State(initialValue: draft)
         self.automation = automation
         self.sessions = sessions
+        self.currentModel = currentModel
     }
 
     var body: some View {
@@ -1224,9 +1228,33 @@ private struct EventTriggerEditorView: View {
                         }
                     }
                     if draft.targetSessionID == EventTriggerEditorDraft.dedicatedAgentChat {
-                        Text("Creates one lasting conversation in Agents that every matching event arrives in. It keeps its own agent identity while retaining access to the selected chat’s workspace, so future context and AGENTS.md settings can attach to it.")
-                            .font(.locus(size: 8))
-                            .foregroundStyle(LocusTheme.muted)
+                        if draft.id != nil, let model = existingAgentModel {
+                            // An edit keeps the agent's own model, because it
+                            // used to follow whatever the app was set to. The
+                            // change is available, but it has to be asked for:
+                            // it is also the way a broken route is repaired.
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(draft.adoptCurrentRoute
+                                    ? "Moves to \(currentModel) when you save."
+                                    : "Runs on \(model). Saving keeps that model.")
+                                    .font(.locus(size: 8, weight: .medium))
+                                    .foregroundStyle(LocusTheme.textSecondary)
+                                if !draft.adoptCurrentRoute, currentModel != model {
+                                    Button("Switch to \(currentModel)") {
+                                        draft.adoptCurrentRoute = true
+                                    }
+                                    .buttonStyle(.locus())
+                                    .font(.locus(size: 8, weight: .semibold))
+                                    .accessibilityIdentifier("eventTrigger.route.adopt")
+                                }
+                            }
+                            .accessibilityElement(children: .combine)
+                            .accessibilityIdentifier("eventTrigger.route")
+                        } else {
+                            Text("Creates one lasting conversation in Agents that every matching event arrives in. It keeps its own agent identity while retaining access to the selected chat’s workspace, so future context and AGENTS.md settings can attach to it.")
+                                .font(.locus(size: 8))
+                                .foregroundStyle(LocusTheme.muted)
+                        }
                     }
                     Picker("Mode", selection: $draft.mode) {
                         ForEach(WorkMode.allCases) { mode in Text(mode.title).tag(mode) }
@@ -1379,6 +1407,11 @@ private struct EventTriggerEditorView: View {
             Text("Choose a connection to configure deterministic filters.")
                 .foregroundStyle(LocusTheme.muted)
         }
+    }
+
+    /// The model recorded on the agent's own chat, when editing one.
+    private var existingAgentModel: String? {
+        sessions.first { $0.id == draft.templateSessionID }?.model?.nilIfEmpty
     }
 
     /// Which sources can start this kind of agent. Price alerts read a feed or

--- a/Locus/InspectorAgentTab.swift
+++ b/Locus/InspectorAgentTab.swift
@@ -8,11 +8,14 @@ import SwiftUI
 /// mode always has something to say.
 struct InspectorAgentTab: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var schedule: ScheduleModel
+    @EnvironmentObject private var sessionCatalog: SessionCatalogModel
 
     var body: some View {
         AgentInspectorPanel(
             automation: model.eventAutomations,
-            sessionCatalog: model.sessionCatalog
+            schedule: schedule,
+            sessionCatalog: sessionCatalog
         )
         .environmentObject(model)
     }
@@ -21,17 +24,18 @@ struct InspectorAgentTab: View {
 private struct AgentInspectorPanel: View {
     @EnvironmentObject private var model: AppModel
     @ObservedObject var automation: EventAutomationModel
+    @ObservedObject var schedule: ScheduleModel
     @ObservedObject var sessionCatalog: SessionCatalogModel
 
-    private var currentTriggerID: String? {
+    private var currentAgentID: String? {
         sessionCatalog.snapshot.sessionsByID[model.currentSessionID]?.agentTriggerID?.nilIfEmpty
     }
 
     var body: some View {
         Group {
-            if let triggerID = currentTriggerID {
-                AgentDetailView(overview: overview(for: triggerID), automation: automation)
-                    .id(triggerID)
+            if let agentID = currentAgentID {
+                AgentDetailView(overview: overview(for: agentID), automation: automation)
+                    .id(agentID)
             } else {
                 AgentFleetView(entries: fleet, automation: automation)
             }
@@ -51,27 +55,39 @@ private struct AgentInspectorPanel: View {
         // Fixtures carry their own state and have no backend to ask.
         .task {
             guard !model.isUITesting else { return }
-            await automation.refresh(announceFailure: false)
+            await refreshAll()
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(20))
                 guard !Task.isCancelled else { return }
-                await automation.refresh(announceFailure: false)
+                await refreshAll()
             }
         }
         .onChange(of: model.currentSessionID) {
             guard !model.isUITesting else { return }
-            Task { await automation.refresh(announceFailure: false) }
+            Task { await refreshAll() }
         }
     }
 
-    private func overview(for triggerID: String) -> AgentOverview {
+    /// Both stores, and the current schedule agent's run history, which the
+    /// schedule model only loads on request.
+    private func refreshAll() async {
+        async let automations: Void = automation.refresh(announceFailure: false)
+        async let schedules: Void = schedule.refreshScheduledTasks(announceFailure: false)
+        _ = await (automations, schedules)
+        if let task = model.agentDefinition(for: currentAgentID)?.schedule {
+            await schedule.refreshOccurrences(for: task, announceFailure: false)
+        }
+    }
+
+    private func overview(for agentID: String) -> AgentOverview {
         AgentOverview.resolve(
-            triggerID: triggerID,
-            trigger: automation.triggers.first { $0.id == triggerID },
+            agentID: agentID,
+            definition: model.agentDefinition(for: agentID),
             connections: automation.connections,
             actionConnections: automation.connections,
             sessions: sessionCatalog.snapshot.sessions,
             deliveries: automation.deliveries,
+            occurrences: schedule.occurrencesBySchedule[agentID] ?? [],
             currentSessionID: model.currentSessionID,
             runningSessionIDs: model.runningChatSessionIDs,
             startedAt: model.runningChatStartTimes
@@ -82,6 +98,7 @@ private struct AgentInspectorPanel: View {
         AgentFleet.entries(
             triggers: automation.triggers,
             connections: automation.connections,
+            schedules: schedule.scheduledTasks,
             sessions: sessionCatalog.snapshot.sessions,
             runningSessionIDs: model.runningChatSessionIDs
         )
@@ -118,10 +135,11 @@ private struct AgentDetailView: View {
         .alert("Delete \(overview.name)?", isPresented: $confirmsDelete) {
             Button("Cancel", role: .cancel) {}
             Button("Delete", role: .destructive) {
-                if let trigger = overview.trigger { automation.deleteTrigger(trigger) }
+                if let definition = overview.definition { model.deleteAgent(definition) }
             }
         } message: {
-            Text("Its chats and delivery history are kept; only the trigger is removed.")
+            Text("Its chats and \(overview.vocabulary.arrival) history are kept;"
+                + " only the \(overview.vocabulary.record) is removed.")
         }
     }
 
@@ -139,7 +157,7 @@ private struct AgentDetailView: View {
                             .lineLimit(2)
                             .accessibilityIdentifier("agentOverview.name")
                         Spacer(minLength: 4)
-                        AgentStatusPill(status: overview.status)
+                        AgentStatusPill(status: overview.status, vocabulary: overview.vocabulary)
                             .accessibilityIdentifier("agentOverview.status")
                     }
                     Text(overview.summary)
@@ -151,38 +169,53 @@ private struct AgentDetailView: View {
             }
 
             AgentFlowLayout(spacing: 6) {
-                if overview.trigger != nil {
+                if overview.definition != nil {
                     AgentActionButton(
                         title: "New chat",
                         symbol: "plus",
                         prominent: true,
-                        help: "Start a side conversation with this agent. It does not receive events.",
+                        help: "Start a side conversation with this agent."
+                            + " It does not receive \(overview.vocabulary.arrivals).",
                         identifier: "agentOverview.newChat"
                     ) {
-                        model.newAgentChat(triggerID: overview.triggerID)
+                        model.newAgentChat(triggerID: overview.agentID)
                     }
                 }
-                if let trigger = overview.trigger {
+                if let definition = overview.definition {
+                    if overview.canRunNow {
+                        AgentActionButton(
+                            title: "Run now",
+                            symbol: "play.circle",
+                            help: "Run this schedule immediately in its chat",
+                            identifier: "agentOverview.runNow"
+                        ) {
+                            model.runAgentNow(definition)
+                        }
+                    }
                     AgentActionButton(
                         title: "Edit",
                         symbol: "slider.horizontal.3",
                         help: "Change what starts this agent and what it does",
                         identifier: "agentOverview.edit"
                     ) {
-                        editAgent(trigger)
+                        model.editAgent(definition)
                     }
                     AgentActionButton(
-                        title: trigger.enabled ? "Pause" : "Resume",
-                        symbol: trigger.enabled ? "pause" : "play",
+                        title: definition.enabled ? "Pause" : "Resume",
+                        symbol: definition.enabled ? "pause" : "play",
                         prominent: overview.status.needsResume,
-                        help: trigger.enabled
-                            ? "Keep recording events without starting chats"
-                            : "Start chats for matching events again, and clear the error",
+                        help: definition.isSchedule
+                            ? (definition.enabled
+                                ? "Skip scheduled runs until you resume it"
+                                : "Run on schedule again, and clear the error")
+                            : (definition.enabled
+                                ? "Keep recording events without starting chats"
+                                : "Start chats for matching events again, and clear the error"),
                         identifier: "agentOverview.toggle"
                     ) {
-                        automation.setTrigger(trigger, enabled: !trigger.enabled)
+                        model.setAgentEnabled(definition, enabled: !definition.enabled)
                     }
-                    if overview.canRearm {
+                    if overview.canRearm, let trigger = overview.trigger {
                         AgentActionButton(
                             title: "Re-arm",
                             symbol: "arrow.counterclockwise",
@@ -198,7 +231,9 @@ private struct AgentDetailView: View {
         }
         .agentCard()
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(overview.name), \(overview.status.title)")
+        .accessibilityLabel(
+            "\(overview.name), \(overview.status.title(for: overview.vocabulary))"
+        )
         .accessibilityIdentifier("agentOverview.identity")
     }
 
@@ -221,7 +256,7 @@ private struct AgentDetailView: View {
                     NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
                 }
             }
-            if overview.trigger != nil {
+            if overview.definition != nil {
                 Divider()
                 Button("Delete Agent…", role: .destructive) { confirmsDelete = true }
                     .accessibilityIdentifier("agentOverview.menu.delete")
@@ -247,12 +282,6 @@ private struct AgentDetailView: View {
         .accessibilityIdentifier("agentOverview.more")
     }
 
-    private func editAgent(_ trigger: EventTrigger) {
-        let isDedicated = overview.chats.contains { $0.session.id == trigger.targetSessionID }
-            || overview.currentChat != nil
-        model.editAgentTrigger(trigger, isDedicatedAgent: isDedicated)
-    }
-
     // MARK: Attention
 
     private func attentionBanner(_ error: String) -> some View {
@@ -262,7 +291,9 @@ private struct AgentDetailView: View {
                 .foregroundStyle(LocusTheme.warning)
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 2) {
-                Text(overview.status.isWarning ? overview.status.detail : "Last error")
+                Text(overview.status.isWarning
+                    ? overview.status.detail(for: overview.vocabulary)
+                    : "Last error")
                     .font(.locus(size: 9, weight: .semibold))
                     .foregroundStyle(LocusTheme.ink)
                     .fixedSize(horizontal: false, vertical: true)
@@ -306,15 +337,18 @@ private struct AgentDetailView: View {
             )
             AgentStatTile(
                 value: "\(overview.eventCount)",
-                label: overview.eventCount == 1 ? "Event" : "Events",
+                label: overview.schedule != nil
+                    ? (overview.eventCount == 1 ? "Run" : "Runs")
+                    : (overview.eventCount == 1 ? "Event" : "Events"),
                 caption: overview.failedEventCount > 0
-                    ? "\(overview.failedEventCount) failed" : "all delivered",
+                    ? "\(overview.failedEventCount) failed"
+                    : (overview.schedule != nil ? "all ran" : "all delivered"),
                 captionColor: overview.failedEventCount > 0 ? LocusTheme.warning : LocusTheme.textSecondary,
                 identifier: "agentOverview.stats.events"
             )
             AgentStatTile(
                 value: overview.lastEventAt.map { AgentOverviewFormatting.relative($0) } ?? "—",
-                label: "Last event",
+                label: overview.schedule != nil ? "Last run" : "Last event",
                 caption: overview.lastEventAt.map { AgentOverviewFormatting.absolute($0) }
                     ?? "nothing yet",
                 captionColor: LocusTheme.textSecondary,
@@ -331,7 +365,36 @@ private struct AgentDetailView: View {
     private var triggerCard: some View {
         VStack(alignment: .leading, spacing: 10) {
             AgentEyebrow(title: "What starts it")
-            if let trigger = overview.trigger {
+            if let task = overview.schedule {
+                HStack(spacing: 9) {
+                    Image(systemName: "calendar.badge.clock")
+                        .font(.locus(size: 12, weight: .semibold))
+                        .foregroundStyle(LocusTheme.signalDeep)
+                        .frame(width: 28, height: 28)
+                        .background(LocusTheme.signal.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(AgentOverviewFormatting.rule(task.rule))
+                            .font(.locus(size: 10, weight: .semibold))
+                            .foregroundStyle(LocusTheme.ink)
+                            .lineLimit(1)
+                        Text(task.nextRunDate.map {
+                            "Next run \(AgentOverviewFormatting.absolute($0))"
+                        } ?? (task.enabled ? "No next run" : "Paused"))
+                            .font(.locus(size: 8))
+                            .foregroundStyle(LocusTheme.textSecondary)
+                            .lineLimit(2)
+                    }
+                    Spacer(minLength: 0)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityIdentifier("agentOverview.source")
+                if !overview.filters.isEmpty {
+                    AgentChipFlow(chips: overview.filters)
+                        .accessibilityIdentifier("agentOverview.filters")
+                }
+            } else if let trigger = overview.trigger {
                 HStack(spacing: 9) {
                     Image(systemName: overview.connection?.kind.symbol
                         ?? (trigger.triggerKind == .price ? "chart.line.uptrend.xyaxis" : "bolt"))
@@ -373,7 +436,7 @@ private struct AgentDetailView: View {
                     .accessibilityIdentifier("agentOverview.priceState")
                 }
             } else {
-                Text(overview.status.detail)
+                Text(overview.status.detail(for: overview.vocabulary))
                     .font(.locus(size: 9))
                     .foregroundStyle(LocusTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -403,7 +466,7 @@ private struct AgentDetailView: View {
         VStack(alignment: .leading, spacing: 10) {
             AgentEyebrow(title: "What it does")
             if overview.instruction.isEmpty {
-                Text(overview.trigger == nil
+                Text(overview.definition == nil
                     ? "No instruction is stored without a trigger."
                     : "No instruction yet — the agent receives each event as is.")
                     .font(.locus(size: 9))
@@ -452,9 +515,9 @@ private struct AgentDetailView: View {
             HStack {
                 AgentEyebrow(title: "Chats", count: overview.chats.count)
                 Spacer(minLength: 4)
-                if overview.trigger != nil {
+                if overview.definition != nil {
                     Button {
-                        model.newAgentChat(triggerID: overview.triggerID)
+                        model.newAgentChat(triggerID: overview.agentID)
                     } label: {
                         Label("New", systemImage: "plus")
                             .font(.locus(size: 8, weight: .semibold))
@@ -464,29 +527,33 @@ private struct AgentDetailView: View {
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.locus())
-                    .help("Start a side conversation with this agent. It does not receive events.")
+                    .help("Start a side conversation with this agent."
+                        + " It does not receive \(overview.vocabulary.arrivals)")
                     .accessibilityLabel("New chat with \(overview.name)")
                     .accessibilityIdentifier("agentOverview.chats.new")
                 }
             }
             if let eventChat = overview.eventChat, overview.chats.count > 1 {
-                Text("Events arrive in \(eventChat.session.displayTitle). Other chats are side conversations.")
+                Text("\(overview.vocabulary.arrivals.capitalized) arrive in"
+                    + " \(eventChat.session.displayTitle). Other chats are side conversations.")
                     .font(.locus(size: 8))
                     .foregroundStyle(LocusTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityIdentifier("agentOverview.chats.explainer")
             }
             if overview.chats.isEmpty {
-                Text(overview.trigger == nil
+                Text(overview.definition == nil
                     ? "No chats survived for this agent."
-                    : "No chats yet. Every event arrives in this agent's event chat; New chat starts a side conversation that does not receive events.")
+                    : "No chats yet. Every \(overview.vocabulary.arrival) arrives in this agent's"
+                        + " \(overview.vocabulary.arrival) chat; New chat starts a side conversation"
+                        + " that does not receive \(overview.vocabulary.arrivals).")
                     .font(.locus(size: 9))
                     .foregroundStyle(LocusTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             } else {
                 VStack(spacing: 2) {
                     ForEach(overview.chats) { chat in
-                        AgentChatRow(chat: chat) {
+                        AgentChatRow(chat: chat, vocabulary: overview.vocabulary) {
                             guard !chat.isCurrent else { return }
                             model.resume(chat.session)
                         }
@@ -505,7 +572,10 @@ private struct AgentDetailView: View {
     private var eventsCard: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
-                AgentEyebrow(title: "Recent events", count: overview.eventCount)
+                AgentEyebrow(
+                    title: overview.schedule != nil ? "Recent runs" : "Recent events",
+                    count: overview.eventCount
+                )
                 Spacer(minLength: 4)
                 if overview.eventCount > overview.events.count, let trigger = overview.trigger {
                     Button("View all") {
@@ -518,9 +588,11 @@ private struct AgentDetailView: View {
                 }
             }
             if overview.events.isEmpty {
-                Text(overview.trigger?.enabled == false
-                    ? "Paused agents keep recording events; none have arrived yet."
-                    : "Nothing has reached this agent yet. Matching events will appear here with their outcome.")
+                Text(overview.schedule != nil
+                    ? "No runs yet. Each run continues this agent's chat and appears here with its outcome."
+                    : (overview.definition?.enabled == false
+                        ? "Paused agents keep recording events; none have arrived yet."
+                        : "Nothing has reached this agent yet. Matching events will appear here with their outcome."))
                     .font(.locus(size: 9))
                     .foregroundStyle(LocusTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -529,7 +601,7 @@ private struct AgentDetailView: View {
                     ForEach(overview.events) { event in
                         AgentEventRow(
                             event: event,
-                            onRetry: { automation.retry(event.delivery) },
+                            onRetry: { if let delivery = event.delivery { automation.retry(delivery) } },
                             onOpenChat: openChat(for: event)
                         )
                     }
@@ -538,12 +610,12 @@ private struct AgentDetailView: View {
         }
         .agentCard()
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Recent events")
+        .accessibilityLabel("Recent \(overview.vocabulary.arrivals)")
         .accessibilityIdentifier("agentOverview.events")
     }
 
     private func openChat(for event: AgentOverview.Event) -> (() -> Void)? {
-        guard let sessionID = event.delivery.sessionID,
+        guard let sessionID = event.sessionID,
               let session = model.sessionCatalog.snapshot.sessionsByID[sessionID]
         else { return nil }
         return {
@@ -634,7 +706,7 @@ private struct AgentFleetView: View {
     }
 
     private var fleetSummary: String {
-        guard !entries.isEmpty else { return "Persistent agents that wake on events" }
+        guard !entries.isEmpty else { return "Persistent agents that wake on events and schedules" }
         var parts = ["\(entries.count) configured", "\(activeCount) active"]
         if stoppedCount > 0 {
             parts.append("\(stoppedCount) stopped by Locus")
@@ -651,7 +723,7 @@ private struct AgentFleetView: View {
             Text("No agents yet")
                 .font(.locus(size: 10, weight: .semibold))
                 .foregroundStyle(LocusTheme.ink)
-            Text("An agent is a trigger — Gmail, Telegram, a webhook, or a price — with its own instruction and its own chats. Configure one and it appears here.")
+            Text("An agent waits on something — Gmail, Telegram, a webhook, a price, or a schedule — and does its own work in its own chats. Configure one and it appears here.")
                 .font(.locus(size: 9))
                 .foregroundStyle(LocusTheme.textSecondary)
                 .multilineTextAlignment(.center)
@@ -702,6 +774,7 @@ private struct AgentGlyph: View {
 
 private struct AgentStatusPill: View {
     let status: AgentOverview.Status
+    var vocabulary: Vocabulary = .events
 
     private var color: Color {
         switch status {
@@ -718,7 +791,7 @@ private struct AgentStatusPill: View {
             Circle()
                 .fill(color)
                 .frame(width: 6, height: 6)
-            Text(status.title)
+            Text(status.title(for: vocabulary))
                 .font(.locus(size: 8, weight: .semibold))
                 .foregroundStyle(LocusTheme.ink)
                 .lineLimit(1)
@@ -727,11 +800,11 @@ private struct AgentStatusPill: View {
         .frame(height: 22)
         .background(color.opacity(0.14))
         .clipShape(Capsule())
-        .help(status.detail)
+        .help(status.detail(for: vocabulary))
         // Combined rather than ignored: a combined element carries the pill's
         // text as its label on every macOS release XCUITest runs on.
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Status: \(status.title)")
+        .accessibilityLabel("Status: \(status.title(for: vocabulary))")
     }
 }
 
@@ -854,6 +927,7 @@ private struct AgentFactRow: View {
 
 private struct AgentChatRow: View {
     let chat: AgentOverview.Chat
+    var vocabulary: Vocabulary = .events
     let action: () -> Void
 
     var body: some View {
@@ -870,7 +944,7 @@ private struct AgentChatRow: View {
                             .foregroundStyle(LocusTheme.ink)
                             .lineLimit(1)
                         if chat.isEventTarget {
-                            Text("EVENTS")
+                            Text(vocabulary.badge)
                                 .font(.locus(size: 7, weight: .bold))
                                 .tracking(0.4)
                                 .foregroundStyle(LocusTheme.signalDeep)
@@ -915,10 +989,10 @@ private struct AgentChatRow: View {
         }
         .buttonStyle(.locus())
         .help(chat.isEventTarget
-            ? "Every event this agent receives arrives here"
+            ? "Every \(vocabulary.arrival) this agent receives arrives here"
             : (chat.isCurrent ? "This chat is open" : "Open \(chat.session.displayTitle)"))
         .accessibilityLabel(chat.isEventTarget
-            ? "\(chat.session.displayTitle), receives events"
+            ? "\(chat.session.displayTitle), receives \(vocabulary.arrivals)"
             : chat.session.displayTitle)
         .accessibilityValue(chat.isRunning ? "Running" : (chat.isCurrent ? "Open" : "Idle"))
         .accessibilityIdentifier("agentOverview.chat.\(chat.session.id)")
@@ -933,13 +1007,16 @@ private struct AgentEventRow: View {
     private var stateColor: Color {
         if event.isFailed { return LocusTheme.warning }
         if event.isInFlight { return LocusTheme.blue }
+        // A skipped slot neither succeeded nor failed, so it is neither green
+        // nor amber: it simply passed.
+        if event.isSkipped { return LocusTheme.muted }
         return LocusTheme.success
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             HStack(alignment: .firstTextBaseline, spacing: 7) {
-                Image(systemName: event.delivery.source.symbol)
+                Image(systemName: event.sourceSymbol)
                     .font(.locus(size: 9, weight: .semibold))
                     .foregroundStyle(LocusTheme.textSecondary)
                     .frame(width: 14)
@@ -963,8 +1040,8 @@ private struct AgentEventRow: View {
                     Text("· \(price)")
                         .font(.locus(size: 8, weight: .semibold, design: .monospaced))
                 }
-                if event.delivery.attempt > 1 {
-                    Text("· attempt \(event.delivery.attempt)")
+                if event.attempt > 1 {
+                    Text("· attempt \(event.attempt)")
                 }
                 Spacer(minLength: 0)
                 if event.canRetry {
@@ -985,10 +1062,10 @@ private struct AgentEventRow: View {
             .font(.locus(size: 8))
             .foregroundStyle(LocusTheme.textSecondary)
             .padding(.leading, 21)
-            if let error = event.delivery.error?.nilIfEmpty {
+            if let error = event.error?.nilIfEmpty {
                 Text(error)
                     .font(.locus(size: 8))
-                    .foregroundStyle(LocusTheme.warning)
+                    .foregroundStyle(event.isSkipped ? LocusTheme.textSecondary : LocusTheme.warning)
                     .lineLimit(2)
                     .padding(.leading, 21)
             }
@@ -1009,12 +1086,13 @@ private struct AgentFleetRow: View {
     let action: () -> Void
 
     private var detail: String {
+        let words = entry.definition.vocabulary
         var parts = [AgentOverviewFormatting.chatCount(entry.chatCount)]
         if entry.runningChatCount > 0 { parts.append("\(entry.runningChatCount) running") }
         if let last = entry.lastEventAt {
-            parts.append("last event \(AgentOverviewFormatting.relative(last))")
+            parts.append("last \(words.arrival) \(AgentOverviewFormatting.relative(last))")
         } else {
-            parts.append("no events yet")
+            parts.append("no \(words.arrivals) yet")
         }
         return parts.joined(separator: " · ")
     }
@@ -1024,7 +1102,7 @@ private struct AgentFleetRow: View {
             HStack(alignment: .top, spacing: 10) {
                 AgentGlyph(size: 30, symbolSize: 14, status: entry.status)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(entry.trigger.name)
+                    Text(entry.name)
                         .font(.locus(size: 10, weight: .semibold))
                         .foregroundStyle(LocusTheme.ink)
                         .lineLimit(1)
@@ -1038,7 +1116,7 @@ private struct AgentFleetRow: View {
                         .lineLimit(1)
                 }
                 Spacer(minLength: 4)
-                AgentStatusPill(status: entry.status)
+                AgentStatusPill(status: entry.status, vocabulary: entry.definition.vocabulary)
             }
             .padding(10)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1051,9 +1129,11 @@ private struct AgentFleetRow: View {
             .contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
         }
         .buttonStyle(.locus(.card))
-        .help(entry.latestChat == nil ? "Open Configure Agent" : "Open the latest chat with \(entry.trigger.name)")
-        .accessibilityLabel("\(entry.trigger.name), \(entry.status.title), \(detail)")
-        .accessibilityIdentifier("agentOverview.fleet.\(entry.trigger.id)")
+        .help(entry.latestChat == nil ? "Open Manage Agents" : "Open the latest chat with \(entry.name)")
+        .accessibilityLabel(
+            "\(entry.name), \(entry.status.title(for: entry.definition.vocabulary)), \(detail)"
+        )
+        .accessibilityIdentifier("agentOverview.fleet.\(entry.id)")
     }
 }
 

--- a/Locus/Models/EventAutomationModels.swift
+++ b/Locus/Models/EventAutomationModels.swift
@@ -362,6 +362,9 @@ struct EventTriggerEditorDraft: Identifiable, Hashable {
     var filters = EventTriggerFilters()
     var actionConnectionIDs: [String] = []
     var enabled = true
+    /// Set when the person asks an existing agent to move to the model the app
+    /// is on now. Off by default: an ordinary edit keeps the agent's route.
+    var adoptCurrentRoute = false
 
     init() {}
 

--- a/Locus/Models/SessionModels.swift
+++ b/Locus/Models/SessionModels.swift
@@ -29,6 +29,13 @@ struct SessionSummary: Codable, Hashable, Identifiable {
     let sortOrder: Int?
     let agentTriggerID: String?
     let agentName: String?
+    /// The one chat an agent's events (or scheduled runs) land in. Side
+    /// conversations under the same agent carry the id but not this flag.
+    let agentPrimary: Bool?
+    /// The route recorded for the chat, so an agent's editor can show what it
+    /// runs on without asking the backend.
+    let model: String?
+    let provider: String?
 
     init(
         id: String,
@@ -48,7 +55,10 @@ struct SessionSummary: Codable, Hashable, Identifiable {
         folderID: String? = nil,
         sortOrder: Int? = nil,
         agentTriggerID: String? = nil,
-        agentName: String? = nil
+        agentName: String? = nil,
+        agentPrimary: Bool? = nil,
+        model: String? = nil,
+        provider: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -68,6 +78,9 @@ struct SessionSummary: Codable, Hashable, Identifiable {
         self.sortOrder = sortOrder
         self.agentTriggerID = agentTriggerID
         self.agentName = agentName
+        self.agentPrimary = agentPrimary
+        self.model = model
+        self.provider = provider
     }
 
     enum CodingKeys: String, CodingKey {
@@ -78,6 +91,8 @@ struct SessionSummary: Codable, Hashable, Identifiable {
         case sortOrder = "sort_order"
         case agentTriggerID = "agent_trigger_id"
         case agentName = "agent_name"
+        case agentPrimary = "agent_primary"
+        case model, provider
     }
 
     var displayTitle: String {
@@ -111,6 +126,8 @@ struct SessionSummary: Codable, Hashable, Identifiable {
     var isPinned: Bool { pinned ?? false }
     var isArchived: Bool { archived ?? false }
     var isAgentChat: Bool { agentTriggerID?.isEmpty == false }
+    /// Whether this is the chat an agent's events arrive in.
+    var isAgentEventChat: Bool { isAgentChat && agentPrimary == true }
 
     var workspacePath: String? {
         guard let cwd = cwd?.trimmingCharacters(in: .whitespacesAndNewlines), !cwd.isEmpty else {
@@ -138,7 +155,10 @@ struct SessionSummary: Codable, Hashable, Identifiable {
             folderID: folderID,
             sortOrder: sortOrder,
             agentTriggerID: agentTriggerID,
-            agentName: agentName
+            agentName: agentName,
+            agentPrimary: agentPrimary,
+            model: model,
+            provider: provider
         )
     }
 

--- a/Locus/ScheduleModel.swift
+++ b/Locus/ScheduleModel.swift
@@ -13,6 +13,9 @@ final class ScheduleModel: ObservableObject {
     @Published private(set) var isSavingSchedule = false
     @Published private(set) var isRefreshingSchedules = false
     @Published private(set) var occurrencesBySchedule: [String: [ScheduleOccurrence]] = [:]
+    /// Whether the schedule list has ever loaded. Until it has, a schedule
+    /// that is not in `scheduledTasks` may simply not have arrived yet.
+    @Published private(set) var hasLoaded = false
 
     private var scheduleCoordinatorTask: Task<Void, Never>?
     private var isDispatchingSchedules = false
@@ -64,6 +67,16 @@ final class ScheduleModel: ObservableObject {
         self.toastHandler = toastHandler
     }
 
+    /// UI-test fixtures need scheduled agents without a backend.
+    func seedForUITesting(
+        tasks: [ScheduledTask],
+        occurrences: [String: [ScheduleOccurrence]] = [:]
+    ) {
+        scheduledTasks = tasks
+        occurrencesBySchedule = occurrences
+        hasLoaded = true
+    }
+
     func cancelAll() {
         scheduleCoordinatorTask?.cancel()
         scheduleCoordinatorTask = nil
@@ -78,7 +91,15 @@ final class ScheduleModel: ObservableObject {
             let response: SchedulesResponse = try await backend.get(
                 "/api/schedules", as: SchedulesResponse.self
             )
+            let known = Set(scheduledTasks.map(\.id))
             scheduledTasks = response.schedules
+            hasLoaded = true
+            // Listing gives a schedule that predates agents its dedicated
+            // chat, and a schedule made elsewhere arrives with one; either
+            // way the sidebar needs the session list to show it.
+            if response.schedules.contains(where: { !known.contains($0.id) }) {
+                await refreshMetadata()
+            }
         } catch {
             if announceFailure {
                 toastHandler("Could not load schedules: \(error.localizedDescription)")
@@ -135,7 +156,11 @@ final class ScheduleModel: ObservableObject {
                 ($0.nextRunAt ?? .greatestFiniteMagnitude) < ($1.nextRunAt ?? .greatestFiniteMagnitude)
             }
             scheduleEditorDraft = nil
-            toastHandler(draft.id == nil ? "Schedule created" : "Schedule updated")
+            // The backend creates the agent's dedicated chat with the schedule
+            // and renames it with the schedule, so the sidebar needs a fresh
+            // session list to show it.
+            await refreshMetadata()
+            toastHandler(draft.id == nil ? "Agent created" : "Agent updated")
             return true
         } catch {
             toastHandler("Could not save schedule: \(error.localizedDescription)")
@@ -153,9 +178,9 @@ final class ScheduleModel: ObservableObject {
                     as: ScheduledTask.self
                 )
                 replaceScheduledTask(updated)
-                toastHandler(enabled ? "Schedule resumed" : "Schedule paused")
+                toastHandler(enabled ? "Agent resumed" : "Agent paused")
             } catch {
-                toastHandler("Could not update schedule: \(error.localizedDescription)")
+                toastHandler("Could not update this agent: \(error.localizedDescription)")
             }
         }
     }
@@ -169,9 +194,9 @@ final class ScheduleModel: ObservableObject {
                     "/api/schedules/\(task.id)", as: DeleteScheduleResponse.self
                 )
                 scheduledTasks.removeAll { $0.id == task.id }
-                toastHandler("Schedule deleted; its chats were kept")
+                toastHandler("Agent deleted; its chats were kept")
             } catch {
-                toastHandler("Could not delete schedule: \(error.localizedDescription)")
+                toastHandler("Could not delete this agent: \(error.localizedDescription)")
             }
         }
     }
@@ -186,7 +211,7 @@ final class ScheduleModel: ObservableObject {
         }
     }
 
-    func refreshOccurrences(for task: ScheduledTask) async {
+    func refreshOccurrences(for task: ScheduledTask, announceFailure: Bool = true) async {
         guard let backend else { return }
         do {
             let response: ScheduleOccurrencesResponse = try await backend.get(
@@ -196,7 +221,9 @@ final class ScheduleModel: ObservableObject {
             )
             occurrencesBySchedule[task.id] = response.occurrences
         } catch {
-            toastHandler("Could not load time-trigger history: \(error.localizedDescription)")
+            if announceFailure {
+                toastHandler("Could not load run history: \(error.localizedDescription)")
+            }
         }
     }
 

--- a/Locus/SessionSidebarView.swift
+++ b/Locus/SessionSidebarView.swift
@@ -147,7 +147,7 @@ struct SessionSidebarView: View {
     @State private var folderEditor: ChatFolderEditorRequest?
     @State private var folderEditorName = ""
     @State private var collapsedAgentIDs: Set<String> = []
-    @State private var agentToDelete: EventTrigger?
+    @State private var agentToDelete: AgentDefinition?
     @State private var searchExpanded = false
     @FocusState private var searchFocused: Bool
 
@@ -377,13 +377,15 @@ struct SessionSidebarView: View {
             titleVisibility: .visible
         ) {
             Button("Delete Agent", role: .destructive) {
-                if let agentToDelete { model.eventAutomations.deleteTrigger(agentToDelete) }
+                if let agentToDelete { model.deleteAgent(agentToDelete) }
                 agentToDelete = nil
             }
             .accessibilityIdentifier("agent.delete.confirm")
             Button("Cancel", role: .cancel) { agentToDelete = nil }
         } message: {
-            Text("It stops listening for events. Its chats stay where they are.")
+            Text(agentToDelete?.isSchedule == true
+                ? "It stops running on its schedule. Its chats stay where they are."
+                : "It stops listening for events. Its chats stay where they are.")
         }
         .confirmationDialog(
             "Delete \(folderToDelete?.name ?? "this folder")?",
@@ -827,11 +829,16 @@ struct SessionSidebarView: View {
                     .accessibilityIdentifier("session.\(session.id).restoreWorktree")
             }
             Divider()
+            if let owner = model.agentOwningEventChat(session) {
+                Text("Receives \(owner.name)'s \(owner.vocabulary.arrivals)"
+                    + " — delete the agent to remove it")
+            }
             Button("Delete Chat", role: .destructive) {
                 model.deleteChat(session)
             }
             .disabled(
                 model.isBusy || model.hasPendingPermission || model.chatHasActiveRun(session)
+                    || model.agentOwningEventChat(session) != nil
             )
             .accessibilityIdentifier("session.\(session.id).delete")
         }
@@ -876,88 +883,21 @@ struct SessionSidebarView: View {
     }
 
     private func agentGroupRow(_ agent: AgentSidebarGroupModel) -> some View {
-        let expanded = !collapsedAgentIDs.contains(agent.id)
-        let trigger = model.eventAutomations.triggers.first { $0.id == agent.id }
-        let status = AgentOverview.status(for: trigger)
-        return Button {
-            withAnimation(LocusMotion.spatial) {
-                if expanded {
-                    collapsedAgentIDs.insert(agent.id)
-                } else {
-                    collapsedAgentIDs.remove(agent.id)
+        AgentGroupRow(
+            agent: agent,
+            automation: model.eventAutomations,
+            expanded: !collapsedAgentIDs.contains(agent.id),
+            toggle: {
+                withAnimation(LocusMotion.spatial) {
+                    if collapsedAgentIDs.contains(agent.id) {
+                        collapsedAgentIDs.remove(agent.id)
+                    } else {
+                        collapsedAgentIDs.insert(agent.id)
+                    }
                 }
-            }
-        } label: {
-            HStack(spacing: 7) {
-                Image(systemName: expanded ? "chevron.down" : "chevron.right")
-                    .font(.locus(size: 7, weight: .bold))
-                    .foregroundStyle(LocusTheme.muted)
-                    .frame(width: 9)
-                Image(locusSymbol: LocusSymbol.robot)
-                    .font(.locus(size: 12, weight: .semibold))
-                    .foregroundStyle(status.isWarning ? LocusTheme.warning : LocusTheme.signalDeep)
-                    .frame(width: 21, height: 21)
-                    .accessibilityHidden(true)
-                Text(agent.name)
-                    .font(.locus(size: 10, weight: .semibold))
-                    .foregroundStyle(LocusTheme.ink)
-                    .lineLimit(1)
-                if status != .active {
-                    Image(systemName: agentStatusSymbol(status))
-                        .font(.locus(size: 8, weight: .semibold))
-                        .foregroundStyle(status.isWarning ? LocusTheme.warning : LocusTheme.muted)
-                        .help(status.detail)
-                        .accessibilityHidden(true)
-                }
-                Spacer(minLength: 4)
-                Text("\(agent.tasks.count)")
-                    .font(.locus(size: 8, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(LocusTheme.muted)
-            }
-            .padding(.horizontal, 8)
-            .frame(height: 32)
-            .background(LocusTheme.white.opacity(0.36))
-            .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
-        }
-        .buttonStyle(.locus())
-        .contextMenu {
-            Button("New Chat with \(agent.name)") {
-                model.newAgentChat(triggerID: agent.id)
-            }
-            .accessibilityIdentifier("agent.\(agent.id).newChat")
-            if let trigger {
-                Button("Edit Agent…") {
-                    model.editAgentTrigger(trigger, isDedicatedAgent: true)
-                }
-                .accessibilityIdentifier("agent.\(agent.id).edit")
-                Button(trigger.enabled ? "Pause Agent" : "Resume Agent") {
-                    model.eventAutomations.setTrigger(trigger, enabled: !trigger.enabled)
-                }
-                .accessibilityIdentifier("agent.\(agent.id).toggle")
-                Divider()
-                Button("Delete Agent…", role: .destructive) {
-                    agentToDelete = trigger
-                }
-                .accessibilityIdentifier("agent.\(agent.id).delete")
-            }
-        }
-        .help(status.detail)
-        .accessibilityLabel("\(agent.name) agent")
-        .accessibilityValue(
-            "\(status.title), \(agent.tasks.count) \(agent.tasks.count == 1 ? "chat" : "chats"), "
-                + (expanded ? "expanded" : "collapsed")
+            },
+            confirmDelete: { agentToDelete = $0 }
         )
-        .accessibilityIdentifier("agent.\(agent.id)")
-    }
-
-    private func agentStatusSymbol(_ status: AgentOverview.Status) -> String {
-        switch status {
-        case .active: "circle"
-        case .paused: "pause.circle.fill"
-        case .stopped, .missingTrigger: "exclamationmark.triangle.fill"
-        case .failing: "exclamationmark.circle.fill"
-        case .fired: "checkmark.circle.fill"
-        }
     }
 
     private func emptyState(snapshot: SessionCatalogSnapshot) -> some View {
@@ -1990,6 +1930,124 @@ private struct SessionRow: View {
             "Needs Attention"
         default:
             state.title
+        }
+    }
+}
+
+/// One agent's group header in the sidebar.
+///
+/// It observes the trigger and schedule stores directly rather than reading
+/// them back through AppModel: pausing or deleting an agent from this row
+/// publishes only on those stores, so a row that watched AppModel alone kept
+/// drawing the state the agent had before the click.
+private struct AgentGroupRow: View {
+    @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var schedule: ScheduleModel
+    @ObservedObject var automation: EventAutomationModel
+    let agent: AgentSidebarGroupModel
+    let expanded: Bool
+    let toggle: () -> Void
+    let confirmDelete: (AgentDefinition) -> Void
+
+    init(
+        agent: AgentSidebarGroupModel,
+        automation: EventAutomationModel,
+        expanded: Bool,
+        toggle: @escaping () -> Void,
+        confirmDelete: @escaping (AgentDefinition) -> Void
+    ) {
+        self.agent = agent
+        self.automation = automation
+        self.expanded = expanded
+        self.toggle = toggle
+        self.confirmDelete = confirmDelete
+    }
+
+    private var definition: AgentDefinition? {
+        AgentDefinition.resolve(
+            agentID: agent.id,
+            triggers: automation.triggers,
+            schedules: schedule.scheduledTasks
+        )
+    }
+
+    var body: some View {
+        let record = definition
+        let status = AgentOverview.status(for: record)
+        let words = record?.vocabulary ?? .events
+        return Button(action: toggle) {
+            HStack(spacing: 7) {
+                Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                    .font(.locus(size: 7, weight: .bold))
+                    .foregroundStyle(LocusTheme.muted)
+                    .frame(width: 9)
+                Image(locusSymbol: LocusSymbol.robot)
+                    .font(.locus(size: 12, weight: .semibold))
+                    .foregroundStyle(status.isWarning ? LocusTheme.warning : LocusTheme.signalDeep)
+                    .frame(width: 21, height: 21)
+                    .accessibilityHidden(true)
+                Text(agent.name)
+                    .font(.locus(size: 10, weight: .semibold))
+                    .foregroundStyle(LocusTheme.ink)
+                    .lineLimit(1)
+                if status != .active {
+                    Image(systemName: AgentGroupRow.statusSymbol(status))
+                        .font(.locus(size: 8, weight: .semibold))
+                        .foregroundStyle(status.isWarning ? LocusTheme.warning : LocusTheme.muted)
+                        .help(status.detail(for: words))
+                        .accessibilityHidden(true)
+                }
+                Spacer(minLength: 4)
+                Text("\(agent.tasks.count)")
+                    .font(.locus(size: 8, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(LocusTheme.muted)
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 32)
+            .background(LocusTheme.white.opacity(0.36))
+            .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+        }
+        .buttonStyle(.locus())
+        .contextMenu {
+            Button("New Chat with \(agent.name)") {
+                model.newAgentChat(triggerID: agent.id)
+            }
+            .accessibilityIdentifier("agent.\(agent.id).newChat")
+            if let record {
+                if record.isSchedule {
+                    Button("Run Now") { model.runAgentNow(record) }
+                        .accessibilityIdentifier("agent.\(agent.id).runNow")
+                }
+                Button("Edit Agent…") { model.editAgent(record) }
+                    .accessibilityIdentifier("agent.\(agent.id).edit")
+                Button(record.enabled ? "Pause Agent" : "Resume Agent") {
+                    model.setAgentEnabled(record, enabled: !record.enabled)
+                }
+                .accessibilityIdentifier("agent.\(agent.id).toggle")
+                Divider()
+                Button("Delete Agent…", role: .destructive) {
+                    confirmDelete(record)
+                }
+                .accessibilityIdentifier("agent.\(agent.id).delete")
+            }
+        }
+        .help(status.detail(for: words))
+        .accessibilityLabel("\(agent.name) agent")
+        .accessibilityValue(
+            "\(status.title(for: words)), "
+                + "\(agent.tasks.count) \(agent.tasks.count == 1 ? "chat" : "chats"), "
+                + (expanded ? "expanded" : "collapsed")
+        )
+        .accessibilityIdentifier("agent.\(agent.id)")
+    }
+
+    private static func statusSymbol(_ status: AgentOverview.Status) -> String {
+        switch status {
+        case .active: "circle"
+        case .paused: "pause.circle.fill"
+        case .stopped, .missingTrigger: "exclamationmark.triangle.fill"
+        case .failing: "exclamationmark.circle.fill"
+        case .fired: "checkmark.circle.fill"
         }
     }
 }

--- a/LocusTests/AgentOverviewTests.swift
+++ b/LocusTests/AgentOverviewTests.swift
@@ -71,6 +71,66 @@ final class AgentOverviewTests: XCTestCase {
         )
     }
 
+    private func scheduledTask(
+        id: String = "morning",
+        name: String = "Morning review",
+        enabled: Bool = true,
+        lastError: String? = nil,
+        rule: ScheduleRule = ScheduleRule(kind: .weekdays, hour: 9, minute: 30),
+        nextRunAt: Double? = nil,
+        lastRunAt: Double? = nil,
+        environment: ChatExecutionEnvironment = .local
+    ) -> ScheduledTask {
+        ScheduledTask(
+            id: id,
+            name: name,
+            prompt: "Review the workspace and summarize what changed.",
+            workspaceRoot: "/tmp/review-workspace",
+            mode: .work,
+            executionEnvironment: environment,
+            runner: .solo,
+            teamID: nil,
+            teamName: nil,
+            provider: "ollama",
+            providerAccountID: nil,
+            model: "qwen3:8b",
+            timezone: TimeZone.current.identifier,
+            rule: rule,
+            enabled: enabled,
+            nextRunAt: nextRunAt,
+            createdAt: now.timeIntervalSince1970 - 86_400 * 7,
+            updatedAt: now.timeIntervalSince1970 - 60,
+            lastRunAt: lastRunAt,
+            lastRunID: nil,
+            lastError: lastError
+        )
+    }
+
+    private func occurrence(
+        _ id: String,
+        scheduleID: String = "morning",
+        state: String,
+        age: TimeInterval,
+        trigger: String = "due",
+        sessionID: String? = "morning-chat",
+        error: String? = nil
+    ) -> ScheduleOccurrence {
+        let when = now.timeIntervalSince1970 - age
+        return ScheduleOccurrence(
+            id: id,
+            scheduleID: scheduleID,
+            scheduleName: "Morning review",
+            scheduledFor: when,
+            trigger: trigger,
+            state: state,
+            sessionID: sessionID,
+            runID: state == "queued" ? "run-\(id)" : nil,
+            error: error,
+            createdAt: when,
+            updatedAt: when + 5
+        )
+    }
+
     private func delivery(
         _ id: String,
         state: String,
@@ -174,7 +234,8 @@ final class AgentOverviewTests: XCTestCase {
     }
 
     func testStatusSeparatesAPersonPausingFromLocusStoppingTheAgent() {
-        XCTAssertEqual(AgentOverview.status(for: nil), .missingTrigger)
+        XCTAssertEqual(AgentOverview.status(for: nil as EventTrigger?), .missingTrigger)
+        XCTAssertEqual(AgentOverview.status(for: nil as AgentDefinition?), .missingTrigger)
         // enabled, no error: listening.
         XCTAssertEqual(AgentOverview.status(for: trigger()), .active)
         // disabled, no error: someone pressed Pause.
@@ -331,6 +392,242 @@ final class AgentOverviewTests: XCTestCase {
         XCTAssertEqual(AgentOverview.Event(delivery: noSubject).title, "Body text here")
         XCTAssertEqual(AgentOverview.Event(delivery: delivery("d2", state: "queued", age: 1)).title, "Storm warning")
         XCTAssertTrue(AgentOverview.Event(delivery: delivery("d3", state: "queued", age: 1)).isInFlight)
+    }
+
+    // MARK: Schedules
+
+    func testAScheduledAgentResolvesFromItsScheduleAndOccurrences() {
+        let primary = SessionSummary(
+            id: "morning-chat", name: "morning-chat.jsonl", preview: "", mtime: now.timeIntervalSince1970 - 60,
+            size: 10, title: "Morning review", cwd: "/tmp/review-workspace",
+            agentTriggerID: "morning", agentName: "Morning review", agentPrimary: true,
+            model: "qwen3:8b", provider: "ollama"
+        )
+        let side = SessionSummary(
+            id: "morning-side", name: "morning-side.jsonl", preview: "", mtime: now.timeIntervalSince1970 - 30,
+            size: 10, title: "Chat 2", cwd: "/tmp/review-workspace",
+            agentTriggerID: "morning", agentName: "Morning review"
+        )
+        let task = scheduledTask(
+            nextRunAt: now.timeIntervalSince1970 + 3_600,
+            lastRunAt: now.timeIntervalSince1970 - 600
+        )
+        let overview = AgentOverview.resolve(
+            agentID: "morning",
+            definition: .schedule(task),
+            connections: [],
+            sessions: [primary, side],
+            deliveries: [],
+            occurrences: [
+                occurrence("o-old", state: "failed", age: 90_000, error: "The model is not installed."),
+                occurrence("o-new", state: "queued", age: 600),
+                occurrence("foreign", scheduleID: "other", state: "queued", age: 1),
+            ],
+            currentSessionID: "morning-side",
+            runningSessionIDs: [],
+            now: now
+        )
+
+        XCTAssertEqual(overview.name, "Morning review")
+        XCTAssertEqual(overview.status, .active)
+        XCTAssertEqual(overview.summary, "Schedule · Weekdays at 09:30 · Work")
+        XCTAssertEqual(overview.instruction, "Review the workspace and summarize what changed.")
+        XCTAssertEqual(overview.filters, ["Next in 1h"], "the cadence heads the card; chips add the rest")
+        XCTAssertTrue(overview.canRunNow)
+        XCTAssertFalse(overview.canRearm)
+        XCTAssertNil(overview.priceState)
+
+        // The primary flag marks the chat every run continues; the side chat
+        // shares the identity and nothing else.
+        XCTAssertEqual(overview.eventChat?.id, "morning-chat")
+        XCTAssertEqual(overview.chats.map(\.id), ["morning-side", "morning-chat"])
+        XCTAssertEqual(overview.chats.filter(\.isEventTarget).map(\.id), ["morning-chat"])
+
+        // Occurrences stand in for deliveries: newest first, own schedule only.
+        XCTAssertEqual(overview.events.map(\.id), ["o-new", "o-old"])
+        XCTAssertEqual(overview.eventCount, 2)
+        XCTAssertEqual(overview.failedEventCount, 1)
+        XCTAssertTrue(overview.events[1].isFailed)
+        XCTAssertFalse(overview.events[1].canRetry, "schedules run again on their own; there is no retry")
+        XCTAssertTrue(overview.events[0].isInFlight)
+        XCTAssertTrue(overview.events[0].title.hasPrefix("Scheduled run · "))
+        XCTAssertEqual(overview.events[0].sourceSymbol, "calendar.badge.clock")
+        XCTAssertEqual(overview.lastEventAt, now.addingTimeInterval(-600), "the schedule's own last run wins")
+
+        XCTAssertEqual(
+            overview.facts.map(\.label),
+            ["Runs as", "Runner", "Environment", "Model", "Next run", "Workspace", "Created"]
+        )
+        XCTAssertEqual(overview.facts[1].value, "Solo")
+        XCTAssertEqual(overview.facts[2].value, "Local")
+        XCTAssertEqual(overview.facts[3].value, "qwen3:8b")
+        XCTAssertEqual(overview.facts[5].value, "review-workspace")
+    }
+
+    func testScheduleStatusUsesTheSameFourStatesAsTriggers() {
+        XCTAssertEqual(AgentOverview.status(for: .schedule(scheduledTask())), .active)
+        XCTAssertEqual(AgentOverview.status(for: .schedule(scheduledTask(enabled: false))), .paused)
+        XCTAssertEqual(
+            AgentOverview.status(for: .schedule(scheduledTask(enabled: false, lastError: "Model removed"))),
+            .stopped
+        )
+        XCTAssertEqual(
+            AgentOverview.status(for: .schedule(scheduledTask(lastError: "The workspace is gone"))),
+            .failing
+        )
+        let paused = AgentOverview.resolve(
+            agentID: "morning", definition: .schedule(scheduledTask(enabled: false)),
+            connections: [], sessions: [], deliveries: [], currentSessionID: "",
+            runningSessionIDs: [], now: now
+        )
+        XCTAssertEqual(paused.filters, ["Paused"])
+        XCTAssertEqual(paused.facts.first { $0.label == "Next run" }?.value, "Paused")
+    }
+
+    func testASkippedRunIsNotAFailureOfTheAgent() {
+        // Two runs of one schedule overlapping is a normal outcome: the slot
+        // passes, the agent keeps working, and nothing needs a person.
+        let overview = AgentOverview.resolve(
+            agentID: "morning",
+            definition: .schedule(scheduledTask(lastRunAt: now.timeIntervalSince1970 - 600)),
+            connections: [],
+            sessions: [],
+            deliveries: [],
+            occurrences: [
+                occurrence(
+                    "o-skip", state: "skipped", age: 600,
+                    error: "Skipped: the previous run in this agent's chat was still in progress."
+                ),
+            ],
+            currentSessionID: "",
+            runningSessionIDs: [],
+            now: now
+        )
+
+        XCTAssertEqual(overview.status, .active)
+        XCTAssertEqual(overview.failedEventCount, 0)
+        XCTAssertFalse(overview.events[0].isFailed)
+        XCTAssertFalse(overview.events[0].isInFlight)
+        XCTAssertTrue(overview.events[0].isSkipped)
+        XCTAssertEqual(overview.events[0].stateTitle, "Skipped")
+    }
+
+    func testAgentCopySaysRunsForSchedulesAndEventsForTriggers() {
+        let schedule = AgentDefinition.schedule(scheduledTask())
+        let trigger = AgentDefinition.trigger(trigger(id: "mail"))
+
+        XCTAssertEqual(schedule.vocabulary, .runs)
+        XCTAssertEqual(trigger.vocabulary, .events)
+        XCTAssertEqual(
+            AgentOverview.Status.failing.title(for: schedule.vocabulary), "Last run failed"
+        )
+        XCTAssertEqual(
+            AgentOverview.Status.failing.title(for: trigger.vocabulary), "Last event failed"
+        )
+        XCTAssertEqual(
+            AgentOverview.Status.failing.title(for: .events), "Last event failed",
+            "an event agent never reports a run"
+        )
+        for status in [AgentOverview.Status.active, .paused, .stopped, .failing] {
+            XCTAssertFalse(
+                status.detail(for: schedule.vocabulary).localizedCaseInsensitiveContains("event"),
+                "a schedule has runs, not events: \(status)"
+            )
+        }
+    }
+
+    func testAScheduleThatWillNotRunAgainStillSaysSo() {
+        // A one-shot schedule that has fired has no cadence chip, no worktree
+        // and no foreign timezone; an empty chip row would read as a blank gap.
+        let task = scheduledTask(
+            rule: ScheduleRule(kind: .once, hour: 9, minute: 30),
+            nextRunAt: nil
+        )
+        XCTAssertEqual(AgentOverview.scheduleChips(for: task, now: now), ["No further runs"])
+    }
+
+    func testScheduleRulesReadAsSentences() {
+        XCTAssertEqual(AgentOverviewFormatting.rule(ScheduleRule(kind: .daily, hour: 7, minute: 5)), "Daily at 07:05")
+        XCTAssertEqual(AgentOverviewFormatting.rule(ScheduleRule(kind: .weekdays, hour: 18, minute: 0)), "Weekdays at 18:00")
+        XCTAssertEqual(
+            AgentOverviewFormatting.rule(ScheduleRule(kind: .weekly, hour: 9, minute: 0, weekday: 4)),
+            "Weekly on Friday at 09:00",
+            "weekdays are Monday-based, matching the backend"
+        )
+        XCTAssertEqual(
+            AgentOverviewFormatting.rule(ScheduleRule(kind: .interval, every: 15, unit: .minutes)),
+            "Every 15 minutes"
+        )
+        XCTAssertEqual(
+            AgentOverviewFormatting.rule(ScheduleRule(kind: .interval, every: 1, unit: .hours)),
+            "Every hour"
+        )
+        let at = now.timeIntervalSince1970
+        XCTAssertEqual(
+            AgentOverviewFormatting.rule(ScheduleRule(kind: .once, at: at)),
+            "Once on " + now.formatted(date: .abbreviated, time: .shortened)
+        )
+        XCTAssertEqual(AgentOverviewFormatting.upcoming(now.addingTimeInterval(90), now: now), "in 1m")
+        XCTAssertEqual(AgentOverviewFormatting.upcoming(now.addingTimeInterval(-5), now: now), "overdue")
+    }
+
+    func testFleetListsSchedulesBesideTriggersUnderOneOrdering() {
+        var stoppedSchedule = scheduledTask(id: "nightly", name: "Nightly", enabled: false, lastError: "boom")
+        stoppedSchedule.name = "Nightly"
+        let entries = AgentFleet.entries(
+            triggers: [trigger(id: "weather", lastEventAt: now.timeIntervalSince1970 - 60)],
+            connections: [gmail],
+            schedules: [
+                scheduledTask(id: "morning", lastRunAt: now.timeIntervalSince1970 - 30),
+                stoppedSchedule,
+            ],
+            sessions: [
+                SessionSummary(
+                    id: "m1", name: "m1.jsonl", preview: "", mtime: now.timeIntervalSince1970,
+                    size: 1, cwd: "/tmp", agentTriggerID: "morning", agentName: "Morning review",
+                    agentPrimary: true
+                ),
+            ],
+            runningSessionIDs: ["m1"]
+        )
+        XCTAssertEqual(entries.map(\.id), ["nightly", "morning", "weather"])
+        XCTAssertEqual(entries[0].status, .stopped)
+        XCTAssertEqual(entries[1].summary, "Schedule · Weekdays at 09:30 · Work")
+        XCTAssertEqual(entries[1].chatCount, 1)
+        XCTAssertEqual(entries[1].runningChatCount, 1)
+        XCTAssertNil(entries[1].connection)
+        XCTAssertEqual(entries[2].name, "Weather watch")
+    }
+
+    @MainActor
+    func testAgentDefinitionsAndEventChatOwnershipCoverBothKinds() {
+        let model = AppModel(startImmediately: false)
+        model.eventAutomations.seedForUITesting(connections: [gmail], triggers: [trigger()], deliveries: [])
+        model.schedule.seedForUITesting(tasks: [scheduledTask()])
+        model.sessions = [
+            session("chat-new", age: 60),
+            SessionSummary(
+                id: "morning-chat", name: "morning-chat.jsonl", preview: "", mtime: 1, size: 1,
+                cwd: "/tmp", agentTriggerID: "morning", agentName: "Morning review", agentPrimary: true
+            ),
+            SessionSummary(
+                id: "morning-side", name: "morning-side.jsonl", preview: "", mtime: 1, size: 1,
+                cwd: "/tmp", agentTriggerID: "morning", agentName: "Morning review"
+            ),
+            session("plain", triggerID: nil, name: nil, age: 5),
+        ]
+
+        XCTAssertEqual(model.agentDefinition(for: "weather")?.trigger?.id, "weather")
+        XCTAssertEqual(model.agentDefinition(for: "morning")?.schedule?.id, "morning")
+        XCTAssertNil(model.agentDefinition(for: "gone"))
+        XCTAssertNil(model.agentDefinition(for: nil))
+
+        let byID = Dictionary(uniqueKeysWithValues: model.sessions.map { ($0.id, $0) })
+        // The trigger's target chat is its event chat even without the flag.
+        XCTAssertEqual(model.agentOwningEventChat(byID["chat-new"]!)?.name, "Weather watch")
+        XCTAssertEqual(model.agentOwningEventChat(byID["morning-chat"]!)?.name, "Morning review")
+        XCTAssertNil(model.agentOwningEventChat(byID["morning-side"]!), "side chats are not protected")
+        XCTAssertNil(model.agentOwningEventChat(byID["plain"]!))
     }
 
     // MARK: Filters
@@ -656,9 +953,26 @@ final class AgentOverviewTests: XCTestCase {
         model.eventAutomations.seedForUITesting(
             connections: [], triggers: [trigger(id: "someone-else")], deliveries: []
         )
+        model.schedule.seedForUITesting(tasks: [])
         model.newAgentChat()
         XCTAssertFalse(model.configureAgentPresented)
-        XCTAssertEqual(model.toastCenter.toast?.message.contains("trigger was deleted"), true)
+        XCTAssertEqual(model.toastCenter.toast?.message.contains("was deleted"), true)
+    }
+
+    @MainActor
+    func testAMissingAgentIsNotCalledDeletedBeforeBothStoresHaveAnswered() {
+        let model = AppModel(startImmediately: false)
+        model.sessions = [session("chat-new", age: 60)]
+        model.currentSessionID = "chat-new"
+        // Triggers are in; schedules have not answered yet, so an agent that is
+        // in neither list may still be a schedule that is on its way.
+        model.eventAutomations.seedForUITesting(
+            connections: [], triggers: [trigger(id: "someone-else")], deliveries: []
+        )
+
+        model.newAgentChat()
+
+        XCTAssertNil(model.toastCenter.toast?.message)
     }
 
     @MainActor

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -1879,6 +1879,60 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(anyElement("inspector.rail.agent").exists)
     }
 
+    func testAScheduledAgentIsAnAgentInTheSidebarAndTheFleet() {
+        relaunchWithAgentFixture("fleet")
+
+        // The schedule's dedicated chat groups under the schedule like any agent.
+        let group = anyElement("agent.seed-schedule")
+        XCTAssertTrue(group.waitForExistence(timeout: Self.launchContentTimeout))
+        XCTAssertTrue((group.label + " " + (group.value as? String ?? "")).contains("Active"))
+        XCTAssertTrue(anyElement("session.seed-schedule-chat").exists)
+
+        // The fleet lists it with its cadence, not a connector.
+        let row = anyElement("agentOverview.fleet.seed-schedule")
+        XCTAssertTrue(row.waitForExistence(timeout: 3))
+        XCTAssertTrue(row.label.contains("Morning Review"))
+        XCTAssertTrue(row.label.contains("Active"))
+
+        // Schedules gain the one action triggers cannot have.
+        group.rightClick()
+        XCTAssertTrue(
+            app.menuItems["agent.seed-schedule.runNow"].waitForExistence(timeout: 3)
+                || app.descendants(matching: .any)["agent.seed-schedule.runNow"].exists
+        )
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    func testTheAgentPanelForAScheduleShowsItsCadenceRunsAndSkippedSlot() {
+        relaunchWithAgentFixture("schedule")
+
+        // A schedule is an agent: same panel, its own words.
+        let source = anyElement("agentOverview.source")
+        XCTAssertTrue(source.waitForExistence(timeout: Self.launchContentTimeout))
+        let sourceText = source.label + " " + (source.value as? String ?? "")
+        XCTAssertTrue(sourceText.contains("Weekdays at 09:00"), "the cadence is what starts it")
+
+        // Run Now is the action only a schedule has.
+        XCTAssertTrue(anyElement("agentOverview.runNow").exists)
+
+        // Its arrivals are runs, not events.
+        let runs = anyElement("agentOverview.stats.events")
+        XCTAssertTrue((runs.label + " " + (runs.value as? String ?? "")).contains("Runs"))
+
+        // The slot that was skipped left the agent healthy: a run overlapping
+        // the one before it is a normal outcome, not something to look at.
+        let status = anyElement("agentOverview.status")
+        XCTAssertTrue(
+            (status.label + " " + (status.value as? String ?? "")).contains("Active"),
+            "a skipped run is not a failure"
+        )
+
+        // Both tiles speak of runs, so the panel never calls a scheduled run
+        // an event.
+        let last = anyElement("agentOverview.stats.lastEvent")
+        XCTAssertTrue((last.label + " " + (last.value as? String ?? "")).contains("Last run"))
+    }
+
     func testAStoppedAgentReadsDifferentlyFromAPausedOneInSidebarAndFleet() {
         relaunchWithAgentFixture("fleet")
 

--- a/agent/ollama_code/api/event_triggers.py
+++ b/agent/ollama_code/api/event_triggers.py
@@ -178,7 +178,20 @@ def trigger_target_create(
     if not name:
         raise HTTPException(422, "agent name is required")
 
-    for summary in SessionStore.summaries(limit=500, include_archived=True):
+    candidates = SessionStore.summaries(limit=500, include_archived=True)
+    # Side chats share the agent id; only the primary chat may be recovered as
+    # the event destination. The trigger's own target wins, because an agent
+    # made before the flag existed marks none of its chats, and its history
+    # must not move to whichever side chat was touched most recently.
+    trigger = service.run_store.event_trigger(trigger_id)
+    current_target = str((trigger or {}).get("target_session_id") or "")
+    candidates.sort(
+        key=lambda item: (
+            str(item.get("id")) != current_target,
+            not bool(item.get("agent_primary")),
+        )
+    )
+    for summary in candidates:
         metadata = SessionMeta.get(str(summary["id"]))
         if metadata.get("agent_trigger_id") == trigger_id:
             workspace = str(summary.get("cwd") or "")
@@ -197,6 +210,7 @@ def trigger_target_create(
                         provider_account_id=account_id or None,
                         provider_account_label=account_label or None,
                         agent_name=name,
+                        agent_primary=True,
                     )
                 _detach_agent_session(str(summary["id"]), workspace)
                 summary = next(
@@ -238,6 +252,7 @@ def trigger_target_create(
         provider_account_label=account_label or None,
         agent_trigger_id=trigger_id,
         agent_name=name,
+        agent_primary=True,
     )
 
     _detach_agent_session(session_id, cwd)

--- a/agent/ollama_code/api/schedules.py
+++ b/agent/ollama_code/api/schedules.py
@@ -1,6 +1,8 @@
 """Scheduled and companion chat dispatch routes."""
 
+import hashlib
 import re
+import threading
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -20,6 +22,7 @@ from ..worktrees import (
     is_git_workspace,
 )
 from .dependencies import get_service
+from .event_triggers import _detach_agent_session
 
 ServiceDependency = Annotated[ChatService, Depends(get_service)]
 
@@ -67,6 +70,267 @@ def _scheduled_chat_title(schedule: dict[str, Any], scheduled_for: float) -> str
     zone = schedule_timezone(str(schedule["timezone"]))
     value = datetime.fromtimestamp(scheduled_for, zone).strftime("%b %d, %Y %H:%M")
     return f"{schedule['name']} · {value.replace(' 0', ' ')}"
+
+
+class _OccurrenceSkipped(Exception):
+    """The dedicated chat was busy, so this occurrence was recorded and skipped."""
+
+
+def _checkout_task_id(schedule_id: str, workspace_root: str) -> str:
+    """A worktree id the checkout store accepts, stable for the schedule.
+
+    The workspace is part of the id so that pointing a schedule at another
+    repository takes a fresh checkout and leaves the old one recoverable
+    rather than silently reusing a checkout of the wrong tree.
+    """
+    cleaned = "".join(ch if ch.isalnum() or ch in "_-" else "-" for ch in schedule_id)
+    digest = hashlib.sha256(workspace_root.encode("utf-8")).hexdigest()[:8]
+    return f"schedule-{cleaned}"[:110] + f"-{digest}"
+
+
+def _schedule_session_id(schedule_id: str) -> str | None:
+    """The dedicated chat every run of this schedule continues, if it exists."""
+    for session_id, entry in SessionMeta.all().items():
+        if (
+            entry.get("agent_trigger_id") == schedule_id
+            and entry.get("agent_primary")
+            and SessionStore.path_for(session_id) is not None
+        ):
+            return session_id
+    return None
+
+
+def _local_metadata(workspace_root: str) -> dict[str, Any]:
+    return {
+        "workspace_root": workspace_root,
+        "execution_path": workspace_root,
+        "environment": {"type": "local", "isolation": "local"},
+        "task": None,
+    }
+
+
+def _checkout_metadata(record: TaskCheckout) -> dict[str, Any]:
+    return {
+        "workspace_root": record.workspace_root,
+        "execution_path": record.execution_path,
+        "task": record.as_dict(),
+        "environment": {
+            "type": "worktree",
+            "isolation": "managed_worktree",
+            "worktree_id": record.id,
+            "starting_ref": record.starting_ref,
+        },
+    }
+
+
+def _schedule_checkout(schedule: dict[str, Any], *, session_id: str | None) -> TaskCheckout:
+    """The one worktree a scheduled agent runs in, created or repaired.
+
+    A schedule keeps a single checkout rather than one per run, which makes it
+    durable state: it is marked permanent so pruning leaves it alone, and it is
+    restored when an archive or an older prune has already taken it away.
+    """
+    workspace_root = _schedule_workspace(schedule["workspace_root"])
+    task_id = _checkout_task_id(str(schedule["id"]), workspace_root)
+    record = TaskCheckoutStore.load(task_id)
+    if record is None:
+        # A creation the app did not finish leaves a directory that would
+        # refuse every later attempt at this stable id.
+        TaskCheckoutStore.discard_unreadable(workspace_root, task_id)
+        record = TaskCheckoutStore.create(workspace_root, task_id, session_id=session_id)
+    elif not Path(record.execution_path).is_dir():
+        record = TaskCheckoutStore.restore(task_id)
+    if not record.permanent or (session_id and record.session_id != session_id):
+        record.permanent = True
+        if session_id:
+            record.session_id = session_id
+        record.save()
+    return record
+
+
+def _release_checkout(metadata: dict[str, Any], *, keep: str) -> None:
+    """Let pruning reclaim a checkout the agent has moved away from."""
+    task = metadata.get("task")
+    task_id = str(task.get("id") or "") if isinstance(task, dict) else ""
+    if not task_id or task_id == keep:
+        return
+    record = TaskCheckoutStore.load(task_id)
+    if record is not None and record.permanent:
+        record.permanent = False
+        record.save()
+
+
+def _schedule_location(
+    schedule: dict[str, Any], *, session_id: str, metadata: dict[str, Any]
+) -> dict[str, Any]:
+    """Where the agent's runs execute, kept in step with the schedule.
+
+    Every dispatch reads the workspace and checkout from the chat, so an edit
+    that changed either would otherwise leave the agent working in the place
+    it was created while the editor reported the new one.
+    """
+    workspace_root = _schedule_workspace(schedule["workspace_root"])
+    if str(schedule["execution_environment"]) != "worktree":
+        _release_checkout(metadata, keep="")
+        if (
+            str(metadata.get("workspace_root") or "") == workspace_root
+            and str(metadata.get("execution_path") or "") == workspace_root
+            and not metadata.get("task")
+        ):
+            return {}
+        return _local_metadata(workspace_root)
+    record = _schedule_checkout(schedule, session_id=session_id)
+    _release_checkout(metadata, keep=record.id)
+    return _checkout_metadata(record)
+
+
+def _refresh_schedule_checkout(session_id: str, metadata: dict[str, Any]) -> dict[str, Any]:
+    """Start a scheduled run from today's workspace, not the day it was made.
+
+    One lasting checkout would otherwise replay the commit that was current
+    when the schedule was created. Anything the agent left uncommitted is
+    kept: only a clean checkout is rebuilt.
+    """
+    task = metadata.get("task")
+    task_id = str(task.get("id") or "") if isinstance(task, dict) else ""
+    if not task_id:
+        return metadata
+    record = TaskCheckoutStore.load(task_id)
+    if record is None or not Path(record.execution_path).is_dir():
+        return metadata
+    try:
+        patch, _ = record.patch()
+    except WorktreeError:
+        # Unreadable work is still work: keep the checkout as it is rather
+        # than rebuilding over it.
+        return metadata
+    if patch.strip():
+        return metadata
+    refreshed = TaskCheckoutStore.refresh_from_workspace(task_id)
+    refreshed.permanent = True
+    refreshed.session_id = session_id
+    refreshed.save()
+    return SessionMeta.update(session_id, **_checkout_metadata(refreshed))
+
+
+def _ensure_schedule_session(schedule: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Return the schedule's dedicated chat, creating it on first use.
+
+    A scheduled agent, like an event agent, owns one lasting conversation that
+    every run continues, so the person reads a history rather than a scatter
+    of single-run chats. It is created with the schedule so Agents mode shows
+    the agent before its first run, and its name, route and workspace follow
+    the schedule's.
+    """
+    schedule_id = str(schedule["id"])
+    name = str(schedule["name"])
+    provider = str(schedule["provider"])
+    model = str(schedule["model"])
+    account_id = str(schedule.get("provider_account_id") or "")
+    workspace_root = _schedule_workspace(schedule["workspace_root"])
+    identity: dict[str, Any] = {
+        "title": name,
+        "agent_name": name,
+        "provider": provider,
+        "model": model,
+        "provider_account_id": account_id or None,
+        "team": (
+            {"id": schedule.get("team_id"), "name": schedule.get("team_name")}
+            if schedule["runner"] == "team"
+            else None
+        ),
+    }
+
+    existing = _schedule_session_id(schedule_id)
+    if existing is not None:
+        location = _schedule_location(
+            schedule, session_id=existing, metadata=SessionMeta.get(existing)
+        )
+        return existing, SessionMeta.update(existing, **identity, **location)
+
+    # The checkout comes first: a worktree that cannot be made must not leave
+    # an untitled chat behind in the workspace.
+    record = (
+        _schedule_checkout(schedule, session_id=None)
+        if str(schedule["execution_environment"]) == "worktree"
+        else None
+    )
+    session = SessionStore(workspace_root, model, provider, account_id=account_id)
+    session_id = session.session_id
+    if record is not None:
+        record.session_id = session_id
+        record.save()
+    SessionMeta.update(
+        session_id,
+        **identity,
+        **(_checkout_metadata(record) if record is not None else _local_metadata(workspace_root)),
+        schedule_id=schedule_id,
+        agent_trigger_id=schedule_id,
+        agent_primary=True,
+    )
+    _detach_agent_session(session_id, workspace_root)
+    return session_id, SessionMeta.get(session_id)
+
+
+def _record_skip(store: Any, occurrence: dict[str, Any], session_id: str) -> None:
+    """Note an overlapping occurrence without marking the agent as failing.
+
+    Claiming advances the cadence before the chat is known to be free, and for
+    a schedule that runs once that also switches it off. A skip there would
+    drop the only run and leave the agent reading as though a person had
+    paused it, so the slot goes back and the next tick tries again.
+    """
+    store.finish_schedule_occurrence(
+        str(occurrence["id"]),
+        state="skipped",
+        session_id=session_id,
+        error="Skipped: the previous run in this agent's chat was still in progress.",
+    )
+    schedule = store.schedule(str(occurrence["schedule_id"])) or {}
+    if (
+        str(occurrence.get("trigger") or "") == "due"
+        and not schedule.get("enabled")
+        and schedule.get("next_run_at") is None
+    ):
+        store.rearm_schedule_slot(
+            str(occurrence["schedule_id"]),
+            next_run_at=float(occurrence["scheduled_for"]),
+        )
+
+
+def _queue_scheduled_run(
+    store: Any,
+    run_id: str,
+    occurrence: dict[str, Any],
+    session_id: str,
+    **fields: Any,
+) -> dict[str, Any]:
+    """Reserve the run, or skip when something reached the chat first.
+
+    The check and the reservation share the store lock, so a due tick and a
+    Run Now that arrive together cannot both queue a turn into the one chat.
+    """
+    try:
+        return store.queue_run_if_idle(run_id, session_id=session_id, **fields)
+    except RunStoreError as exc:
+        if str(exc) != "the chat is busy":
+            raise
+        _record_skip(store, occurrence, session_id)
+        raise _OccurrenceSkipped() from None
+
+
+def _session_summary(session_id: str) -> dict[str, Any]:
+    summary = next(
+        (
+            item
+            for item in SessionStore.summaries(limit=500, include_archived=True)
+            if item["id"] == session_id
+        ),
+        None,
+    )
+    if summary is None:
+        raise HTTPException(500, "the agent chat could not be created")
+    return summary
 
 
 def _companion_chat_title(prompt: str) -> str:
@@ -197,7 +461,35 @@ def _dispatch_companion_chat(
     return {"ok": True, "claimed": True, "run": run}
 
 
+_DISPATCH_LOCKS: dict[str, threading.Lock] = {}
+_DISPATCH_LOCKS_GUARD = threading.Lock()
+
+
+def _dispatch_lock(schedule_id: str) -> threading.Lock:
+    with _DISPATCH_LOCKS_GUARD:
+        return _DISPATCH_LOCKS.setdefault(schedule_id, threading.Lock())
+
+
 def _dispatch_schedule(
+    service: ChatService,
+    schedule_id: str,
+    *,
+    trigger: str,
+    request_id: str = "",
+) -> dict[str, Any]:
+    """Run one occurrence of a schedule, one dispatch at a time.
+
+    A due tick and a Run Now can arrive together, and both rebuild and reserve
+    the agent's single chat and checkout. Without this lock the second would
+    find the worktree mid-rebuild and pause the whole agent.
+    """
+    with _dispatch_lock(schedule_id):
+        return _dispatch_claimed_schedule(
+            service, schedule_id, trigger=trigger, request_id=request_id
+        )
+
+
+def _dispatch_claimed_schedule(
     service: ChatService,
     schedule_id: str,
     *,
@@ -228,7 +520,6 @@ def _dispatch_schedule(
             "run": run,
         }
 
-    task: TaskCheckout | None = None
     session_id = ""
     run_id = str(occurrence["id"])
     try:
@@ -237,51 +528,20 @@ def _dispatch_schedule(
         if environment == "worktree" and not is_git_workspace(workspace_root):
             raise WorktreeError("scheduled worktrees require a Git repository")
 
-        session = SessionStore(
-            workspace_root,
-            str(schedule["model"]),
-            str(schedule["provider"]),
-            str(schedule.get("provider_account_id") or ""),
-        )
-        session_id = session.session_id
-        execution_path = workspace_root
-        metadata: dict[str, Any] = {
-            "title": _scheduled_chat_title(
-                schedule,
-                float(occurrence["scheduled_for"]),
-            ),
-            "workspace_root": workspace_root,
-            "execution_path": workspace_root,
-            "environment": {"type": "local", "isolation": "local"},
-            "schedule_id": schedule_id,
-            "occurrence_id": occurrence["id"],
-        }
+        session_id, metadata = _ensure_schedule_session(schedule)
+        if store.session_has_active_run(session_id):
+            # The previous occurrence is still running in this chat. Record the
+            # skip against this occurrence and leave the schedule enabled: the
+            # next occurrence runs as usual, and an overlap is not a failure of
+            # the agent. Stacking a second turn would send it into the worker
+            # mid-turn.
+            _record_skip(store, occurrence, session_id)
+            raise _OccurrenceSkipped()
         if environment == "worktree":
-            task = TaskCheckoutStore.create(
-                workspace_root,
-                str(occurrence["id"]),
-                session_id=session_id,
-            )
-            execution_path = task.execution_path
-            metadata.update(
-                {
-                    "workspace_root": task.workspace_root,
-                    "execution_path": task.execution_path,
-                    "task": task.as_dict(),
-                    "environment": {
-                        "type": "worktree",
-                        "isolation": "managed_worktree",
-                        "worktree_id": task.id,
-                        "starting_ref": task.starting_ref,
-                    },
-                }
-            )
-        if schedule["runner"] == "team":
-            metadata["team"] = {
-                "id": schedule.get("team_id"),
-                "name": schedule.get("team_name"),
-            }
-        SessionMeta.update(session_id, **metadata)
+            metadata = _refresh_schedule_checkout(session_id, metadata)
+        execution_path = str(metadata.get("execution_path") or workspace_root)
+        if not Path(execution_path).is_dir():
+            raise HTTPException(409, "the agent's checkout is unavailable")
 
         manifest = {
             "scheduled": True,
@@ -297,12 +557,14 @@ def _dispatch_schedule(
             "model": schedule["model"],
             "timezone": schedule["timezone"],
         }
-        run = store.queue_run(
+        run = _queue_scheduled_run(
+            store,
             run_id,
-            session_id=session_id,
+            occurrence,
+            session_id,
             team_id=str(schedule.get("team_id") or ""),
             team_name=str(schedule.get("team_name") or ""),
-            workspace_root=workspace_root,
+            workspace_root=str(metadata.get("workspace_root") or workspace_root),
             execution_path=execution_path,
             request=str(schedule["prompt"]),
             run_kind="team" if schedule["runner"] == "team" else "solo",
@@ -325,13 +587,13 @@ def _dispatch_schedule(
             "occurrence": occurrence,
             "run": run,
         }
+    except _OccurrenceSkipped:
+        raise HTTPException(
+            409,
+            f"skipped this run: the previous run in {schedule['name']}'s chat is still in progress",
+        ) from None
     except (HTTPException, WorktreeError, OSError, RunStoreError) as exc:
         detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
-        if task is not None:
-            try:
-                TaskCheckoutStore.cleanup(task.id)
-            except WorktreeError:
-                pass
         try:
             store.finish_schedule_occurrence(
                 str(occurrence["id"]),
@@ -347,10 +609,66 @@ def _dispatch_schedule(
         raise HTTPException(status, str(detail)) from exc
 
 
+_ADOPTION_LOCK = threading.Lock()
+_ADOPTED_SCHEDULES: set[str] = set()
+
+
+def _adopt_pre_agent_schedules(schedules: list[dict[str, Any]]) -> None:
+    """Give schedules made before they were agents their dedicated chat.
+
+    Updating the app is then enough for them to appear in Agents mode, and
+    the chats their earlier runs left behind become that agent's side
+    conversations instead of loose chats in the workspace. Each schedule is
+    adopted once per run of the backend, under a lock so two overlapping
+    listings cannot both create a chat for one schedule.
+    """
+    pending = [
+        schedule
+        for schedule in schedules
+        if str(schedule.get("id") or "") and str(schedule["id"]) not in _ADOPTED_SCHEDULES
+    ]
+    if not pending:
+        return
+    with _ADOPTION_LOCK:
+        entries = SessionMeta.all()
+        primary = {
+            str(entry.get("agent_trigger_id")): session_id
+            for session_id, entry in entries.items()
+            if entry.get("agent_primary") and entry.get("agent_trigger_id")
+        }
+        for schedule in pending:
+            schedule_id = str(schedule["id"])
+            try:
+                if primary.get(schedule_id) is None:
+                    _ensure_schedule_session(schedule)
+                _adopt_earlier_run_chats(schedule_id, str(schedule["name"]), entries)
+            except (HTTPException, WorktreeError, RunStoreError, OSError):
+                # Listing must not fail because one schedule could not be
+                # adopted; the next listing tries again.
+                continue
+            _ADOPTED_SCHEDULES.add(schedule_id)
+
+
+def _adopt_earlier_run_chats(
+    schedule_id: str, name: str, entries: dict[str, dict[str, Any]]
+) -> None:
+    """Group the single-run chats older builds made under their agent."""
+    for session_id, entry in entries.items():
+        if (
+            str(entry.get("schedule_id") or "") == schedule_id
+            and not entry.get("agent_trigger_id")
+            and SessionStore.path_for(session_id) is not None
+        ):
+            SessionMeta.update(session_id, agent_trigger_id=schedule_id, agent_name=name)
+
+
 def schedule_list(service: ServiceDependency) -> dict[str, Any]:
     _require_capability("durable_runs")
     store = service.run_store
-    return {"schedules": store.schedules(), "read_only": store.read_only}
+    schedules = store.schedules()
+    if not store.read_only:
+        _adopt_pre_agent_schedules(schedules)
+    return {"schedules": schedules, "read_only": store.read_only}
 
 
 def schedule_create(
@@ -358,10 +676,22 @@ def schedule_create(
     body: dict[str, Any] = Body(default_factory=dict),
 ) -> dict[str, Any]:
     _require_capability("durable_runs")
+    store = service.run_store
     try:
-        return service.run_store.create_schedule(_validate_schedule_payload(body))
+        schedule = store.create_schedule(_validate_schedule_payload(body))
     except RunStoreError as exc:
         raise HTTPException(422, str(exc)) from exc
+    try:
+        _ensure_schedule_session(schedule)
+    except (HTTPException, WorktreeError, OSError) as exc:
+        # A schedule without its chat is not an agent; do not leave half of one.
+        try:
+            store.delete_schedule(str(schedule["id"]))
+        except RunStoreError:
+            pass
+        detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
+        raise HTTPException(409, f"the agent chat could not be created: {detail}") from exc
+    return schedule
 
 
 def schedule_update(
@@ -375,17 +705,77 @@ def schedule_update(
     if existing is None:
         raise HTTPException(404, "schedule not found")
     try:
-        return store.update_schedule(
-            schedule_id,
-            _validate_schedule_payload(body, existing=existing),
-        )
+        payload = _validate_schedule_payload(body, existing=existing)
+    except RunStoreError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    proposed = {**existing, **payload}
+    moved = (
+        str(proposed["workspace_root"]) != str(existing["workspace_root"])
+        or str(proposed["execution_environment"]) != str(existing["execution_environment"])
+    )
+    # The chat moves first: a move that cannot be made must leave the schedule
+    # exactly as it was, rather than pointing somewhere its runs cannot go.
+    # Anything else — renaming, pausing, changing the prompt — stays possible
+    # even when the chat cannot be rebuilt right now.
+    try:
+        _ensure_schedule_session(proposed)
+    except (HTTPException, WorktreeError, RunStoreError, OSError) as exc:
+        if moved:
+            detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
+            raise HTTPException(409, str(detail)) from exc
+    try:
+        updated = store.update_schedule(schedule_id, payload)
     except RunStoreError as exc:
         status = 404 if str(exc) == "schedule not found" else 422
         raise HTTPException(status, str(exc)) from exc
+    return updated
+
+
+def schedule_task_create(
+    schedule_id: str,
+    service: ServiceDependency,
+    body: dict[str, Any] = Body(default_factory=dict),
+) -> dict[str, Any]:
+    """Create a side conversation beneath a scheduled agent.
+
+    It carries the agent's identity, workspace, and model but never receives a
+    scheduled run; those continue the dedicated chat.
+    """
+    _require_capability("durable_runs")
+    schedule = service.run_store.schedule(schedule_id)
+    if schedule is None:
+        raise HTTPException(404, "schedule not found")
+    workspace_root = _schedule_workspace(schedule["workspace_root"])
+    provider = str(schedule["provider"])
+    model = str(schedule["model"])
+    account_id = str(schedule.get("provider_account_id") or "")
+    title = " ".join(str(body.get("name") or "New chat").split())[:120] or "New chat"
+    session = SessionStore(workspace_root, model, provider, account_id=account_id)
+    session_id = session.session_id
+    SessionMeta.update(
+        session_id,
+        title=title,
+        workspace_root=workspace_root,
+        execution_path=workspace_root,
+        environment={"type": "local", "isolation": "local"},
+        provider=provider,
+        model=model,
+        provider_account_id=account_id or None,
+        schedule_id=schedule_id,
+        agent_trigger_id=schedule_id,
+        agent_name=str(schedule["name"]),
+    )
+    _detach_agent_session(session_id, workspace_root)
+    return {"ok": True, "session": _session_summary(session_id), "created": True}
 
 
 def schedule_delete(schedule_id: str, service: ServiceDependency) -> dict[str, Any]:
     _require_capability("durable_runs")
+    session_id = _schedule_session_id(schedule_id)
+    if session_id is not None:
+        # The agent's checkout was kept out of pruning's reach while it
+        # existed; with the agent gone it is ordinary again.
+        _release_checkout(SessionMeta.get(session_id), keep="")
     try:
         service.run_store.delete_schedule(schedule_id)
     except RunStoreError as exc:
@@ -468,6 +858,9 @@ def register_routes(router: APIRouter) -> None:
     )
     router.add_api_route(
         "/api/schedules/{schedule_id}/dispatch", schedule_dispatch, methods=["POST"]
+    )
+    router.add_api_route(
+        "/api/schedules/{schedule_id}/tasks", schedule_task_create, methods=["POST"]
     )
     router.add_api_route(
         "/api/companion/chats", companion_chat_dispatch, methods=["POST"]

--- a/agent/ollama_code/api/sessions.py
+++ b/agent/ollama_code/api/sessions.py
@@ -43,6 +43,25 @@ def _session_has_active_run(service: ChatService, session_id: str) -> bool:
     return session_has_active_run(service.run_store, session_id)
 
 
+def _agent_owning_chat(service: ChatService, session_id: str) -> str | None:
+    """The agent whose events land in this chat, if one still exists.
+
+    Deleting that chat would leave the agent pointing at nothing: every later
+    dispatch fails, the agent is paused with a 404, and even resuming or
+    renaming it fails because target validation runs first. Refusing here is
+    the only place the repair is cheap.
+    """
+    for trigger in service.run_store.event_triggers():
+        if str(trigger.get("target_session_id") or "") == session_id:
+            return str(trigger.get("name") or "an agent")
+    entry = SessionMeta.get(session_id)
+    if entry.get("agent_primary") and entry.get("agent_trigger_id"):
+        schedule = service.run_store.schedule(str(entry["agent_trigger_id"]))
+        if schedule is not None:
+            return str(schedule.get("name") or entry.get("agent_name") or "an agent")
+    return None
+
+
 def sessions(
     service: ServiceDependency,
     include_archived: bool = False,
@@ -243,6 +262,11 @@ def session_delete(session_id: str, service: ServiceDependency) -> dict[str, Any
         raise HTTPException(404, f"session not found: {session_id}")
     if _session_has_active_run(service, session_id):
         raise HTTPException(409, "wait for this chat to stop before deleting it")
+    owner = _agent_owning_chat(service, session_id)
+    if owner is not None:
+        raise HTTPException(
+            409, f"this chat receives {owner}'s events; delete the agent first"
+        )
     try:
         with service.state_mutation():
             deleted_active = session_id == service.core.session.session_id
@@ -497,6 +521,10 @@ def session_metadata_update(
             raise HTTPException(422, f"{field} must be true or false")
 
     archived = body.get("archived")
+    if archived and (owner := _agent_owning_chat(service, session_id)):
+        # Archiving takes the chat's worktree with it, which would leave the
+        # agent with nowhere to run and no way back.
+        raise HTTPException(409, f"this chat receives {owner}'s runs; pause the agent instead")
     if archived and session_id == service.core.session.session_id:
         raise HTTPException(409, "start a new session before archiving the active one")
     if archived and _session_has_active_run(service, session_id):

--- a/agent/ollama_code/runstore.py
+++ b/agent/ollama_code/runstore.py
@@ -2106,8 +2106,8 @@ class RunStore:
     ) -> dict[str, Any]:
         if self.read_only:
             raise RunStoreError("the run database is read-only")
-        if state not in {"queued", "failed"}:
-            raise RunStoreError("occurrence state must be queued or failed")
+        if state not in {"queued", "failed", "skipped"}:
+            raise RunStoreError("occurrence state must be queued, failed or skipped")
         current = time.time()
         with self._lock, self._connect() as connection:
             row = connection.execute(
@@ -2126,13 +2126,17 @@ class RunStore:
                     current, occurrence_id,
                 ),
             )
-            connection.execute(
-                "UPDATE schedules SET last_run_id=?, last_error=?, updated_at=? WHERE id=?",
-                (
-                    run_id or None, error[:4_000] or None, current,
-                    occurrence["schedule_id"],
-                ),
-            )
+            if state != "skipped":
+                # A skipped occurrence is a healthy overlap, not a failure: it
+                # must not overwrite the schedule's last run or raise its
+                # error, which is what the agent's status is read from.
+                connection.execute(
+                    "UPDATE schedules SET last_run_id=?, last_error=?, updated_at=? WHERE id=?",
+                    (
+                        run_id or None, error[:4_000] or None, current,
+                        occurrence["schedule_id"],
+                    ),
+                )
             updated = connection.execute(
                 "SELECT * FROM schedule_occurrences WHERE id=?", (occurrence_id,)
             ).fetchone()
@@ -2218,6 +2222,55 @@ class RunStore:
                         (position, message_id[:160], retry_parent_id[:160] or None, run_id),
                     )
         return self.run(run_id) or {}
+
+    def queue_run_if_idle(self, run_id: str, *, session_id: str, **fields: Any) -> dict[str, Any]:
+        """Queue a run only while the chat has nothing in flight.
+
+        The check and the reservation share the store lock, so a due tick and
+        a Run Now arriving together cannot both put a turn into one chat.
+        """
+        with self._lock:
+            if self.session_has_active_run(session_id):
+                raise RunStoreError("the chat is busy")
+            return self.queue_run(run_id, session_id=session_id, **fields)
+
+    def session_has_active_run(self, session_id: str) -> bool:
+        """Whether a run with a live owner is working in this chat.
+
+        A paused or interrupted run is waiting for a person, not working: it
+        must not count, or one unattended pause would silence a scheduled
+        agent for as long as the app stays open.
+        """
+        if not session_id:
+            return False
+        active = sorted(ACTIVE_NONRECOVERABLE_STATES | {"waiting_dispatch_approval"})
+        places = ",".join("?" * len(active))
+        with self._lock, self._connect(readonly=True) as connection:
+            row = connection.execute(
+                f"SELECT 1 FROM runs WHERE session_id=? AND state IN ({places}) LIMIT 1",
+                (session_id, *active),
+            ).fetchone()
+        return row is not None
+
+    def rearm_schedule_slot(self, schedule_id: str, *, next_run_at: float) -> dict[str, Any]:
+        """Put back a slot whose occurrence was skipped rather than run.
+
+        Claiming an occurrence advances the cadence before the chat is known
+        to be free, and for a one-shot schedule that also switches it off. A
+        skip would otherwise drop the only run and leave the agent looking as
+        though a person had paused it.
+        """
+        if self.read_only:
+            raise RunStoreError("the run database is read-only")
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                "UPDATE schedules SET enabled=1, next_run_at=?, last_error=NULL,"
+                " updated_at=? WHERE id=?",
+                (float(next_run_at), time.time(), schedule_id),
+            )
+            if cursor.rowcount != 1:
+                raise RunStoreError("schedule not found")
+        return self.schedule(schedule_id) or {}
 
     def reorder_queue(self, run_id: str, action: str) -> dict[str, Any]:
         if self.read_only:

--- a/agent/ollama_code/sessions.py
+++ b/agent/ollama_code/sessions.py
@@ -1197,6 +1197,11 @@ class SessionStore:
                 "environment": entry.get("environment"),
                 "agent_trigger_id": entry.get("agent_trigger_id"),
                 "agent_name": entry.get("agent_name"),
+                # The one chat an agent's events land in, as opposed to a side
+                # conversation started under the same identity.
+                "agent_primary": bool(entry.get("agent_primary") or False),
+                "model": entry.get("model"),
+                "provider": entry.get("provider"),
                 "folder_id": (
                     placement.get("folder_id") if isinstance(placement, dict) else None
                 ),

--- a/agent/ollama_code/worktrees.py
+++ b/agent/ollama_code/worktrees.py
@@ -478,6 +478,34 @@ class TaskCheckoutStore:
         return record
 
     @staticmethod
+    def discard_unreadable(workspace: str, task_id: str) -> bool:
+        """Clear a half-built checkout directory that has no readable record.
+
+        A creation interrupted before its metadata was written leaves a
+        directory that refuses every later create for the same id. Ids derived
+        from their owner are stable, so without this the owner could never
+        rebuild its checkout.
+        """
+        task_dir = (TASKS_DIR / task_id).resolve()
+        if task_dir.parent != TASKS_DIR.resolve() or not task_dir.exists():
+            return False
+        if TaskCheckoutStore.load(task_id) is not None:
+            return False
+        root = Path(workspace).expanduser().resolve()
+        checkout = task_dir / "checkout"
+        if checkout.exists():
+            try:
+                _git(root, "worktree", "remove", "--force", str(checkout))
+            except WorktreeError:
+                pass
+        shutil.rmtree(task_dir, ignore_errors=True)
+        try:
+            _git(root, "worktree", "prune")
+        except WorktreeError:
+            pass
+        return True
+
+    @staticmethod
     def snapshot_and_remove(task_id: str) -> dict[str, Any]:
         """Save a restorable Git object, then remove only the managed checkout."""
         record = TaskCheckoutStore.load(task_id)

--- a/agent/tests/fixtures/server-routes.txt
+++ b/agent/tests/fixtures/server-routes.txt
@@ -77,6 +77,7 @@ DELETE /api/schedules/{schedule_id}
 GET /api/schedules/{schedule_id}/occurrences
 POST /api/schedules/{schedule_id}/pause
 POST /api/schedules/{schedule_id}/dispatch
+POST /api/schedules/{schedule_id}/tasks
 GET /api/connectors
 POST /api/connectors
 PATCH /api/connectors/{connection_id}

--- a/agent/tests/test_backend.py
+++ b/agent/tests/test_backend.py
@@ -2249,8 +2249,13 @@ def test_schedule_crud_and_manual_dispatch_preserve_foreground_chat(client, tmp_
     assert client.app.state.service.core.session.session_id == foreground
     scheduled_session = result["run"]["session_id"]
     assert SessionStore.path_for(scheduled_session) is not None
+    # A schedule is an agent: every run continues its one dedicated chat,
+    # which carries the schedule's current name rather than a run timestamp.
     metadata = SessionMeta.get(scheduled_session)
-    assert metadata["title"].startswith("Weekly dependency audit · ")
+    assert metadata["title"] == "Weekly dependency audit"
+    assert metadata["agent_trigger_id"] == schedule_id
+    assert metadata["agent_name"] == "Weekly dependency audit"
+    assert metadata["agent_primary"] is True
 
     duplicate = client.post(
         f"/api/schedules/{schedule_id}/dispatch",

--- a/agent/tests/test_event_triggers.py
+++ b/agent/tests/test_event_triggers.py
@@ -435,6 +435,72 @@ def test_dedicated_agent_can_create_top_level_conversational_tasks(tmp_path) -> 
     assert task["id"] not in snapshot["placements"]
 
 
+def test_the_event_chat_is_primary_and_survives_side_chats_and_deletion(tmp_path) -> None:
+    from fastapi import HTTPException
+
+    from ollama_code.api.sessions import _agent_owning_chat, session_delete
+
+    template = SessionStore(
+        str(tmp_path), model="k3", provider="remote", account="A", account_id="acct"
+    )
+    service = ChatService(AgentCore(cwd=str(tmp_path), config={"model": "local"}))
+    request = {
+        "trigger_id": "weather-agent",
+        "template_session_id": template.session_id,
+        "name": "Weather agent",
+    }
+    target = trigger_target_create(service, request)["session"]
+    assert target["agent_primary"] is True
+    _connection(service.run_store)
+    _trigger(service.run_store, trigger_id="weather-agent", session_id=target["id"])
+
+    # A side chat shares the identity but is not where events land.
+    side = trigger_task_create("weather-agent", service, {})["session"]
+    assert side["agent_primary"] is False
+    assert _agent_owning_chat(service, side["id"]) is None
+
+    # Editing the agent recovers the event chat, not the newer side chat.
+    again = trigger_target_create(service, request)
+    assert again["created"] is False
+    assert again["session"]["id"] == target["id"]
+
+    # The event chat cannot be pulled out from under a live agent.
+    with pytest.raises(HTTPException) as refused:
+        session_delete(target["id"], service)
+    assert refused.value.status_code == 409
+    # The guard names the trigger, whose stored name the helper sets.
+    assert "Important mail" in refused.value.detail
+    service.run_store.delete_event_trigger("weather-agent")
+    assert _agent_owning_chat(service, target["id"]) is None
+
+
+def test_editing_an_older_agent_keeps_its_own_event_chat(tmp_path) -> None:
+    """An agent made before chats carried the flag must not move its events."""
+    from ollama_code.sessions import SessionMeta
+
+    service = ChatService(AgentCore(cwd=str(tmp_path), config={"model": "local"}))
+    target = SessionStore(str(tmp_path), model="k3", provider="ollama")
+    SessionMeta.update(target.session_id, agent_trigger_id="weather-agent", title="Weather")
+    side = SessionStore(str(tmp_path), model="k3", provider="ollama")
+    SessionMeta.update(side.session_id, agent_trigger_id="weather-agent", title="Chat 2")
+    _connection(service.run_store)
+    _trigger(service.run_store, trigger_id="weather-agent", session_id=target.session_id)
+
+    recovered = trigger_target_create(
+        service,
+        {
+            "trigger_id": "weather-agent",
+            "template_session_id": target.session_id,
+            "name": "Weather agent",
+        },
+    )
+
+    # The newer side chat is not promoted over the chat the trigger points at.
+    assert recovered["created"] is False
+    assert recovered["session"]["id"] == target.session_id
+    assert SessionMeta.get(target.session_id)["agent_primary"] is True
+
+
 def test_delivery_manifest_prefers_repaired_agent_route_metadata(tmp_path) -> None:
     target = SessionStore(
         str(tmp_path),

--- a/agent/tests/test_schedules.py
+++ b/agent/tests/test_schedules.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import os
 import sqlite3
+import time
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
@@ -178,3 +181,429 @@ def test_crud_rejects_invalid_once_dates_and_unknown_fields(tmp_path) -> None:
         store.update_schedule(created["id"], {"attachments": []}, now=1_100)
     store.delete_schedule(created["id"])
     assert store.schedule(created["id"]) is None
+
+
+# --------------------------------------------------------------- dedicated chat
+
+
+def _service(tmp_path):
+    from ollama_code.chat_service import ChatService
+    from ollama_code.core import AgentCore
+
+    return ChatService(AgentCore(cwd=str(tmp_path), config={"model": "local"}))
+
+
+def _primary_session(schedule_id: str) -> str | None:
+    from ollama_code.sessions import SessionMeta
+
+    return next(
+        (
+            session_id
+            for session_id, entry in SessionMeta.all().items()
+            if entry.get("agent_trigger_id") == schedule_id and entry.get("agent_primary")
+        ),
+        None,
+    )
+
+
+def test_a_schedule_owns_one_chat_that_every_run_continues(tmp_path) -> None:
+    from fastapi import HTTPException
+
+    from ollama_code.api.schedules import _dispatch_schedule, schedule_create
+    from ollama_code.sessions import SessionMeta, SessionStore
+
+    service = _service(tmp_path)
+    schedule = schedule_create(service, schedule_value(tmp_path))
+
+    # The chat exists before the first run, so Agents mode can show the agent.
+    primary = _primary_session(schedule["id"])
+    assert primary is not None
+    metadata = SessionMeta.get(primary)
+    assert metadata["title"] == "Morning review"
+    assert metadata["agent_name"] == "Morning review"
+    assert metadata["model"] == "test-model"
+    summary = next(
+        item for item in SessionStore.summaries(limit=500, include_archived=True)
+        if item["id"] == primary
+    )
+    assert summary["agent_primary"] is True
+    assert summary["model"] == "test-model"
+    assert summary["provider"] == "ollama"
+
+    first = _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="one")
+    assert first["occurrence"]["session_id"] == primary
+
+    # While that run is still open the next occurrence is skipped, not queued
+    # behind it into the same worker, and the schedule stays enabled.
+    with pytest.raises(HTTPException) as skipped:
+        _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="two")
+    assert skipped.value.status_code == 409
+    assert "still in progress" in skipped.value.detail
+    occurrences = service.run_store.schedule_occurrences(schedule["id"])
+    assert any(
+        item["state"] == "skipped" and "Skipped" in str(item["error"] or "")
+        for item in occurrences
+    )
+    # An overlap is not a failure of the agent: the schedule keeps running and
+    # its last run still points at the run that is actually in progress.
+    after_skip = service.run_store.schedule(schedule["id"])
+    assert after_skip["enabled"] is True
+    assert after_skip["last_error"] is None
+    assert after_skip["last_run_id"] == first["run"]["id"]
+
+    # Once it finishes, the following occurrence continues the same chat.
+    service.run_store.set_state(first["run"]["id"], "completed")
+    third = _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="three")
+    assert third["occurrence"]["session_id"] == primary
+    owned = [
+        session_id
+        for session_id, entry in SessionMeta.all().items()
+        if entry.get("agent_trigger_id") == schedule["id"]
+    ]
+    assert owned == [primary]
+
+
+def test_a_schedule_side_chat_shares_identity_but_never_receives_runs(tmp_path) -> None:
+    from ollama_code.api.schedules import (
+        _dispatch_schedule,
+        schedule_create,
+        schedule_task_create,
+    )
+
+    service = _service(tmp_path)
+    schedule = schedule_create(service, schedule_value(tmp_path))
+    primary = _primary_session(schedule["id"])
+
+    side = schedule_task_create(schedule["id"], service, {"name": "Ask about Monday"})["session"]
+    assert side["id"] != primary
+    assert side["title"] == "Ask about Monday"
+    assert side["agent_trigger_id"] == schedule["id"]
+    assert side["agent_name"] == "Morning review"
+    assert side["agent_primary"] is False
+
+    run = _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="x")
+    assert run["occurrence"]["session_id"] == primary
+
+
+def test_renaming_a_schedule_renames_its_chat(tmp_path) -> None:
+    from ollama_code.api.schedules import schedule_create, schedule_update
+    from ollama_code.sessions import SessionMeta
+
+    service = _service(tmp_path)
+    schedule = schedule_create(service, schedule_value(tmp_path))
+    primary = _primary_session(schedule["id"])
+
+    schedule_update(schedule["id"], service, {"name": "Evening review"})
+
+    metadata = SessionMeta.get(primary)
+    assert metadata["title"] == "Evening review"
+    assert metadata["agent_name"] == "Evening review"
+
+
+def test_an_agents_event_chat_cannot_be_deleted_while_the_agent_exists(tmp_path) -> None:
+    from fastapi import HTTPException
+
+    from ollama_code.api.schedules import schedule_create, schedule_task_create
+    from ollama_code.api.sessions import _agent_owning_chat, session_delete
+
+    service = _service(tmp_path)
+    schedule = schedule_create(service, schedule_value(tmp_path))
+    primary = _primary_session(schedule["id"])
+
+    with pytest.raises(HTTPException) as refused:
+        session_delete(primary, service)
+    assert refused.value.status_code == 409
+    assert "Morning review" in refused.value.detail
+
+    # A side chat is not the agent's event chat, so it may go.
+    side = schedule_task_create(schedule["id"], service, {})["session"]
+    assert _agent_owning_chat(service, side["id"]) is None
+
+    # Once the agent itself is gone, so is the protection.
+    service.run_store.delete_schedule(schedule["id"])
+    assert _agent_owning_chat(service, primary) is None
+
+
+def test_listing_gives_pre_existing_schedules_their_chat(tmp_path) -> None:
+    from ollama_code.api.schedules import schedule_list
+
+    service = _service(tmp_path)
+    # Created straight in the store, the way schedules existed before they
+    # were agents: no dedicated chat.
+    created = service.run_store.create_schedule(schedule_value(tmp_path))
+    assert _primary_session(created["id"]) is None
+
+    listed = schedule_list(service)
+    assert [item["id"] for item in listed["schedules"]] == [created["id"]]
+    primary = _primary_session(created["id"])
+    assert primary is not None
+
+    # Listing again reuses it rather than making another.
+    schedule_list(service)
+    assert _primary_session(created["id"]) == primary
+
+
+def _repo(tmp_path, monkeypatch, name="repo"):
+    """A throwaway git workspace a scheduled agent can run a worktree in."""
+    import shutil
+    import subprocess
+
+    if shutil.which("git") is None:
+        pytest.skip("git is not installed")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    root = tmp_path / name
+    root.mkdir()
+    run = lambda *args: subprocess.run(  # noqa: E731
+        ["git", *args], cwd=root, check=True, capture_output=True
+    )
+    run("init", "-q")
+    run("symbolic-ref", "HEAD", "refs/heads/main")
+    run("config", "user.email", "t@example.com")
+    run("config", "user.name", "Test")
+    run("config", "commit.gpgsign", "false")
+    (root / "first.txt").write_text("one\n", encoding="utf-8")
+    run("add", "-A")
+    run("commit", "-q", "-m", "first")
+    return root, run
+
+
+def test_moving_a_schedule_moves_where_its_runs_execute(tmp_path) -> None:
+    from ollama_code.api.schedules import _dispatch_schedule, schedule_create, schedule_update
+    from ollama_code.sessions import SessionMeta
+
+    service = _service(tmp_path)
+    here = tmp_path / "here"
+    there = tmp_path / "there"
+    here.mkdir()
+    there.mkdir()
+    schedule = schedule_create(service, schedule_value(tmp_path, workspace_root=str(here)))
+    first = _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="one")
+    assert first["run"]["execution_path"] == str(here)
+
+    schedule_update(schedule["id"], service, {"workspace_root": str(there)})
+
+    primary = _primary_session(schedule["id"])
+    metadata = SessionMeta.get(primary)
+    assert metadata["workspace_root"] == str(there)
+    assert metadata["execution_path"] == str(there)
+
+    service.run_store.set_state(first["run"]["id"], "completed")
+    second = _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="two")
+    assert second["run"]["execution_path"] == str(there)
+    assert second["occurrence"]["session_id"] == primary
+
+
+def test_a_worktree_agent_keeps_one_checkout_that_follows_the_workspace(
+    tmp_path, monkeypatch
+) -> None:
+    from ollama_code import worktrees
+    from ollama_code.api.schedules import _dispatch_schedule, schedule_create
+    from ollama_code.sessions import SessionMeta
+    from ollama_code.worktrees import TaskCheckoutStore
+
+    monkeypatch.setattr(worktrees, "TASKS_DIR", tmp_path / "tasks")
+    root, run = _repo(tmp_path, monkeypatch)
+    service = _service(tmp_path)
+    schedule = schedule_create(
+        service,
+        schedule_value(tmp_path, workspace_root=str(root), execution_environment="worktree"),
+    )
+    primary = _primary_session(schedule["id"])
+    task_id = str(SessionMeta.get(primary)["task"]["id"])
+
+    # The checkout is the agent's home, so pruning idle worktrees must skip it.
+    assert TaskCheckoutStore.load(task_id).permanent is True
+
+    first = _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="one")
+    checkout = Path(first["run"]["execution_path"])
+    assert checkout.is_dir()
+    assert (checkout / "first.txt").exists()
+
+    # Work landed in the workspace after the agent was made reaches its runs.
+    (root / "second.txt").write_text("two\n", encoding="utf-8")
+    run("add", "-A")
+    run("commit", "-q", "-m", "second")
+    service.run_store.set_state(first["run"]["id"], "completed")
+    second = _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="two")
+    assert (Path(second["run"]["execution_path"]) / "second.txt").exists()
+
+    # A checkout taken away by an archive or an older prune is restored rather
+    # than pausing the agent for good.
+    TaskCheckoutStore.snapshot_and_remove(task_id)
+    service.run_store.set_state(second["run"]["id"], "completed")
+    third = _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="three")
+    assert Path(third["run"]["execution_path"]).is_dir()
+    assert service.run_store.schedule(schedule["id"])["enabled"] is True
+
+
+def test_archiving_the_chat_an_agent_runs_in_is_refused(tmp_path) -> None:
+    from fastapi import HTTPException
+
+    from ollama_code.api.schedules import schedule_create
+    from ollama_code.api.sessions import session_metadata_update
+
+    service = _service(tmp_path)
+    schedule = schedule_create(service, schedule_value(tmp_path))
+    primary = _primary_session(schedule["id"])
+
+    with pytest.raises(HTTPException) as refused:
+        session_metadata_update(primary, service, {"archived": True})
+    assert refused.value.status_code == 409
+    assert "Morning review" in refused.value.detail
+
+
+def test_listing_adopts_older_schedules_and_the_chats_their_runs_left(tmp_path) -> None:
+    from ollama_code.api.schedules import schedule_list
+    from ollama_code.sessions import SessionMeta, SessionStore
+
+    service = _service(tmp_path)
+    created = service.run_store.create_schedule(schedule_value(tmp_path))
+    assert _primary_session(created["id"]) is None
+
+    # A chat from the days when every run opened its own conversation.
+    older = SessionStore(str(tmp_path), "test-model", "ollama").session_id
+    SessionMeta.update(older, title="Morning review · Sep 1", schedule_id=created["id"])
+
+    listed = schedule_list(service)
+    assert [item["id"] for item in listed["schedules"]] == [created["id"]]
+    primary = _primary_session(created["id"])
+    assert primary is not None and primary != older
+
+    # The older run's chat joins the agent as a side conversation.
+    adopted = SessionMeta.get(older)
+    assert adopted["agent_trigger_id"] == created["id"]
+    assert adopted["agent_name"] == "Morning review"
+    assert adopted.get("agent_primary") is None
+
+    # Listing again reuses what is there rather than making a second chat.
+    schedule_list(service)
+    assert _primary_session(created["id"]) == primary
+
+
+def test_a_second_dispatch_cannot_queue_into_a_chat_that_is_already_running(tmp_path) -> None:
+    store = RunStore(tmp_path / "runs.sqlite3")
+    store.queue_run_if_idle("run-one", session_id="chat", request="first")
+
+    with pytest.raises(RunStoreError, match="the chat is busy"):
+        store.queue_run_if_idle("run-two", session_id="chat", request="second")
+
+    store.set_state("run-one", "completed")
+    assert store.queue_run_if_idle("run-two", session_id="chat", request="second")["id"] == "run-two"
+
+
+def test_a_run_waiting_for_a_person_does_not_silence_the_agent(tmp_path) -> None:
+    from ollama_code.api.schedules import _dispatch_schedule, schedule_create
+
+    service = _service(tmp_path)
+    schedule = schedule_create(service, schedule_value(tmp_path))
+    first = _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="one")
+
+    # A paused run is waiting for the person, not working. One unattended
+    # pause must not stop every future run of the agent.
+    service.run_store.set_state(first["run"]["id"], "paused", recoverable=True)
+
+    second = _dispatch_schedule(service, schedule["id"], trigger="manual", request_id="two")
+    assert second["occurrence"]["session_id"] == _primary_session(schedule["id"])
+    assert second["run"]["id"] != first["run"]["id"]
+
+
+def test_a_skipped_one_shot_keeps_the_run_it_never_had(tmp_path) -> None:
+    from ollama_code.api.schedules import _record_skip, schedule_create
+
+    service = _service(tmp_path)
+    at = time.time() + 300
+    schedule = schedule_create(
+        service, schedule_value(tmp_path, rule={"kind": "once", "at": at})
+    )
+    # Claiming consumes the single slot and switches the schedule off before
+    # the chat is known to be free.
+    _, occurrence, claimed = service.run_store.claim_schedule_occurrence(
+        schedule["id"], trigger="due", now=at + 1
+    )
+    assert claimed
+    assert service.run_store.schedule(schedule["id"])["enabled"] is False
+
+    _record_skip(service.run_store, occurrence, _primary_session(schedule["id"]))
+
+    restored = service.run_store.schedule(schedule["id"])
+    assert restored["enabled"] is True, "a skipped run is not a run that happened"
+    assert restored["next_run_at"] == pytest.approx(at)
+    assert restored["last_error"] is None
+
+
+def test_a_move_that_cannot_be_made_leaves_the_schedule_where_it_was(
+    tmp_path, monkeypatch
+) -> None:
+    import subprocess
+
+    from fastapi import HTTPException
+
+    from ollama_code import worktrees
+    from ollama_code.api.schedules import schedule_create, schedule_update
+
+    monkeypatch.setattr(worktrees, "TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    service = _service(tmp_path)
+    schedule = schedule_create(service, schedule_value(tmp_path))
+    # A repository with no commits: it passes validation, but no worktree can
+    # be cut from it.
+    unborn = tmp_path / "unborn"
+    unborn.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=unborn, check=True, capture_output=True)
+
+    with pytest.raises(HTTPException) as refused:
+        schedule_update(
+            schedule["id"],
+            service,
+            {"workspace_root": str(unborn), "execution_environment": "worktree"},
+        )
+    assert refused.value.status_code == 409
+
+    # The edit was reported as failed, so it must not have happened.
+    row = service.run_store.schedule(schedule["id"])
+    assert row["workspace_root"] == str(tmp_path)
+    assert row["execution_environment"] == "local"
+
+
+def test_a_half_built_checkout_does_not_brick_a_worktree_agent(tmp_path, monkeypatch) -> None:
+    from ollama_code import worktrees
+    from ollama_code.api.schedules import _checkout_task_id, _ensure_schedule_session
+
+    monkeypatch.setattr(worktrees, "TASKS_DIR", tmp_path / "tasks")
+    root, _ = _repo(tmp_path, monkeypatch)
+    service = _service(tmp_path)
+    created = service.run_store.create_schedule(
+        schedule_value(tmp_path, workspace_root=str(root), execution_environment="worktree")
+    )
+    # A creation that died before it wrote its metadata. The id is derived
+    # from the schedule, so nothing else would ever get past it.
+    (tmp_path / "tasks" / _checkout_task_id(created["id"], str(root))).mkdir(parents=True)
+
+    session_id, metadata = _ensure_schedule_session(created)
+
+    assert Path(metadata["execution_path"]).is_dir()
+    assert _primary_session(created["id"]) == session_id
+
+
+def test_deleting_a_worktree_agent_frees_its_checkout(tmp_path, monkeypatch) -> None:
+    from ollama_code import worktrees
+    from ollama_code.api.schedules import schedule_create, schedule_delete
+    from ollama_code.sessions import SessionMeta
+    from ollama_code.worktrees import TaskCheckoutStore
+
+    monkeypatch.setattr(worktrees, "TASKS_DIR", tmp_path / "tasks")
+    root, _ = _repo(tmp_path, monkeypatch, name="delete-repo")
+    service = _service(tmp_path)
+    schedule = schedule_create(
+        service,
+        schedule_value(tmp_path, workspace_root=str(root), execution_environment="worktree"),
+    )
+    task_id = str(SessionMeta.get(_primary_session(schedule["id"]))["task"]["id"])
+    assert TaskCheckoutStore.load(task_id).permanent is True
+
+    schedule_delete(schedule["id"], service)
+
+    # Kept out of pruning's reach while the agent existed; ordinary again now.
+    assert TaskCheckoutStore.load(task_id).permanent is False


### PR DESCRIPTION
## Summary

Phase 2 of the agents UX audit: **schedules become agents**, each with one dedicated chat that every run continues, the same shape event and price agents already have.

- **One chat per schedule.** It is created with the schedule (tagged `agent_trigger_id`, `agent_name`, `agent_primary`), reused by every dispatch, and its name, model, workspace and worktree follow later edits. Renaming or moving the schedule moves the agent.
- **Overlapping runs skip, they do not stack.** A run that arrives while the previous one is still going records a skipped occurrence and leaves the agent healthy; the skip no longer lands in the schedule's error, so a busy agent never reports "Last run failed". The busy check and the run reservation now share the store lock, so a due tick and Run Now cannot both queue.
- **A worktree agent keeps one checkout.** It is marked permanent so pruning leaves it alone, restored when an archive or an earlier prune removed it, and refreshed from the workspace before a run whenever the agent left it clean, so weekly runs stop replaying the commit that was current the day the schedule was made.
- **Existing schedules are adopted.** The first listing after the update gives them their chat, and the single-run chats their earlier runs left behind join the agent as side conversations.
- **Side chats** come from `POST /api/schedules/{id}/tasks`: they share the agent's identity and never receive a run.
- **The panel and the sidebar** understand schedules: cadence as a sentence, next run, recent runs, Run now, Pause, Edit, Delete, a fleet that ranks schedules beside triggers, and copy that says runs for a schedule and events for a trigger. The sidebar row observes the stores it draws, so pausing from its context menu updates it.
- **Model pinned on edit.** Editing an agent no longer re-points it at whatever model the app is on. The editor shows the model it runs on and offers to move it, which is also the way a broken route is repaired.
- **The chat an agent runs in is protected.** Deleting or archiving it is refused while the agent exists, and recovering an older agent's chat prefers the one its trigger already points at rather than the most recently touched side chat.

## Verification

- Backend: `ruff` clean; `pytest` 739 passed, including a git-backed test that a worktree agent's runs follow the workspace and survive its checkout being taken away.
- Swift: `LocusTests` 1036 passed; observation-boundary lint; design audit; `xcodegen` diff clean; protocol manifest current.
- UI: ten agent tests pass, including a new one for the schedule panel.
- Screenshots of the schedule agent in light and dark.
