### PR TITLE
Smooth browser expansion and improve Task Capsule setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+
+- Task Capsules now guide model setup, keep the next action visible, and make
+  saved plans, edits, and past runs easier to find and review at compact sizes.
+
+### Fixed
+
+- Expanding the browser avoids repeated transcript layout and file lookups,
+  improving responsiveness in conversations with many file links.
+
 ## 2.5.0 — 2026-09-06
 
 ### Added

--- a/Docs/TaskCapsules.md
+++ b/Docs/TaskCapsules.md
@@ -1,27 +1,40 @@
 # Task Capsules
 
-Task Capsules save a plan with separate profiles for planning, implementation,
+Task Capsules save a plan with model choices for planning, implementation,
 and optional review. The implementation model receives the saved specification
 and executes its ordered steps. It does not call the planning model to recreate
 the plan or write a final summary.
 
-## Using ChatGPT and Kimi plans
+## Getting started
 
-1. Connect your ChatGPT account and Kimi Code membership in Locus's model
-   accounts. Kimi Code membership and Kimi's metered API are distinct accounts.
-2. In agent profiles, create a planning profile using your preferred ChatGPT
-   model and an implementation profile using Kimi Code. Give the implementation
-   profile workspace write access. Choose models available on those accounts;
-   capsules do not hard-code model names.
+1. Connect the model account you want to use, or choose a local model. For
+   example, you can plan with ChatGPT and implement with Kimi Code. Kimi Code
+   membership and Kimi's metered API are distinct accounts.
+2. In settings, choose **Add Agent**, select an account under **Provider route**,
+   and choose a model. For implementation, set **Access ceiling** to **Workspace
+   edits**. One profile can handle planning and implementation, or use separate
+   profiles such as ChatGPT for planning and Kimi Code for implementation.
+   Choose models available on those accounts; capsules do not hard-code model names.
 3. Open **Locus → Task Capsules…** (⌥⌘K) in the workspace you want to work on.
-4. Enter a request, choose **Plan with** and **Implement with**, and optionally
-   select **Review with**. Set the usage allowances if needed.
+4. Describe your task, or choose an editable example and replace its bracketed
+   details. The capsule name is optional. Choose **Plan with** and **Implement
+   with**, and optionally select **Review with**. The same profile can serve
+   multiple roles. **Advanced · Usage limits** contains the optional allowances.
 5. Choose **Generate plan**. Planning happens read-only in the conversation;
    answer any clarification there. A successful structured plan is saved
    automatically. You can also save an existing conversation plan.
-6. Reopen Task Capsules, inspect the instructions and checks, and choose
-   **Run saved capsule**. Run history keeps each stage's outcome and available
-   usage measurements. **Review result** performs a separate read-only review.
+6. Reopen Task Capsules, inspect the instructions, checks, constraints, and design
+   decisions, and choose **Run plan**. **Expand steps** shows every step’s details.
+   Run history keeps each stage's outcome and available usage measurements, with
+   a link back to its conversation. **Review result** performs a separate read-only
+   review. A previously executed plan offers **Run again**.
+
+The primary action stays visible while you review a long plan. With no agent
+profiles yet, **Set up models** takes you to settings and preserves your draft.
+If setup is incomplete, a message explains what is needed. Saved capsules can be searched in
+the sidebar; smaller windows use a capsule menu. A waiting planner offers
+**Continue planning** to return directly to its conversation. Your description
+is preserved when you close the sheet or open profile settings.
 
 Each stage uses the exact account associated with its profile. An unavailable
 account stops the stage. Subscription routes never silently fall back to a
@@ -42,8 +55,8 @@ older plans without detailed steps also work, but have fewer explicit checks.
 
 Fingerprints cover only the files named in detailed steps, including files to
 create. Locus checks them against the saved baseline before execution. Changed,
-removed, or unexpectedly created files pause the handoff; **Ask the planner for
-help** can inspect the current workspace and save a revised plan. A legacy plan
+removed, or unexpectedly created files pause the handoff; **Update the plan or
+ask for help** can inspect the current workspace and save a revised plan. A legacy plan
 without named files has no file baseline. This is not a whole-repository change
 detector.
 
@@ -67,7 +80,7 @@ detector.
   billing ceiling. It excludes planning, standalone review, tool charges, and
   image generation. Subscription routes track calls and tokens without
   inventing per-token subscription prices.
-- **Edit models and limits** changes the saved recipe explicitly. It preserves
+- **Edit** in **Models & limits** changes the saved recipe explicitly. It preserves
   the existing file baseline and run history. Increasing an allowance does not
   erase previous attempts.
 

--- a/Locus/AppModel+InspectorLayout.swift
+++ b/Locus/AppModel+InspectorLayout.swift
@@ -220,6 +220,18 @@ extension AppModel {
     /// without the window growing.
     func setInspectorZoomed(_ zoomed: Bool) {
         guard zoomed != inspectorZoomed else { return }
+        // Commit the destination geometry once. Animating this width reflows
+        // every visible Markdown leaf and the live web page on every frame.
+        // Disable implicit sidebar animations too: zoom borrows its space in
+        // the same transaction, and restoring it must be just as immediate.
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            applyInspectorZoomed(zoomed)
+        }
+    }
+
+    private func applyInspectorZoomed(_ zoomed: Bool) {
         if zoomed {
             guard !justChatEnabled else { return }
             if openInspectorTabs.isEmpty {

--- a/Locus/AppModel+TaskCapsules.swift
+++ b/Locus/AppModel+TaskCapsules.swift
@@ -55,6 +55,15 @@ extension AppModel {
             manageProfiles: { [weak self] in
                 self?.settingsPage = .agents
                 self?.settingsPresented = true
+            },
+            openConversation: { [weak self] sessionID in
+                guard let self else { return }
+                guard sessionID != currentSessionID else { return }
+                guard let session = sessions.first(where: { $0.id == sessionID }) else {
+                    showToast("This capsule's conversation is no longer available")
+                    return
+                }
+                resume(session)
             }
         )
     }

--- a/Locus/AppModel+UITestFixtures.swift
+++ b/Locus/AppModel+UITestFixtures.swift
@@ -430,6 +430,13 @@ extension AppModel {
         ] == "1" {
             let imagePath = "/tmp/locus-performance-fixture.png"
             writePerformanceFixtureImage(to: imagePath)
+            let fileList = (0..<10).map { index in
+                let name = "locus-performance-source-\(index).swift"
+                try? "// Local resize fixture \(index)\n".write(
+                    toFile: "/tmp/\(name)", atomically: true, encoding: .utf8
+                )
+                return "- `\(name)` — source file with a description that wraps in a narrow conversation."
+            }.joined(separator: "\n")
             let prose = (0..<12).map { index in
                 """
                 ## Performance section \(index + 1)
@@ -471,7 +478,7 @@ extension AppModel {
                 ChatBlock(
                     id: UUID(uuidString: "00000000-0000-0000-0000-000000000903")!,
                     kind: .assistant,
-                    text: prose + "\n\n![Performance image](\(imagePath))",
+                    text: prose + "\n\n![Performance image](\(imagePath))\n\nFiles in this workspace:\n\n" + fileList,
                     assistantPhase: .finalAnswer
                 ),
                 ChatBlock(

--- a/Locus/BrowserHost.swift
+++ b/Locus/BrowserHost.swift
@@ -120,11 +120,10 @@ final class OffscreenWebHost {
     /// it at a time — `NSView` has a single superview, so lending it twice
     /// takes it away from the first borrower.
     func lend(to container: NSView) {
-        if webView.superview !== container {
-            webView.removeFromSuperview()
-            container.addSubview(webView)
-        }
-        webView.frame = container.bounds
+        guard webView.superview !== container else { return }
+        webView.removeFromSuperview()
+        container.addSubview(webView)
+        if webView.frame != container.bounds { webView.frame = container.bounds }
         webView.autoresizingMask = [.width, .height]
     }
 
@@ -133,7 +132,11 @@ final class OffscreenWebHost {
     func park() {
         guard !isParked else { return }
         webView.removeFromSuperview()
-        webView.frame = NSRect(origin: .zero, size: viewport)
+        // Visible resizing records the viewport without moving this unused
+        // window. Bring its geometry up to date once, before returning the view.
+        resizeParkedPanel()
+        let frame = NSRect(origin: .zero, size: viewport)
+        if webView.frame != frame { webView.frame = frame }
         webView.autoresizingMask = [.width, .height]
         panel.contentView?.addSubview(webView)
         // The parked panel keeps WebKit's "visible" state so pages stay live,
@@ -156,11 +159,18 @@ final class OffscreenWebHost {
             height: max(120, min(size.height, 4_000))
         )
         viewport = clamped
-        panel.setFrame(
-            NSRect(origin: Self.parkingOrigin, size: clamped),
-            display: false
-        )
-        webView.frame = NSRect(origin: .zero, size: clamped)
+        if isParked { resizeParkedPanel() }
+        let frame = NSRect(origin: .zero, size: clamped)
+        // AppKit may already have resized the borrowed view through its
+        // autoresizing mask. Reassigning its frame still enters WebKit's
+        // viewport machinery, even when the resulting rectangle is unchanged.
+        if webView.frame != frame { webView.frame = frame }
+    }
+
+    private func resizeParkedPanel() {
+        let frame = NSRect(origin: Self.parkingOrigin, size: viewport)
+        guard panel.frame != frame else { return }
+        panel.setFrame(frame, display: false)
     }
 
     // MARK: - Real input

--- a/Locus/InspectorBrowserTab.swift
+++ b/Locus/InspectorBrowserTab.swift
@@ -22,9 +22,7 @@ struct InspectorBrowserTab: View {
             },
             isExpanded: model.inspectorZoomed,
             onToggleExpand: { [weak model] in
-                withAnimation(LocusMotion.spatial) {
-                    model?.toggleInspectorZoom()
-                }
+                model?.toggleInspectorZoom()
             },
             onPrivateFill: { model.useIdentityApplicationLocally(upload: false) },
             onPrivateUpload: { model.useIdentityApplicationLocally(upload: true) },
@@ -820,25 +818,44 @@ struct BrowserPanel: View {
 @MainActor
 final class BrowserCanvasContainer: NSView {
     weak var host: OffscreenWebHost?
+    private var lastLayoutSize: CGSize?
+
+    override func setBoundsSize(_ newSize: NSSize) {
+        guard newSize != bounds.size else { return }
+        super.setBoundsSize(newSize)
+        // Frame changes already schedule AppKit layout; bounds-only changes
+        // do not, even though they change the space available to the page.
+        needsLayout = true
+    }
 
     override func layout() {
         super.layout()
-        guard let host, bounds.width > 0, bounds.height > 0 else { return }
+        guard let host, host.webView.superview === self,
+              bounds.width > 0, bounds.height > 0,
+              bounds.size != lastLayoutSize else { return }
+        lastLayoutSize = bounds.size
         host.setViewport(bounds.size)
     }
 
     func display(_ newHost: OffscreenWebHost) {
+        // Loading progress and other browser state can refresh SwiftUI many
+        // times without changing the page or the available space.
+        guard host !== newHost || newHost.webView.superview !== self else { return }
         if let host, host !== newHost { parkIfStillOwner() }
         host = newHost
+        lastLayoutSize = nil
         newHost.lend(to: self)
         needsLayout = true
-        layoutSubtreeIfNeeded()
+        // Let AppKit coalesce this with the enclosing inspector's layout. A
+        // synchronous layout here re-enters page layout during SwiftUI updates.
     }
 
     func parkIfStillOwner() {
-        guard let host, host.webView.superview === self else { return }
-        host.park()
+        guard let host else { return }
         self.host = nil
+        lastLayoutSize = nil
+        guard host.webView.superview === self else { return }
+        host.park()
     }
 }
 

--- a/Locus/InspectorRail.swift
+++ b/Locus/InspectorRail.swift
@@ -79,9 +79,7 @@ struct InspectorRail: View {
 
     private var zoomButton: some View {
         Button {
-            withAnimation(LocusMotion.spatial) {
-                model.toggleInspectorZoom()
-            }
+            model.toggleInspectorZoom()
         } label: {
             Image(
                 systemName: model.inspectorZoomed

--- a/Locus/LocusApp.swift
+++ b/Locus/LocusApp.swift
@@ -219,7 +219,7 @@ struct LocusApp: App {
                 .keyboardShortcut("i", modifiers: [.command, .option])
                 .disabled(model.justChatEnabled)
                 Button(model.inspectorZoomed ? "Restore Panel" : "Expand Panel") {
-                    withAnimation(LocusMotion.spatial) { model.toggleInspectorZoom() }
+                    model.toggleInspectorZoom()
                 }
                 .keyboardShortcut("e", modifiers: [.command, .option])
                 .disabled(model.justChatEnabled)
@@ -970,12 +970,10 @@ struct RootView: View {
                 transaction.disablesAnimations = true
             }
         }
-        // Keyed on the sidebar and the zoom flag only: including the inspector
-        // would put the width change in scope too, and the panel would lag
-        // behind the cursor during a resize drag. Zoom is safe — it flips on
-        // toggle, never during a drag. Collapse animates at its call sites.
+        // Manual sidebar toggles animate; inspector zoom commits its final
+        // geometry without interpolating expensive transcript/WebKit layout.
+        // Divider widths stay outside animation so they follow the cursor.
         .animation(LocusMotion.spatial, value: model.sidebarCollapsed)
-        .animation(LocusMotion.spatial, value: model.inspectorZoomed)
         .background(LocusTheme.paper)
         .overlay(alignment: .bottomTrailing) {
             if let toast = toastCenter.toast {

--- a/Locus/MarkdownRenderer.swift
+++ b/Locus/MarkdownRenderer.swift
@@ -701,13 +701,16 @@ enum MarkdownNativeText {
         color: Color,
         lineSpacing: CGFloat,
         inlineCodeSize: CGFloat,
-        workspacePath: String?
+        workspacePath: String?,
+        resolveArtifact: ((String?) -> WorkspaceArtifactReference?)? = nil
     ) -> NSAttributedString {
         let result = NSMutableAttributedString()
         let paragraph = NSMutableParagraphStyle()
         paragraph.lineSpacing = lineSpacing
         for run in runs {
-            let url = MarkdownLinkPolicy.renderedURL(for: run, workspacePath: workspacePath)
+            let url = MarkdownLinkPolicy.renderedURL(
+                for: run, workspacePath: workspacePath, resolveArtifact: resolveArtifact
+            )
             let spec = MarkdownInlineStyleSpec.resolve(
                 run: run,
                 baseSize: size,
@@ -1041,8 +1044,11 @@ struct StreamingMarkdownBodyView: View {
     }
 }
 
+@MainActor
 private struct MarkdownBlocksView: View {
     @Environment(\.locusAccent) private var accent
+    @Environment(\.locusIsLiveResizing) private var isLiveResizing
+    @State private var artifactCache = WorkspaceArtifactRenderCache()
     let blocks: [MarkdownRenderBlock]
     let workspacePath: String?
     let density: MarkdownRenderDensity
@@ -1057,6 +1063,7 @@ private struct MarkdownBlocksView: View {
     var textColor: Color?
 
     var body: some View {
+        let _ = artifactCache.setLiveResizing(isLiveResizing)
         // Spacing is per-transition rather than uniform, so headings can take
         // more room above than below.
         VStack(alignment: .leading, spacing: 0) {
@@ -1104,7 +1111,7 @@ private struct MarkdownBlocksView: View {
                     }
                 case .compactChip:
                     if let reference = MarkdownArtifactPromotion.leadingArtifact(
-                        in: runs, workspacePath: workspacePath
+                        in: runs, workspacePath: workspacePath, resolveArtifact: resolveArtifact
                     ) {
                         WorkspaceArtifactChipRow(
                             reference: reference,
@@ -1266,7 +1273,8 @@ private struct MarkdownBlocksView: View {
                     color: color,
                     lineSpacing: lineSpacing,
                     inlineCodeSize: density.inlineCodeFontSize,
-                    workspacePath: workspacePath
+                    workspacePath: workspacePath,
+                    resolveArtifact: resolveArtifact
                 ),
                 span: span,
                 store: selectionStore,
@@ -1330,7 +1338,9 @@ private struct MarkdownBlocksView: View {
     ) -> AttributedString {
         var result = AttributedString()
         for run in runs {
-            let url = MarkdownLinkPolicy.renderedURL(for: run, workspacePath: workspacePath)
+            let url = MarkdownLinkPolicy.renderedURL(
+                for: run, workspacePath: workspacePath, resolveArtifact: resolveArtifact
+            )
             let spec = MarkdownInlineStyleSpec.resolve(
                 run: run,
                 baseSize: baseSize,
@@ -1355,10 +1365,11 @@ private struct MarkdownBlocksView: View {
 
     private func standaloneArtifact(in runs: [MarkdownInlineRun]) -> WorkspaceArtifactReference? {
         guard runs.count == 1, let run = runs.first else { return nil }
-        return WorkspaceArtifactReference.classify(
-            MarkdownArtifactPromotion.candidate(in: run),
-            workspacePath: workspacePath
-        )
+        return resolveArtifact(MarkdownArtifactPromotion.candidate(in: run))
+    }
+
+    private func resolveArtifact(_ raw: String?) -> WorkspaceArtifactReference? {
+        artifactCache.classify(raw, workspacePath: workspacePath)
     }
 
     private func open(_ url: URL) {
@@ -1377,6 +1388,11 @@ private struct MarkdownBlocksView: View {
     }
 
     private func open(_ reference: WorkspaceArtifactReference) {
+        // The gesture cache is for presentation only. A file may have changed
+        // or a symlink may have moved since this chip was rendered.
+        guard WorkspaceArtifactReference.classify(
+            reference.url.path, workspacePath: workspacePath
+        ) != nil else { return }
         if let onOpenWorkspaceReference {
             onOpenWorkspaceReference(reference)
         } else {
@@ -1415,16 +1431,14 @@ enum MarkdownArtifactPromotion {
     /// annotation's actions are never attributed to the wrong file.
     static func leadingArtifact(
         in runs: [MarkdownInlineRun],
-        workspacePath: String?
+        workspacePath: String?,
+        resolveArtifact: ((String?) -> WorkspaceArtifactReference?)? = nil
     ) -> WorkspaceArtifactReference? {
+        let resolve = resolveArtifact ?? { WorkspaceArtifactReference.classify($0, workspacePath: workspacePath) }
         guard let first = runs.first,
-              let reference = WorkspaceArtifactReference.classify(
-                candidate(in: first), workspacePath: workspacePath
-              ),
+              let reference = resolve(candidate(in: first)),
               runs.dropFirst().allSatisfy({ run in
-                  WorkspaceArtifactReference.classify(
-                    candidate(in: run), workspacePath: workspacePath
-                  ) == nil
+                  resolve(candidate(in: run)) == nil
               })
         else { return nil }
         return reference
@@ -1516,21 +1530,17 @@ struct WorkspaceArtifactReference: Hashable, Sendable {
                 parsed.path,
                 workspacePath: workspacePath
               ),
-              FileManager.default.fileExists(atPath: url.path)
-        else { return nil }
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
-              !isDirectory.boolValue
+              let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .fileSizeKey]),
+              values.isDirectory == false
         else { return nil }
 
         let root = URL(fileURLWithPath: workspacePath, isDirectory: true)
         let relative = WorkspaceIndex.relativePath(url, root: root.path)
-        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
         return Self(
             url: url,
             relativePath: relative,
             kind: kind(for: url.pathExtension),
-            byteCount: values?.fileSize.map(Int64.init),
+            byteCount: values.fileSize.map(Int64.init),
             sourceLocation: parsed.location
         )
     }
@@ -1573,11 +1583,57 @@ struct WorkspaceArtifactReference: Hashable, Sendable {
     }
 }
 
+/// A file listing asks about each path both for its chip and its inline link.
+/// Retain those filesystem answers only while its column is being resized;
+/// the first render after the gesture reads current metadata again. Navigation
+/// deliberately continues to use the uncached classifier above.
+@MainActor
+final class WorkspaceArtifactRenderCache {
+    private struct Key: Hashable {
+        let raw: String
+        let workspacePath: String
+    }
+
+    private struct Entry {
+        let reference: WorkspaceArtifactReference?
+    }
+
+    private var values: [Key: Entry] = [:]
+    private var isLiveResizing = false
+    private(set) var resolutionCountForTesting = 0
+
+    func setLiveResizing(_ active: Bool) {
+        guard isLiveResizing != active else { return }
+        isLiveResizing = active
+        values.removeAll(keepingCapacity: active)
+    }
+
+    func classify(_ raw: String?, workspacePath: String?) -> WorkspaceArtifactReference? {
+        guard let raw, let workspacePath else { return nil }
+        let key = Key(raw: raw, workspacePath: workspacePath)
+        if isLiveResizing, let cached = values[key] { return cached.reference }
+        resolutionCountForTesting += 1
+        let reference = WorkspaceArtifactReference.classify(raw, workspacePath: workspacePath)
+        if isLiveResizing {
+            // A long streaming response must not retain unbounded candidates
+            // during a resize. Each Markdown subtree owns its own small cache.
+            if values.count >= 256 { values.removeAll(keepingCapacity: true) }
+            values[key] = Entry(reference: reference)
+        }
+        return reference
+    }
+}
+
 enum WorkspacePathReferenceParser {
     struct Parsed: Hashable, Sendable {
         let path: String
         let location: WorkspaceSourceLocation?
     }
+
+    private static let locationExpressions = [
+        #"#L([0-9]+)(?:C([0-9]+))?$"#,
+        #":([0-9]+)(?::([0-9]+))?$"#
+    ].compactMap { try? NSRegularExpression(pattern: $0) }
 
     static func parse(_ raw: String?) -> Parsed? {
         guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -1593,13 +1649,8 @@ enum WorkspacePathReferenceParser {
             return nil
         }
 
-        let patterns = [
-            #"#L([0-9]+)(?:C([0-9]+))?$"#,
-            #":([0-9]+)(?::([0-9]+))?$"#
-        ]
-        for pattern in patterns {
-            guard let expression = try? NSRegularExpression(pattern: pattern),
-                  let match = expression.firstMatch(
+        for expression in locationExpressions {
+            guard let match = expression.firstMatch(
                     in: value,
                     range: NSRange(value.startIndex..., in: value)
                   ),
@@ -1655,12 +1706,14 @@ enum MarkdownLinkPolicy {
         return containedWorkspaceFileURL(parsed.path, workspacePath: workspacePath)
     }
 
-    static func renderedURL(for run: MarkdownInlineRun, workspacePath: String?) -> URL? {
+    static func renderedURL(
+        for run: MarkdownInlineRun,
+        workspacePath: String?,
+        resolveArtifact: ((String?) -> WorkspaceArtifactReference?)? = nil
+    ) -> URL? {
         let localCandidate = run.destination ?? (run.style.contains(.code) ? run.text : nil)
-        if let reference = WorkspaceArtifactReference.classify(
-            localCandidate,
-            workspacePath: workspacePath
-        ) {
+        let resolve = resolveArtifact ?? { WorkspaceArtifactReference.classify($0, workspacePath: workspacePath) }
+        if let reference = resolve(localCandidate) {
             return reference.navigationURL
         }
         return safeURL(run.destination, workspacePath: workspacePath)

--- a/Locus/TaskCapsuleModel.swift
+++ b/Locus/TaskCapsuleModel.swift
@@ -31,6 +31,7 @@ final class TaskCapsuleModel: ObservableObject {
     private var startReview: (TaskCapsule) -> Void = { _ in }
     private var askPlanner: (TaskCapsule, String) -> Void = { _, _ in }
     private var manageProfilesHandler: () -> Void = {}
+    private var openConversationHandler: (String) -> Void = { _ in }
     @Published private var pendingPlanning: [String: TaskCapsulePlanningRequest] = [:]
     private var submittedPlans: [String: PlanDocument] = [:]
     private var refreshGeneration = UUID()
@@ -70,7 +71,8 @@ final class TaskCapsuleModel: ObservableObject {
         startExecution: @escaping (TaskCapsule) -> Void,
         startReview: @escaping (TaskCapsule) -> Void,
         askPlanner: @escaping (TaskCapsule, String) -> Void,
-        manageProfiles: @escaping () -> Void = {}
+        manageProfiles: @escaping () -> Void = {},
+        openConversation: @escaping (String) -> Void = { _ in }
     ) {
         self.backend = backend
         self.workspacePathProvider = workspacePathProvider
@@ -83,6 +85,7 @@ final class TaskCapsuleModel: ObservableObject {
         self.startReview = startReview
         self.askPlanner = askPlanner
         manageProfilesHandler = manageProfiles
+        openConversationHandler = openConversation
     }
 
     var profiles: [AgentProfile] { profilesProvider().filter(\.isConfigured) }
@@ -91,10 +94,18 @@ final class TaskCapsuleModel: ObservableObject {
     var isEditingRecipe: Bool { editingCapsuleID != nil && editingCapsuleID == selectedID }
     var hasActivePlan: Bool { activePlanProvider().map(Self.hasSteps) ?? false }
     var isBusy: Bool { isBusyProvider() || isSaving || !activeStageSessions.isEmpty }
-    var canGenerate: Bool {
-        !draftRequest.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && recipeError(draftRecipe) == nil && !workspaceRoot.isEmpty && !isBusy
+    /// Share the button's availability with its visible explanation so setup
+    /// never leaves a disabled primary action without a next step.
+    var planningUnavailableReason: String? {
+        if workspaceRoot.isEmpty { return "Open a workspace to save your capsule in." }
+        if isBusy { return "Finish the active task before starting a new plan." }
+        if let issue = recipeError(draftRecipe) { return issue }
+        if draftRequest.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Describe your task above, or choose an example to get started."
+        }
+        return nil
     }
+    var canGenerate: Bool { planningUnavailableReason == nil }
     var canCapturePlan: Bool { hasActivePlan && recipeError(draftRecipe) == nil && !workspaceRoot.isEmpty && !isBusy }
     func profileLabel(_ profile: AgentProfile) -> String { profileLabelProvider(profile) }
     func profileLabel(id: String?) -> String {
@@ -121,6 +132,12 @@ final class TaskCapsuleModel: ObservableObject {
     func manageProfiles() {
         isPresented = false
         manageProfilesHandler()
+    }
+
+    func openConversation(sessionID: String) {
+        guard !sessionID.isEmpty else { return }
+        isPresented = false
+        openConversationHandler(sessionID)
     }
 
     func newCapsule() {

--- a/Locus/TaskCapsuleView.swift
+++ b/Locus/TaskCapsuleView.swift
@@ -3,51 +3,73 @@ import SwiftUI
 struct TaskCapsuleView: View {
     @ObservedObject var model: TaskCapsuleModel
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.locusAccent) private var accent
     @State private var showLimits = false
-    @State private var useAPIEstimateLimit = false
-    @State private var apiEstimateLimit = 5.0
+    @State private var librarySearch = ""
+    @State private var expandedSteps: Set<String> = []
+    @FocusState private var requestFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
             header
             Divider()
-            HStack(spacing: 0) {
-                library
-                    .frame(width: 235)
-                Divider()
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 20) {
-                        waitingPlans
-                        if let capsule = model.selectedCapsule { savedCapsule(capsule) }
-                        else { draft }
+            GeometryReader { geometry in
+                HStack(spacing: 0) {
+                    if geometry.size.width >= 800 {
+                        library.frame(width: 220)
+                        Divider()
                     }
-                    .padding(24)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    VStack(spacing: 0) {
+                        if geometry.size.width < 800 {
+                            compactLibrary
+                            Divider()
+                        }
+                        ScrollViewReader { scroll in
+                            ScrollView {
+                                VStack(alignment: .leading, spacing: 22) {
+                                    waitingPlans
+                                    if let capsule = model.selectedCapsule { savedCapsule(capsule) }
+                                    else { draft }
+                                }
+                                .padding(24)
+                                .frame(maxWidth: 780, alignment: .leading)
+                                .frame(maxWidth: .infinity)
+                            }
+                            .onChange(of: model.isEditingRecipe) { _, editing in
+                                if editing { scroll.scrollTo("capsules.recipeEditor", anchor: .top) }
+                            }
+                        }
+                        Divider()
+                        actionBar
+                    }
                 }
             }
-            Divider()
-            footer
+            if model.error != nil || model.status != nil || model.isRefreshing || model.isSaving {
+                Divider()
+                statusBar
+            }
         }
-        .frame(minWidth: 820, idealWidth: 940, minHeight: 600, idealHeight: 730)
+        .frame(minWidth: 640, idealWidth: 960, minHeight: 560, idealHeight: 760)
         .background(LocusTheme.surfaceCanvas)
         .foregroundStyle(LocusTheme.textPrimary)
         .task { await model.refresh() }
-        .onChange(of: model.editingCapsuleID) { _, _ in synchronizeAPIEstimate() }
-        .onAppear { synchronizeAPIEstimate() }
-        .accessibilityIdentifier("capsules.sheet")
+        .onChange(of: model.selectedID) { _, _ in expandedSteps = [] }
     }
 
     private var header: some View {
         HStack(spacing: 12) {
             Image(systemName: "shippingbox")
-                .font(.locus(size: 24))
+                .font(.locus(size: 23))
                 .foregroundStyle(LocusTheme.accentAction)
+                .frame(width: 42, height: 42)
+                .background(LocusTheme.accentFill.opacity(0.12), in: RoundedRectangle(cornerRadius: 12))
+                .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 3) {
                 Text("Task Capsules").font(.title2.weight(.semibold))
-                Text("Plan once. Continue with the model you choose.")
+                Text("Save a plan. Choose who builds it. Run when you’re ready.")
                     .font(.callout).foregroundStyle(LocusTheme.textSecondary)
             }
-            Spacer()
+            Spacer(minLength: 12)
             Button("Done") { model.isPresented = false; dismiss() }
                 .keyboardShortcut(.cancelAction)
                 .buttonStyle(.locus())
@@ -56,334 +78,499 @@ struct TaskCapsuleView: View {
         .padding(20)
     }
 
+    private var filteredCapsules: [TaskCapsule] {
+        let query = librarySearch.trimmingCharacters(in: .whitespacesAndNewlines)
+        return query.isEmpty ? model.capsules : model.capsules.filter {
+            $0.title.localizedCaseInsensitiveContains(query) || $0.request.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    private var workspaceName: String {
+        model.workspaceRoot.isEmpty ? "Choose a workspace" : URL(fileURLWithPath: model.workspaceRoot).lastPathComponent
+    }
+
     private var library: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 14) {
             HStack {
-                Text("SAVED PLANS").font(.caption.weight(.semibold))
-                    .foregroundStyle(LocusTheme.textSecondary)
+                Text("Your capsules").font(.headline)
                 Spacer()
-                Button { Task { await model.refresh() } } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-                .buttonStyle(.locus(.icon))
-                .disabled(model.isRefreshing)
-                .help("Refresh saved capsules")
-                .accessibilityLabel("Refresh saved capsules")
+                refreshButton
             }
-            Text(URL(fileURLWithPath: model.workspaceRoot).lastPathComponent)
-                .font(.caption).foregroundStyle(LocusTheme.textTertiary)
+            Label(workspaceName, systemImage: "folder")
+                .font(.caption).foregroundStyle(LocusTheme.textSecondary)
                 .lineLimit(1).help(model.workspaceRoot)
             Button { model.newCapsule() } label: {
                 Label("New capsule", systemImage: "plus")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(9)
+                    .frame(maxWidth: .infinity, alignment: .leading).padding(10)
             }
             .buttonStyle(.locus(.card))
-            .locusCard(radius: 8)
+            .locusCard(radius: 9)
             .accessibilityIdentifier("capsules.new")
+            if !model.capsules.isEmpty {
+                TextField("Find a capsule", text: $librarySearch)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityLabel("Find a capsule")
+                    .accessibilityIdentifier("capsules.search")
+            }
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 7) {
-                    if model.capsules.isEmpty {
-                        Text(model.isRefreshing ? "Loading saved plans…" : "Your saved plans will appear here. Each capsule keeps its model choices and instructions.")
+                    if filteredCapsules.isEmpty {
+                        Text(model.isRefreshing ? "Loading your capsules…" : model.capsules.isEmpty
+                             ? "Your first capsule starts with a task. Once its plan is ready, it will appear here."
+                             : "No capsules match your search.")
                             .font(.callout).foregroundStyle(LocusTheme.textTertiary)
                             .padding(.vertical, 12)
                     }
-                    ForEach(model.capsules) { capsule in
-                        Button {
-                            model.select(capsule)
-                        } label: {
-                            VStack(alignment: .leading, spacing: 5) {
+                    ForEach(filteredCapsules) { capsule in
+                        Button { model.select(capsule) } label: {
+                            VStack(alignment: .leading, spacing: 6) {
                                 Text(capsule.title).font(.callout.weight(.medium)).lineLimit(2)
-                                Text("\(stepCount(capsule.plan)) steps · Revision \(capsule.revision)")
+                                Text("\(stepSummary(capsule.plan)) · Revision \(capsule.revision)")
                                     .font(.caption).foregroundStyle(LocusTheme.textSecondary)
+                                Label(capsuleState(capsule), systemImage: capsule.runs.isEmpty ? "doc.text" : "clock")
+                                    .font(.caption2).foregroundStyle(LocusTheme.textTertiary)
                             }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(10)
-                            .background(model.selectedID == capsule.id ? LocusTheme.accentFill.opacity(0.22) : Color.clear)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            .frame(maxWidth: .infinity, alignment: .leading).padding(11)
+                            .background(model.selectedID == capsule.id ? LocusTheme.accentFill.opacity(0.17) : Color.clear)
+                            .clipShape(RoundedRectangle(cornerRadius: 9))
                         }
                         .buttonStyle(.locus(.card))
+                        .accessibilityAddTraits(model.selectedID == capsule.id ? .isSelected : [])
                         .accessibilityIdentifier("capsules.saved.\(capsule.id)")
                     }
                 }
             }
             Button("Manage agent profiles") { model.manageProfiles() }
-                .buttonStyle(.locus())
-                .font(.caption)
+                .buttonStyle(.locus()).font(.caption)
         }
         .padding(16)
         .background(LocusTheme.surfaceStructural.opacity(0.5))
     }
 
-    private var draft: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            Text("Give the planner a goal").font(.title3.weight(.semibold))
-            TextField("Capsule name (optional)", text: $model.draftTitle)
-                .textFieldStyle(.roundedBorder)
-                .accessibilityIdentifier("capsules.title")
-            VStack(alignment: .leading, spacing: 6) {
-                Text("What should the task accomplish?").font(.callout.weight(.medium))
-                TextEditor(text: $model.draftRequest)
-                    .foregroundStyle(LocusTheme.inkSoft)
-                    .tint(LocusTheme.accentAction)
-                    .font(.body)
-                    .scrollContentBackground(.hidden)
-                    .padding(8)
-                    .frame(minHeight: 115)
-                    .locusCard(radius: 8)
-                    .accessibilityLabel("Capsule request")
-                    .accessibilityIdentifier("capsules.request")
-            }
-            modelChoices
-            Text("Use your connected ChatGPT or Kimi account, a local model, or an API profile. The planner writes the instructions; the implementation model follows the saved plan.")
-                .font(.callout).foregroundStyle(LocusTheme.textSecondary)
-            DisclosureGroup("Usage limits", isExpanded: $showLimits) {
-                limits.padding(.top, 10)
-            }
-            .font(.callout)
-            HStack(spacing: 12) {
-                Button { model.generatePlan() } label: {
-                    Label("Generate plan", systemImage: "sparkles")
-                        .padding(.horizontal, 12).padding(.vertical, 9)
-                        .background(LocusTheme.accentFill)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
+    private var compactLibrary: some View {
+        HStack(spacing: 12) {
+            Menu {
+                Button("New capsule") { model.newCapsule() }
+                if !model.capsules.isEmpty {
+                    Divider()
+                    ForEach(model.capsules) { capsule in
+                        Button(capsule.title) { model.select(capsule) }
+                    }
                 }
-                .buttonStyle(.locus(.primary))
-                .disabled(!model.canGenerate)
-                .accessibilityIdentifier("capsules.generate")
-                Button("Save current plan") { model.captureActivePlan() }
-                    .buttonStyle(.locus())
-                    .disabled(!model.canCapturePlan)
-                    .help("Save the current conversation's completed plan using these model choices")
-                    .accessibilityIdentifier("capsules.capture")
+            } label: {
+                Label(model.selectedCapsule?.title ?? "New capsule", systemImage: "shippingbox")
+                    .lineLimit(1)
             }
-            Text("Planning opens in the conversation. The completed plan is saved here for you to review and run.")
-                .font(.caption).foregroundStyle(LocusTheme.textTertiary)
+            .accessibilityLabel("Choose a capsule")
+            .accessibilityIdentifier("capsules.libraryMenu")
+            Spacer(minLength: 4)
+            Button { model.newCapsule() } label: { Label("New", systemImage: "plus") }
+                .buttonStyle(.locus())
+                .accessibilityIdentifier("capsules.new")
+            refreshButton
+        }
+        .padding(.horizontal, 20).padding(.vertical, 10)
+    }
+
+    private var refreshButton: some View {
+        Button { Task { await model.refresh() } } label: { Image(systemName: "arrow.clockwise") }
+            .buttonStyle(.locus(.icon)).disabled(model.isRefreshing)
+            .help("Refresh saved capsules").accessibilityLabel("Refresh saved capsules")
+    }
+
+    private var draft: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            VStack(alignment: .leading, spacing: 9) {
+                Text("Turn a task into a reusable plan").font(.title3.weight(.semibold))
+                Text("Your planner works out the steps. You review the plan before the implementation model makes changes.")
+                    .font(.callout).foregroundStyle(LocusTheme.textSecondary)
+                HStack(spacing: 8) {
+                    workflowStep("1", "Describe")
+                    Image(systemName: "chevron.right").accessibilityHidden(true)
+                    workflowStep("2", "Plan")
+                    Image(systemName: "chevron.right").accessibilityHidden(true)
+                    workflowStep("3", "Review & run")
+                }
+                .font(.caption).foregroundStyle(LocusTheme.textTertiary).padding(.top, 3)
+            }
+            VStack(alignment: .leading, spacing: 12) {
+                sectionHeading("1", "Describe your task", detail: "Include the result you want and anything that should stay the same.")
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $model.draftRequest)
+                        .foregroundStyle(LocusTheme.inkSoft).tint(LocusTheme.accentAction)
+                        .font(.body).scrollContentBackground(.hidden)
+                        .padding(8).frame(minHeight: 120)
+                        .focused($requestFocused)
+                        .accessibilityLabel("Capsule request")
+                        .accessibilityIdentifier("capsules.request")
+                    if model.draftRequest.isEmpty {
+                        Text("What would you like to accomplish?")
+                            .font(.body).foregroundStyle(LocusTheme.textTertiary)
+                            .padding(.horizontal, 13).padding(.vertical, 16)
+                            .allowsHitTesting(false).accessibilityHidden(true)
+                    }
+                }
+                .locusCard(radius: 9)
+                if model.draftRequest.isEmpty {
+                    HStack(spacing: 8) {
+                        Text("Try:").font(.caption).foregroundStyle(LocusTheme.textTertiary)
+                        exampleButton("Fix a bug", request: "Fix [describe the issue] in [area of the project]. First reproduce the problem, then plan the smallest change and checks that show it is fixed.")
+                        exampleButton("Build a feature", request: "Add [describe the feature] for [who will use it]. Plan the user experience, implementation, and checks. Keep [existing behavior] working.")
+                        exampleButton("Improve a workflow", request: "Improve [describe the workflow] so [desired result]. Inspect the current approach, explain the proposed changes, and include checks for success.")
+                    }
+                }
+                TextField("Name this capsule (optional)", text: $model.draftTitle)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityLabel("Capsule name, optional")
+                    .accessibilityIdentifier("capsules.title")
+                Text("Leave the name blank to use the planner’s title.")
+                    .font(.caption).foregroundStyle(LocusTheme.textTertiary)
+            }
+            VStack(alignment: .leading, spacing: 12) {
+                sectionHeading("2", "Choose your models", detail: "An agent profile is a saved model, account, and set of permissions.")
+                modelChoices
+            }
+            DisclosureGroup(isExpanded: $showLimits) {
+                limits.padding(.top, 12)
+            } label: {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Advanced · Usage limits").font(.callout.weight(.medium))
+                    Text("\(model.draftRecipe.planningCallLimit) planning calls · \(model.draftRecipe.executionCallLimit) implementation calls")
+                        .font(.caption).foregroundStyle(LocusTheme.textTertiary)
+                }
+            }
+            .padding(14).locusCard(radius: 10)
+            if model.hasActivePlan {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: "doc.badge.plus").foregroundStyle(LocusTheme.accentAction)
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Already planned this in your conversation?").font(.callout.weight(.medium))
+                        Text("Save that plan with these model choices and review it here.")
+                            .font(.caption).foregroundStyle(LocusTheme.textSecondary)
+                        Button("Save current conversation plan") { model.captureActivePlan() }
+                            .buttonStyle(.locus()).disabled(!model.canCapturePlan)
+                            .accessibilityIdentifier("capsules.capture")
+                    }
+                }
+                .padding(14).frame(maxWidth: .infinity, alignment: .leading).locusCard(radius: 10)
+            }
         }
     }
 
+    private func workflowStep(_ number: String, _ title: String) -> some View {
+        HStack(spacing: 5) {
+            Text(number).font(.caption2.weight(.semibold))
+                .frame(width: 20, height: 20)
+                .background(LocusTheme.accentFill.opacity(0.14), in: Circle())
+            Text(title).foregroundStyle(LocusTheme.textSecondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func sectionHeading(_ number: String, _ title: String, detail: String) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("\(number). \(title)").font(.headline)
+            Text(detail).font(.caption).foregroundStyle(LocusTheme.textSecondary)
+        }
+    }
+
+    private func exampleButton(_ title: String, request: String) -> some View {
+        Button(title) {
+            model.draftRequest = request
+            requestFocused = true
+        }
+        .font(.caption).buttonStyle(.locus())
+        .help("Start with an editable example. Replace the bracketed details with your task.")
+        .accessibilityIdentifier("capsules.example.\(title)")
+    }
+
     private var modelChoices: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 16) {
             if model.profiles.isEmpty {
-                Text("Create agent profiles for your planning and implementation models first.")
-                    .font(.callout)
-                Button("Set up agent profiles") { model.manageProfiles() }.buttonStyle(.locus())
+                Label("Set up your first agent profile", systemImage: "person.crop.circle.badge.plus")
+                    .font(.callout.weight(.semibold))
+                Text("One profile can do both jobs. In settings, choose Add Agent, select your account under Provider route and pick a model. Set Access ceiling to Workspace edits so it can implement your plan, then save.")
+                    .font(.callout).foregroundStyle(LocusTheme.textSecondary)
+                Button("Set up agent profiles") { model.manageProfiles() }
+                    .buttonStyle(.locus())
+                    .accessibilityIdentifier("capsules.setupProfiles")
+                Text("Your task description stays here. Reopen Task Capsules after saving your profile to continue.")
+                    .font(.caption).foregroundStyle(LocusTheme.textTertiary)
             } else {
-                profilePicker("Plan with", selection: $model.draftRecipe.plannerProfileID)
-                profilePicker("Implement with", selection: $model.draftRecipe.executorProfileID)
+                profilePicker("Plan with", hint: "Inspects your workspace and writes the plan. Planning is read-only.", selection: $model.draftRecipe.plannerProfileID, implementation: false)
+                Divider()
+                profilePicker("Implement with", hint: "Follows the saved steps and can make changes when you choose Run plan.", selection: $model.draftRecipe.executorProfileID, implementation: true)
                 if model.implementationProfiles.isEmpty {
-                    Text("Enable workspace write access for an implementation profile in Agent Profiles.")
+                    Label("In Manage profiles, edit a profile and set Access ceiling to Workspace edits to enable implementation.", systemImage: "exclamationmark.circle")
                         .font(.caption).foregroundStyle(LocusTheme.warning)
                 }
-                Picker("Review with", selection: Binding(
-                    get: { model.draftRecipe.reviewerProfileID ?? "" },
-                    set: { model.draftRecipe.reviewerProfileID = $0.isEmpty ? nil : $0 }
-                )) {
-                    Text("No separate reviewer").tag("")
-                    if let reviewer = model.draftRecipe.reviewerProfileID,
-                       !model.profiles.contains(where: { $0.id.uuidString == reviewer }) {
-                        Text("Unavailable saved profile").tag(reviewer)
+                Divider()
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Review with").font(.callout.weight(.medium))
+                        Text("Optional").font(.caption).foregroundStyle(LocusTheme.textTertiary)
                     }
-                    ForEach(model.profiles) { profile in
-                        Text(model.profileLabel(profile)).tag(profile.id.uuidString)
+                    Picker("Review with", selection: Binding(
+                        get: { model.draftRecipe.reviewerProfileID ?? "" },
+                        set: { model.draftRecipe.reviewerProfileID = $0.isEmpty ? nil : $0 }
+                    )) {
+                        Text("No separate reviewer").tag("")
+                        if let reviewer = model.draftRecipe.reviewerProfileID,
+                           !model.profiles.contains(where: { $0.id.uuidString.caseInsensitiveCompare(reviewer) == .orderedSame }) {
+                            Text("Unavailable saved profile — choose another").tag(reviewer)
+                        }
+                        ForEach(model.profiles) { profile in
+                            Text(model.profileLabel(profile)).tag(profile.id.uuidString)
+                        }
                     }
+                    .labelsHidden().frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityIdentifier("capsules.reviewer")
+                    Text("Checks the implementation and can request fixes within your repair allowance.")
+                        .font(.caption).foregroundStyle(LocusTheme.textSecondary)
                 }
-                .accessibilityIdentifier("capsules.reviewer")
+                HStack {
+                    Text("You can use the same profile for more than one role.")
+                        .font(.caption).foregroundStyle(LocusTheme.textTertiary)
+                    Spacer(minLength: 8)
+                    Button("Manage profiles") { model.manageProfiles() }
+                        .buttonStyle(.locus()).font(.caption)
+                }
             }
         }
         .padding(16).locusCard(radius: 10)
     }
 
-    private func profilePicker(_ title: String, selection: Binding<String>) -> some View {
-        let choices = title == "Implement with" ? model.implementationProfiles : model.profiles
-        return Picker(title, selection: selection) {
-            if !choices.contains(where: { $0.id.uuidString == selection.wrappedValue }) {
-                Text("Choose an available profile").tag(selection.wrappedValue)
+    private func profilePicker(_ title: String, hint: String, selection: Binding<String>, implementation: Bool) -> some View {
+        let choices = implementation ? model.implementationProfiles : model.profiles
+        return VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.callout.weight(.medium))
+            Picker(title, selection: selection) {
+                if !choices.contains(where: { $0.id.uuidString.caseInsensitiveCompare(selection.wrappedValue) == .orderedSame }) {
+                    Text(selection.wrappedValue.isEmpty ? "Choose a profile" : "Unavailable saved profile — choose another")
+                        .tag(selection.wrappedValue)
+                }
+                ForEach(choices) { profile in
+                    Text(model.profileLabel(profile)).tag(profile.id.uuidString)
+                }
             }
-            ForEach(choices) { profile in
-                Text(model.profileLabel(profile)).tag(profile.id.uuidString)
-            }
+            .labelsHidden().frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityIdentifier(implementation ? "capsules.executor" : "capsules.planner")
+            Text(hint).font(.caption).foregroundStyle(LocusTheme.textSecondary)
         }
-        .accessibilityIdentifier(title == "Plan with" ? "capsules.planner" : "capsules.executor")
     }
 
     private var limits: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Stepper("Planning: up to \(model.draftRecipe.planningCallLimit) model calls", value: $model.draftRecipe.planningCallLimit, in: 1...100)
-            Stepper("Implementation: up to \(model.draftRecipe.executionCallLimit) model calls", value: $model.draftRecipe.executionCallLimit, in: 1...100)
-            Stepper("Total review repair rounds: \(model.draftRecipe.maxRepairAttempts)", value: $model.draftRecipe.maxRepairAttempts, in: 0...7)
-            Stepper("Total planner help requests: \(model.draftRecipe.maxPlannerEscalations)", value: $model.draftRecipe.maxPlannerEscalations, in: 0...10)
-            Text("Repair rounds and planner help are allowances for the saved capsule, including later runs and revisions.")
+            Text("A model call is one request to a model. These allowances stop a stage from continuing indefinitely.")
                 .font(.caption).foregroundStyle(LocusTheme.textSecondary)
-            Text("Implementation and review use their profile's per-response token limit. Your provider manages subscription allowances; model calls and tokens are not converted into a subscription dollar charge.")
+            Stepper("Planning: up to \(model.draftRecipe.planningCallLimit) calls", value: $model.draftRecipe.planningCallLimit, in: 1...100)
+            Stepper("Implementation: up to \(model.draftRecipe.executionCallLimit) calls", value: $model.draftRecipe.executionCallLimit, in: 1...100)
+            Stepper("Review repair rounds: \(model.draftRecipe.maxRepairAttempts)", value: $model.draftRecipe.maxRepairAttempts, in: 0...7)
+            Stepper("Planner help requests: \(model.draftRecipe.maxPlannerEscalations)", value: $model.draftRecipe.maxPlannerEscalations, in: 0...10)
+            Text("Repair rounds and planner help are shared across this capsule’s runs and revisions. Without a reviewer, repair rounds are unused.")
                 .font(.caption).foregroundStyle(LocusTheme.textSecondary)
-            Toggle("Optional implementation API cost estimate limit", isOn: $useAPIEstimateLimit)
-                .onChange(of: useAPIEstimateLimit) { _, enabled in
-                    model.draftRecipe.maximumEstimatedCost = enabled ? apiEstimateLimit : nil
-                }
-            if useAPIEstimateLimit {
+            Toggle("Set an estimated API cost limit", isOn: Binding(
+                get: { model.draftRecipe.maximumEstimatedCost != nil },
+                set: { model.draftRecipe.maximumEstimatedCost = $0 ? 5 : nil }
+            ))
+            if model.draftRecipe.maximumEstimatedCost != nil {
                 HStack {
                     Text("Estimated USD")
-                    TextField("Amount", value: $apiEstimateLimit, format: .number)
-                        .textFieldStyle(.roundedBorder).frame(width: 100)
-                        .onChange(of: apiEstimateLimit) { _, value in
-                            model.draftRecipe.maximumEstimatedCost = value
-                        }
+                    TextField("Amount", value: Binding(
+                        get: { model.draftRecipe.maximumEstimatedCost ?? 5 },
+                        set: { model.draftRecipe.maximumEstimatedCost = $0 }
+                    ), format: .number)
+                    .textFieldStyle(.roundedBorder).frame(width: 100)
+                    .accessibilityLabel("Estimated API cost limit in US dollars")
                 }
-                Text("Applies to implementation and its review calls on API routes with configured prices. Planning calls, third-party tools, and image generation are excluded.")
-                    .font(.caption).foregroundStyle(LocusTheme.textTertiary)
+                Text("An estimate, not a billing cap. Covers implementation and its automatic review with configured API prices. Excludes planning, standalone review, tools, and image generation.")
+                    .font(.caption).foregroundStyle(LocusTheme.textSecondary)
             }
+            Text("Your provider manages subscription allowances. Locus does not convert subscription calls or tokens into a dollar charge. Profile response-token and runtime limits still apply.")
+                .font(.caption).foregroundStyle(LocusTheme.textTertiary)
         }
+        .font(.callout)
     }
 
     private func savedCapsule(_ capsule: TaskCapsule) -> some View {
-        VStack(alignment: .leading, spacing: 18) {
-            Text(capsule.title).font(.title2.weight(.semibold))
-            Text("Revision \(capsule.revision) · \(stepCount(capsule.plan)) saved steps")
-                .font(.caption).foregroundStyle(LocusTheme.textSecondary)
-            if !capsule.request.isEmpty { Text(capsule.request).font(.callout).textSelection(.enabled) }
+        VStack(alignment: .leading, spacing: 20) {
             VStack(alignment: .leading, spacing: 8) {
-                routeSummary("Plan", id: capsule.recipe.plannerProfileID)
-                routeSummary("Implement", id: capsule.recipe.executorProfileID)
-                routeSummary("Review", id: capsule.recipe.reviewerProfileID)
-                Text("Up to \(capsule.recipe.planningCallLimit) planning calls · \(capsule.recipe.executionCallLimit) implementation calls · \(capsule.recipe.maxRepairAttempts) total review repair rounds")
-                    .font(.caption).foregroundStyle(LocusTheme.textTertiary)
+                Label(capsuleState(capsule), systemImage: "doc.text")
+                    .font(.caption.weight(.medium)).foregroundStyle(LocusTheme.accentAction)
+                Text(capsule.title).font(.title2.weight(.semibold)).textSelection(.enabled)
+                Text("Revision \(capsule.revision) · \(stepSummary(capsule.plan)) · \(workspaceName)")
+                    .font(.caption).foregroundStyle(LocusTheme.textSecondary)
+                if !capsule.request.isEmpty {
+                    Text(capsule.request).font(.callout).foregroundStyle(LocusTheme.textSecondary).textSelection(.enabled)
+                }
             }
-            .padding(14).locusCard(radius: 10)
             if model.isEditingRecipe {
                 recipeEditor
+                    .id("capsules.recipeEditor")
             } else {
-                Button("Edit models and limits") { model.beginEditingRecipe() }
-                    .buttonStyle(.locus())
-                    .disabled(model.isBusy)
-                    .accessibilityIdentifier("capsules.editRecipe")
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack {
+                        Text("Models & limits").font(.headline)
+                        Spacer()
+                        Button("Edit") { model.beginEditingRecipe() }
+                            .buttonStyle(.locus()).disabled(model.isBusy)
+                            .accessibilityLabel("Edit models and limits")
+                            .accessibilityIdentifier("capsules.editRecipe")
+                    }
+                    routeSummary("Plan", id: capsule.recipe.plannerProfileID)
+                    routeSummary("Implement", id: capsule.recipe.executorProfileID)
+                    routeSummary("Review", id: capsule.recipe.reviewerProfileID)
+                    Text("Up to \(capsule.recipe.planningCallLimit) planning calls · \(capsule.recipe.executionCallLimit) implementation calls")
+                        .font(.caption).foregroundStyle(LocusTheme.textTertiary)
+                }
+                .padding(16).locusCard(radius: 10)
             }
-            if let issue = model.recipeError(capsule.recipe) {
-                Text(issue).font(.callout).foregroundStyle(LocusTheme.warning)
+            if let issue = model.recipeError(capsule.recipe), !model.isEditingRecipe {
+                Label(issue, systemImage: "exclamationmark.circle")
+                    .font(.callout).foregroundStyle(LocusTheme.warning)
             }
             planSteps(capsule.plan)
-            HStack(spacing: 16) {
-                Button { model.runSelected() } label: {
-                    Label("Run saved capsule", systemImage: "play.fill")
-                        .padding(.horizontal, 12).padding(.vertical, 9)
-                        .background(LocusTheme.accentFill)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                }
-                .buttonStyle(.locus(.primary))
-                .disabled(model.isBusy || model.isEditingRecipe || model.recipeError(capsule.recipe) != nil)
-                .accessibilityIdentifier("capsules.run")
-                if capsule.recipe.reviewerProfileID != nil {
-                    Button("Review result") { model.reviewSelected() }
-                        .buttonStyle(.locus())
-                        .disabled(model.isBusy || model.isEditingRecipe)
-                        .accessibilityIdentifier("capsules.review")
-                }
-            }
-            if capsule.plan.stepDetails.contains(where: { !$0.files.isEmpty }) {
-                Text("Execution uses this saved plan directly. Named files are checked for changes before implementation starts.")
-                    .font(.caption).foregroundStyle(LocusTheme.textSecondary)
-            } else {
-                Text("This saved plan has no named files, so there are no source-change checks. Ask the planner to add file references.")
-                    .font(.caption).foregroundStyle(LocusTheme.warning)
-            }
-            if capsule.recipe.maxPlannerEscalations > 0 {
-                DisclosureGroup("Ask the planner for help") {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("\(capsule.plannerHelpRequestsRemaining) of \(capsule.recipe.maxPlannerEscalations) total planner help requests remaining")
-                            .font(.caption).foregroundStyle(LocusTheme.textSecondary)
-                        if capsule.plannerHelpRequestsRemaining == 0 {
-                            Text("Use Edit models and limits to allow another request.")
-                                .font(.caption).foregroundStyle(LocusTheme.warning)
-                        }
-                        TextField("Describe the blocker or the change needed", text: $model.plannerQuestion, axis: .vertical)
-                            .lineLimit(2...5).textFieldStyle(.roundedBorder)
-                        Button("Ask planner") { model.askPlannerForSelected() }
-                            .buttonStyle(.locus())
-                            .disabled(model.isBusy || model.isEditingRecipe || capsule.plannerHelpRequestsRemaining == 0
-                                      || model.plannerQuestion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                        Text("Uses the planning model again and saves a new revision when the revised plan is complete.")
-                            .font(.caption).foregroundStyle(LocusTheme.textTertiary)
-                    }.padding(.top, 10)
-                }
-            }
-            if !capsule.runs.isEmpty {
-                VStack(alignment: .leading, spacing: 9) {
-                    Text("Run history").font(.headline)
-                    ForEach(capsule.runs) { run in
-                        HStack {
-                            Text(run.stageTitle)
-                            Spacer()
-                            if let calls = run.modelCalls { Text("\(calls) calls") }
-                            if let tokens = run.totalTokens { Text("\(tokens.formatted()) tokens") }
-                            Text(run.status.capitalized)
-                        }.font(.caption).foregroundStyle(LocusTheme.textSecondary)
-                    }
-                }
-            }
+            sourceCheckSummary(capsule)
+            plannerHelp(capsule)
+            if !capsule.runs.isEmpty { runHistory(capsule) }
         }
     }
 
+    private func capsuleState(_ capsule: TaskCapsule) -> String {
+        guard let run = capsule.runs.last(where: { $0.stage == "execute" || $0.stage == "review" }) else {
+            return "Plan saved · Ready to review"
+        }
+        return "Last run: \(run.stageTitle) · \(runStatus(run))"
+    }
+
+    private func runStatus(_ run: TaskCapsuleRun) -> String {
+        switch run.status.lowercased() {
+        case "completed", "complete", "succeeded": return "Completed"
+        case "failed", "error": return "Needs attention"
+        case "interrupted", "cancelled", "canceled", "stopped": return "Stopped"
+        case "running", "active": return "In progress"
+        case "pending", "queued": return "Waiting"
+        default: return run.status.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+
+    private func sourceCheckSummary(_ capsule: TaskCapsule) -> some View {
+        let fileCount = Set(capsule.plan.stepDetails.flatMap(\.files)).count
+        return Label {
+            Text(fileCount > 0
+                 ? "Locus checks \(fileCount) named \(fileCount == 1 ? "file" : "files") for changes before running. If anything has changed, ask the planner to update the plan."
+                 : "This plan has no named files to check before running. You can ask the planner to add file references.")
+        } icon: {
+            Image(systemName: fileCount > 0 ? "doc.text.magnifyingglass" : "info.circle")
+        }
+        .font(.caption).foregroundStyle(fileCount > 0 ? LocusTheme.textSecondary : LocusTheme.warning)
+        .padding(14).frame(maxWidth: .infinity, alignment: .leading).locusCard(radius: 10)
+    }
+
     private func routeSummary(_ stage: String, id: String?) -> some View {
-        HStack(alignment: .top) {
-            Text(stage).font(.callout.weight(.medium)).frame(width: 78, alignment: .leading)
-            Text(model.profileLabel(id: id)).font(.callout).foregroundStyle(LocusTheme.textSecondary)
+        HStack(alignment: .top, spacing: 10) {
+            Text(stage).font(.callout.weight(.medium)).frame(width: 74, alignment: .leading)
+            Text(id == nil ? "No separate reviewer" : model.profileLabel(id: id))
+                .font(.callout).foregroundStyle(LocusTheme.textSecondary).textSelection(.enabled)
         }
     }
 
     private var recipeEditor: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("Models and limits").font(.headline)
+            Label("Editing models & limits", systemImage: "pencil").font(.headline)
             modelChoices
-            limits
-            if let issue = model.recipeError(model.draftRecipe) {
-                Text(issue).font(.caption).foregroundStyle(LocusTheme.warning)
-            }
-            Text("Saving creates a new revision with these choices. The saved instructions and source checks stay as they are.")
+            DisclosureGroup("Usage limits", isExpanded: $showLimits) { limits.padding(.top, 12) }
+            Text("Save to create a new revision. Your plan, file checks, and run history are preserved.")
                 .font(.caption).foregroundStyle(LocusTheme.textSecondary)
-            HStack(spacing: 16) {
-                Button("Save choices") { Task { await model.saveRecipeChanges() } }
-                    .buttonStyle(.locus())
-                    .disabled(model.isBusy || model.recipeError(model.draftRecipe) != nil)
-                    .accessibilityIdentifier("capsules.saveRecipe")
-                Button("Cancel") { model.cancelRecipeEditing() }
-                    .buttonStyle(.locus())
-                    .disabled(model.isSaving)
+            if let issue = model.recipeError(model.draftRecipe) {
+                Label(issue, systemImage: "exclamationmark.circle")
+                    .font(.caption).foregroundStyle(LocusTheme.warning)
             }
         }
-        .padding(14).locusCard(radius: 10)
-    }
-
-    private func synchronizeAPIEstimate() {
-        useAPIEstimateLimit = model.draftRecipe.maximumEstimatedCost != nil
-        apiEstimateLimit = model.draftRecipe.maximumEstimatedCost ?? 5
+        .padding(16).locusCard(radius: 10)
     }
 
     private var waitingPlans: some View {
         ForEach(model.waitingPlans) { waiting in
-            VStack(alignment: .leading, spacing: 8) {
-                Label("Planning is waiting for your reply", systemImage: "bubble.left")
+            VStack(alignment: .leading, spacing: 9) {
+                Label("Finish your plan", systemImage: "bubble.left.and.text.bubble.right")
                     .font(.callout.weight(.semibold))
                 Text(waiting.title).font(.callout).foregroundStyle(LocusTheme.textSecondary)
-                Text("Reply in its conversation to keep planning, or cancel capsule planning to return that conversation to normal model selection.")
+                Text("Open the conversation to answer questions or continue planning. The finished plan will be saved here.")
                     .font(.caption).foregroundStyle(LocusTheme.textSecondary)
-                Button("Cancel capsule planning") { model.cancelPlanning(sessionID: waiting.id) }
-                    .buttonStyle(.locus())
-                    .accessibilityIdentifier("capsules.cancelPlanning.\(waiting.id)")
+                HStack(spacing: 14) {
+                    Button("Continue planning") { model.openConversation(sessionID: waiting.id) }
+                        .buttonStyle(.locus())
+                        .accessibilityIdentifier("capsules.continuePlanning.\(waiting.id)")
+                    Button("Cancel planning") { model.cancelPlanning(sessionID: waiting.id) }
+                        .buttonStyle(.locus())
+                        .accessibilityIdentifier("capsules.cancelPlanning.\(waiting.id)")
+                }
             }
-            .padding(14).frame(maxWidth: .infinity, alignment: .leading).locusCard(radius: 10)
+            .padding(16).frame(maxWidth: .infinity, alignment: .leading).locusCard(radius: 10)
         }
+    }
+
+    private func plannerHelp(_ capsule: TaskCapsule) -> some View {
+        DisclosureGroup("Update the plan or ask for help") {
+            VStack(alignment: .leading, spacing: 10) {
+                if capsule.plannerHelpRequestsRemaining > 0 {
+                    Text("Describe a blocker or change. Your planning model will inspect the workspace and save a revised plan for you to review.")
+                        .font(.caption).foregroundStyle(LocusTheme.textSecondary)
+                    TextField("What should the planner change or investigate?", text: $model.plannerQuestion, axis: .vertical)
+                        .lineLimit(3...6).textFieldStyle(.roundedBorder)
+                        .accessibilityLabel("Question for the planner")
+                        .accessibilityIdentifier("capsules.plannerQuestion")
+                    HStack {
+                        Button("Ask planner") { model.askPlannerForSelected() }
+                            .buttonStyle(.locus())
+                            .disabled(model.isBusy || model.isEditingRecipe || model.recipeError(capsule.recipe) != nil
+                                      || model.plannerQuestion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                            .accessibilityIdentifier("capsules.askPlanner")
+                        Spacer()
+                        Text("\(capsule.plannerHelpRequestsRemaining) of \(capsule.recipe.maxPlannerEscalations) requests left")
+                            .font(.caption).foregroundStyle(LocusTheme.textTertiary)
+                    }
+                } else {
+                    Text(capsule.recipe.maxPlannerEscalations == 0
+                         ? "Planner help is turned off for this capsule. Edit its usage limits to allow a request."
+                         : "You’ve used this capsule’s planner help allowance. Edit its usage limits to allow another request.")
+                        .font(.callout).foregroundStyle(LocusTheme.textSecondary)
+                    Button("Edit usage limits") {
+                        model.beginEditingRecipe()
+                        showLimits = true
+                    }
+                    .buttonStyle(.locus()).disabled(model.isBusy || model.isEditingRecipe)
+                }
+            }
+            .padding(.top, 10)
+        }
+        .font(.callout.weight(.medium))
+        .padding(14).locusCard(radius: 10)
     }
 
     private func stepCount(_ plan: PlanDocument) -> Int { plan.stepDetails.isEmpty ? plan.steps.count : plan.stepDetails.count }
 
+    private func stepSummary(_ plan: PlanDocument) -> String {
+        let count = stepCount(plan)
+        return "\(count) \(count == 1 ? "step" : "steps")"
+    }
+
     private func planSteps(_ plan: PlanDocument) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Saved plan").font(.headline)
-            if !plan.summary.isEmpty {
-                DisclosureGroup("Plan overview") {
-                    Text(plan.summary).font(.callout).textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading).padding(.top, 6)
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Text("Review your plan").font(.headline)
+                Spacer()
+                if !plan.stepDetails.isEmpty {
+                    Button(expandedSteps.count == plan.stepDetails.count ? "Collapse steps" : "Expand steps") {
+                        expandedSteps = expandedSteps.count == plan.stepDetails.count ? [] : Set(plan.stepDetails.map(\.id))
+                    }
+                    .buttonStyle(.locus()).font(.caption)
+                    .accessibilityIdentifier("capsules.expandSteps")
                 }
+            }
+            if !plan.summary.isEmpty {
+                Text(plan.summary).font(.callout).foregroundStyle(LocusTheme.textSecondary).textSelection(.enabled)
             }
             if plan.stepDetails.isEmpty {
                 ForEach(Array(plan.steps.enumerated()), id: \.offset) { index, step in
@@ -391,40 +578,179 @@ struct TaskCapsuleView: View {
                 }
             } else {
                 ForEach(Array(plan.stepDetails.enumerated()), id: \.element.id) { index, step in
-                    DisclosureGroup("\(index + 1). \(step.title)") {
-                        VStack(alignment: .leading, spacing: 7) {
+                    DisclosureGroup(isExpanded: Binding(
+                        get: { expandedSteps.contains(step.id) },
+                        set: { if $0 { expandedSteps.insert(step.id) } else { expandedSteps.remove(step.id) } }
+                    )) {
+                        VStack(alignment: .leading, spacing: 9) {
                             Text(step.instructions).textSelection(.enabled)
-                            if !step.files.isEmpty { Text("Files: " + step.files.joined(separator: ", ")) }
-                            if !step.dependencies.isEmpty { Text("After: " + step.dependencies.joined(separator: ", ")) }
-                            ForEach(Array(step.checks.enumerated()), id: \.offset) { _, check in
-                                Label(check, systemImage: "checkmark.circle")
+                            if !step.files.isEmpty {
+                                Text("Files: " + step.files.joined(separator: ", ")).textSelection(.enabled)
                             }
-                        }.font(.callout).foregroundStyle(LocusTheme.textSecondary).padding(.top, 6)
+                            if !step.dependencies.isEmpty {
+                                Text("After: " + step.dependencies.map { dependency in
+                                    plan.stepDetails.first(where: { $0.id == dependency })?.title ?? dependency
+                                }.joined(separator: ", "))
+                            }
+                            ForEach(Array(step.checks.enumerated()), id: \.offset) { _, check in
+                                Label(check, systemImage: "checkmark.circle").textSelection(.enabled)
+                            }
+                        }
+                        .font(.callout).foregroundStyle(LocusTheme.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading).padding(.top, 10)
+                    } label: {
+                        HStack(alignment: .top, spacing: 10) {
+                            Text("\(index + 1)").font(.caption.weight(.semibold))
+                                .frame(width: 24, height: 24)
+                                .background(LocusTheme.accentFill.opacity(0.13), in: RoundedRectangle(cornerRadius: 6))
+                            Text(step.title).font(.callout.weight(.medium)).padding(.top, 3)
+                        }
                     }
+                    .padding(12).locusCard(radius: 9)
+                    .accessibilityIdentifier("capsules.step.\(step.id)")
                 }
             }
-            if !plan.tests.isEmpty {
-                Text("Completion checks").font(.callout.weight(.semibold)).padding(.top, 4)
-                ForEach(Array(plan.tests.enumerated()), id: \.offset) { _, check in
-                    Label(check, systemImage: "checkmark.circle").font(.callout)
-                }
-            }
+            planNotes("Completion checks", notes: plan.tests, icon: "checkmark.circle")
+            planNotes("Keep in mind", notes: plan.constraints, icon: "pin")
+            planNotes("Design decisions", notes: plan.decisions, icon: "lightbulb")
         }
     }
 
-    private var footer: some View {
-        HStack(spacing: 10) {
-            if model.isRefreshing || model.isSaving || !model.activeStageSessions.isEmpty {
-                ProgressView().controlSize(.small)
+    @ViewBuilder
+    private func planNotes(_ title: String, notes: [String], icon: String) -> some View {
+        if !notes.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title).font(.callout.weight(.semibold))
+                ForEach(Array(notes.enumerated()), id: \.offset) { _, note in
+                    Label(note, systemImage: icon).font(.callout)
+                        .foregroundStyle(LocusTheme.textSecondary).textSelection(.enabled)
+                }
             }
-            Text(model.error ?? model.status ?? "Capsules are saved in this workspace. No model calls are made until you start a stage.")
+            .padding(.top, 4)
+        }
+    }
+
+    private func runHistory(_ capsule: TaskCapsule) -> some View {
+        DisclosureGroup("Run history (\(capsule.runs.count))") {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(capsule.runs.reversed()) { run in
+                    HStack(alignment: .top, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(run.stageTitle).font(.callout.weight(.medium))
+                            Text(runStatus(run)).font(.caption).foregroundStyle(LocusTheme.textSecondary)
+                            if run.modelCalls != nil || run.totalTokens != nil {
+                                Text([run.modelCalls.map { "\($0) calls" }, run.totalTokens.map { "\($0.formatted()) tokens" }]
+                                    .compactMap { $0 }.joined(separator: " · "))
+                                .font(.caption).foregroundStyle(LocusTheme.textTertiary)
+                            }
+                        }
+                        Spacer()
+                        if let sessionID = run.sessionID, !sessionID.isEmpty {
+                            Button("Open conversation") { model.openConversation(sessionID: sessionID) }
+                                .buttonStyle(.locus()).font(.caption)
+                                .accessibilityIdentifier("capsules.runConversation.\(run.id)")
+                        }
+                    }
+                }
+            }
+            .padding(.top, 12)
+        }
+        .font(.callout.weight(.medium))
+    }
+
+    private var actionBar: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if model.isEditingRecipe {
+                HStack(spacing: 14) {
+                    Button { Task { await model.saveRecipeChanges() } } label: {
+                        Text("Save choices")
+                            .padding(.horizontal, 10).padding(.vertical, 7)
+                            .foregroundStyle(Color(nsColor: accent.brandInkNSColor()))
+                            .background(LocusTheme.accentFill, in: RoundedRectangle(cornerRadius: 8))
+                    }
+                        .buttonStyle(.locus(.primary))
+                        .disabled(model.isBusy || model.recipeError(model.draftRecipe) != nil)
+                        .accessibilityIdentifier("capsules.saveRecipe")
+                    Button("Cancel") { model.cancelRecipeEditing() }
+                        .buttonStyle(.locus()).disabled(model.isSaving)
+                }
+                Text("Save or cancel your changes before starting a stage.")
+                    .font(.caption).foregroundStyle(LocusTheme.textSecondary)
+            } else if let capsule = model.selectedCapsule {
+                HStack(spacing: 14) {
+                    Button { model.runSelected() } label: {
+                        Label(capsule.runs.contains(where: { $0.stage == "execute" }) ? "Run again" : "Run plan", systemImage: "play.fill")
+                            .padding(.horizontal, 10).padding(.vertical, 7)
+                            .foregroundStyle(Color(nsColor: accent.brandInkNSColor()))
+                            .background(LocusTheme.accentFill, in: RoundedRectangle(cornerRadius: 8))
+                    }
+                    .buttonStyle(.locus(.primary))
+                    .disabled(model.isBusy || model.recipeError(capsule.recipe) != nil)
+                    .accessibilityIdentifier("capsules.run")
+                    if capsule.recipe.reviewerProfileID != nil {
+                        Button("Review result") { model.reviewSelected() }
+                            .buttonStyle(.locus())
+                            .disabled(model.isBusy || model.recipeError(capsule.recipe) != nil)
+                            .help("Ask the review model to inspect the result without changing files")
+                            .accessibilityIdentifier("capsules.review")
+                    }
+                    Spacer(minLength: 0)
+                }
+                Text(model.isBusy ? "A task is in progress. Follow its conversation to see updates."
+                     : capsule.runs.contains(where: { $0.stage == "execute" })
+                     ? "Review previous changes before running again. A changed file may need a revised plan."
+                     : "Starts in your conversation and may change files in \(workspaceName).")
+                    .font(.caption).foregroundStyle(LocusTheme.textSecondary)
+            } else if model.profiles.isEmpty {
+                Button { model.manageProfiles() } label: {
+                    Label("Set up models", systemImage: "person.crop.circle.badge.plus")
+                        .padding(.horizontal, 10).padding(.vertical, 7)
+                        .foregroundStyle(Color(nsColor: accent.brandInkNSColor()))
+                        .background(LocusTheme.accentFill, in: RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.locus(.primary))
+                .accessibilityIdentifier("capsules.setupModels")
+                Text("One agent profile can plan and run your task. Your description is kept while you set it up.")
+                    .font(.caption).foregroundStyle(LocusTheme.textSecondary)
+            } else {
+                HStack(spacing: 12) {
+                    Button { model.generatePlan() } label: {
+                        Label("Generate plan", systemImage: "sparkles")
+                            .padding(.horizontal, 10).padding(.vertical, 7)
+                            .foregroundStyle(Color(nsColor: accent.brandInkNSColor()))
+                            .background(LocusTheme.accentFill, in: RoundedRectangle(cornerRadius: 8))
+                    }
+                    .buttonStyle(.locus(.primary)).disabled(!model.canGenerate)
+                    .accessibilityIdentifier("capsules.generate")
+                    Text("Next: review the saved plan")
+                        .font(.caption).foregroundStyle(LocusTheme.textSecondary)
+                }
+                Text(model.planningUnavailableReason ?? "Planning opens in your conversation. You decide when implementation starts.")
+                    .font(.caption).foregroundStyle(LocusTheme.textSecondary)
+                    .accessibilityIdentifier("capsules.nextStep")
+            }
+        }
+        .padding(.horizontal, 24).padding(.vertical, 16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(LocusTheme.surfaceStructural.opacity(0.45))
+    }
+
+    private var statusBar: some View {
+        HStack(alignment: .top, spacing: 10) {
+            if model.isRefreshing || model.isSaving {
+                ProgressView().controlSize(.small)
+            } else if model.error != nil {
+                Image(systemName: "exclamationmark.circle").foregroundStyle(LocusTheme.dangerForeground)
+            } else {
+                Image(systemName: "info.circle").foregroundStyle(LocusTheme.textSecondary)
+            }
+            Text(model.error ?? model.status ?? (model.isSaving ? "Saving capsule…" : "Refreshing capsules…"))
                 .font(.caption)
                 .foregroundStyle(model.error == nil ? LocusTheme.textSecondary : LocusTheme.dangerForeground)
-                .lineLimit(3)
                 .textSelection(.enabled)
+                .accessibilityIdentifier("capsules.status")
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 20).padding(.vertical, 12)
-        .frame(minHeight: 44)
     }
 }

--- a/LocusTests/BrowserHostTests.swift
+++ b/LocusTests/BrowserHostTests.swift
@@ -93,10 +93,111 @@ final class BrowserHostTests: XCTestCase {
         XCTAssertEqual(canvas.subviews.count, 1, "No outer magnifying scroll view should wrap the page")
 
         canvas.frame.size = CGSize(width: 760, height: 480)
-        canvas.needsLayout = true
+        XCTAssertTrue(canvas.needsLayout, "An actual frame resize must schedule page layout")
         canvas.layoutSubtreeIfNeeded()
         XCTAssertEqual(host.viewport, CGSize(width: 760, height: 480))
         XCTAssertEqual(host.webView.frame.size, CGSize(width: 760, height: 480))
+    }
+
+    func testBrowserCanvasTracksBoundsOnlyResize() {
+        let (host, _) = makeHost()
+        let canvas = BrowserCanvasContainer(
+            frame: NSRect(x: 0, y: 0, width: 760, height: 480)
+        )
+        canvas.display(host)
+        canvas.layoutSubtreeIfNeeded()
+
+        let resized = CGSize(width: 520, height: 360)
+        canvas.setBoundsSize(resized)
+        XCTAssertTrue(canvas.needsLayout)
+        canvas.layoutSubtreeIfNeeded()
+        XCTAssertEqual(host.viewport, resized)
+        XCTAssertEqual(host.webView.frame.size, resized)
+
+        canvas.setBoundsSize(resized)
+        XCTAssertFalse(canvas.needsLayout, "Unchanged bounds should not schedule another layout")
+    }
+
+    func testUnchangedViewportDoesNotWriteWebViewFrameAgain() {
+        let webView = FrameTrackingWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let host = OffscreenWebHost(webView: webView)
+        host.setViewport(CGSize(width: 1, height: 1))
+        webView.frameWriteCount = 0
+
+        for _ in 0..<20 {
+            host.setViewport(CGSize(width: 80, height: 80))
+        }
+
+        XCTAssertEqual(host.viewport, CGSize(width: 120, height: 120))
+        XCTAssertEqual(webView.frameWriteCount, 0, "Repeated clamped sizes should not enter WebKit resizing")
+    }
+
+    func testRepeatedCanvasUpdatesDoNotRelayoutOrOverrideViewportPreset() {
+        let webView = FrameTrackingWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let host = OffscreenWebHost(webView: webView)
+        let canvas = BrowserCanvasContainer(
+            frame: NSRect(x: 0, y: 0, width: 520, height: 360)
+        )
+        canvas.display(host)
+        canvas.layoutSubtreeIfNeeded()
+        host.setViewport(BrowserViewport.mobile.size)
+        canvas.layoutSubtreeIfNeeded()
+        webView.frameWriteCount = 0
+
+        for _ in 0..<20 { canvas.display(host) }
+
+        XCTAssertFalse(canvas.needsLayout, "SwiftUI state updates should not schedule page layout")
+        canvas.needsLayout = true
+        canvas.layoutSubtreeIfNeeded()
+        XCTAssertEqual(host.viewport, BrowserViewport.mobile.size)
+        XCTAssertEqual(webView.frame.size, BrowserViewport.mobile.size)
+        XCTAssertEqual(webView.frameWriteCount, 0)
+
+        canvas.frame.size = CGSize(width: 760, height: 480)
+        canvas.layoutSubtreeIfNeeded()
+        XCTAssertEqual(host.viewport, canvas.bounds.size, "An actual inspector resize should still fit the page")
+    }
+
+    func testBorrowedViewportDefersParkedWindowResizeUntilParking() throws {
+        let (host, _) = makeHost()
+        let parkedWindow = try XCTUnwrap(host.webView.window)
+        let parkedFrame = parkedWindow.frame
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 520, height: 360))
+        host.lend(to: container)
+
+        let resized = CGSize(width: 900, height: 650)
+        host.setViewport(resized)
+        XCTAssertEqual(host.viewport, resized)
+        XCTAssertEqual(host.webView.frame.size, resized)
+        XCTAssertEqual(parkedWindow.frame, parkedFrame, "The unused window should not resize alongside the inspector")
+
+        host.park()
+        XCTAssertTrue(host.isParked)
+        XCTAssertEqual(parkedWindow.contentView?.bounds.size, resized)
+        XCTAssertEqual(host.webView.frame.size, resized)
+    }
+
+    func testPreviousCanvasCannotResizeOrParkANewBorrowersPage() {
+        let (host, _) = makeHost()
+        let previousCanvas = BrowserCanvasContainer(
+            frame: NSRect(x: 0, y: 0, width: 520, height: 360)
+        )
+        previousCanvas.display(host)
+        previousCanvas.layoutSubtreeIfNeeded()
+        let currentCanvas = BrowserCanvasContainer(
+            frame: NSRect(x: 0, y: 0, width: 900, height: 650)
+        )
+        currentCanvas.display(host)
+        currentCanvas.layoutSubtreeIfNeeded()
+
+        previousCanvas.frame.size = CGSize(width: 600, height: 400)
+        previousCanvas.layoutSubtreeIfNeeded()
+        previousCanvas.parkIfStillOwner()
+
+        XCTAssertTrue(host.webView.superview === currentCanvas)
+        XCTAssertEqual(host.viewport, currentCanvas.bounds.size)
+        XCTAssertEqual(host.webView.frame.size, currentCanvas.bounds.size)
+        XCTAssertNil(previousCanvas.host)
     }
 
     func testWidePageExposesHorizontalOverflowInResponsiveCanvas() async throws {
@@ -176,5 +277,18 @@ final class BrowserHostTests: XCTestCase {
 
         host.setKeptLive(true)
         XCTAssertTrue(host.isKeptLive)
+    }
+}
+
+@MainActor
+private final class FrameTrackingWebView: WKWebView {
+    var frameWriteCount = 0
+
+    override var frame: NSRect {
+        get { super.frame }
+        set {
+            frameWriteCount += 1
+            super.frame = newValue
+        }
     }
 }

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -1185,6 +1185,120 @@ final class FeatureLogicTests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testArtifactListingReusesFileResolutionAcrossResizeRenders() throws {
+        let workspace = FileManager.default.temporaryDirectory
+            .appendingPathComponent("locus-artifact-resize-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workspace) }
+        let names = (0..<10).map { "file-\($0).md" }
+        for name in names {
+            try Data("notes".utf8).write(to: workspace.appendingPathComponent(name))
+        }
+
+        let cache = WorkspaceArtifactRenderCache()
+        cache.setLiveResizing(true)
+        let resolve: (String?) -> WorkspaceArtifactReference? = {
+            cache.classify($0, workspacePath: workspace.path)
+        }
+        // Each resize render promotes the bullet and builds its selectable
+        // inline text. Neither path should repeat filesystem work per frame.
+        for _ in 0..<10 {
+            for name in names {
+                let runs: [MarkdownInlineRun] = [
+                    .init(text: name, style: .code),
+                    .init(text: " — workspace notes"),
+                ]
+                let chip = try XCTUnwrap(MarkdownArtifactPromotion.leadingArtifact(
+                    in: runs, workspacePath: workspace.path, resolveArtifact: resolve
+                ))
+                let text = MarkdownNativeText.attributed(
+                    runs, size: 13, weight: .regular, color: .primary,
+                    lineSpacing: 5, inlineCodeSize: 12,
+                    workspacePath: workspace.path, resolveArtifact: resolve
+                )
+                XCTAssertEqual(text.string, "\(name) — workspace notes")
+                XCTAssertEqual(text.attribute(.link, at: 0, effectiveRange: nil) as? URL, chip.navigationURL)
+                XCTAssertEqual(MarkdownLinkPolicy.renderedURL(
+                    for: runs[0], workspacePath: workspace.path, resolveArtifact: resolve
+                ), chip.navigationURL)
+            }
+        }
+        XCTAssertEqual(cache.resolutionCountForTesting, names.count)
+    }
+
+    @MainActor
+    func testArtifactResizeCacheRefreshesChangedMissingAndRemovedFilesAfterGesture() throws {
+        let workspace = FileManager.default.temporaryDirectory
+            .appendingPathComponent("locus-artifact-refresh-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workspace) }
+        let notes = workspace.appendingPathComponent("notes.md")
+        let created = workspace.appendingPathComponent("created.md")
+        try Data("a".utf8).write(to: notes)
+
+        let cache = WorkspaceArtifactRenderCache()
+        cache.setLiveResizing(true)
+        XCTAssertEqual(cache.classify("notes.md", workspacePath: workspace.path)?.byteCount, 1)
+        XCTAssertNil(cache.classify("created.md", workspacePath: workspace.path))
+        try Data("updated notes".utf8).write(to: notes)
+        try Data("new".utf8).write(to: created)
+        XCTAssertEqual(cache.classify("notes.md", workspacePath: workspace.path)?.byteCount, 1)
+        XCTAssertNil(cache.classify("created.md", workspacePath: workspace.path))
+        XCTAssertEqual(cache.resolutionCountForTesting, 2)
+
+        cache.setLiveResizing(false)
+        XCTAssertEqual(cache.classify("notes.md", workspacePath: workspace.path)?.byteCount, 13)
+        XCTAssertEqual(cache.classify("created.md", workspacePath: workspace.path)?.byteCount, 3)
+        // Outside a gesture there is no persistent filesystem cache.
+        try FileManager.default.removeItem(at: notes)
+        XCTAssertNil(cache.classify("notes.md", workspacePath: workspace.path))
+        try FileManager.default.createDirectory(at: notes, withIntermediateDirectories: false)
+        XCTAssertNil(cache.classify("notes.md", workspacePath: workspace.path))
+        cache.setLiveResizing(true)
+        XCTAssertNil(cache.classify("notes.md", workspacePath: workspace.path))
+    }
+
+    @MainActor
+    func testArtifactResizeCacheDoesNotAuthorizeNavigationOrCrossWorkspaces() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("locus-artifact-boundary-\(UUID().uuidString)", isDirectory: true)
+        let workspace = base.appendingPathComponent("workspace", isDirectory: true)
+        let other = base.appendingPathComponent("other", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: other, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        let sources = workspace.appendingPathComponent("Sources", isDirectory: true)
+        let otherSources = other.appendingPathComponent("Sources", isDirectory: true)
+        try FileManager.default.createDirectory(at: sources, withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: otherSources, withIntermediateDirectories: false)
+        let notes = sources.appendingPathComponent("notes.md")
+        let outside = otherSources.appendingPathComponent("notes.md")
+        try Data("a".utf8).write(to: notes)
+        try Data("other".utf8).write(to: outside)
+
+        let cache = WorkspaceArtifactRenderCache()
+        cache.setLiveResizing(true)
+        let candidate = "Sources/notes.md:12:4"
+        let original = try XCTUnwrap(cache.classify(candidate, workspacePath: workspace.path))
+        XCTAssertEqual(original.sourceLocation, .init(line: 12, column: 4))
+        XCTAssertEqual(WorkspaceArtifactReference.fromNavigationURL(
+            original.navigationURL, workspacePath: workspace.path
+        ), original)
+        XCTAssertEqual(cache.classify(candidate, workspacePath: other.path)?.byteCount, 5)
+        try FileManager.default.removeItem(at: notes)
+        try FileManager.default.createSymbolicLink(at: notes, withDestinationURL: outside)
+        XCTAssertNotNil(cache.classify(candidate, workspacePath: workspace.path))
+        XCTAssertNil(WorkspaceArtifactReference.classify(
+            original.url.path, workspacePath: workspace.path
+        ), "Opening a cached chip must revalidate its absolute path")
+        XCTAssertNil(WorkspaceArtifactReference.fromNavigationURL(
+            original.navigationURL, workspacePath: workspace.path
+        ), "Cached presentation must never authorize a changed symlink target")
+        cache.setLiveResizing(false)
+        XCTAssertNil(cache.classify(candidate, workspacePath: workspace.path))
+    }
+
     func testFileReferencesGetFullCardAtTopLevelAndChipInLists() {
         // A reply that lists a directory writes one bullet per file. Promoting
         // each of those to a 58pt card with three buttons turned a seven-file

--- a/LocusTests/TaskCapsuleModelTests.swift
+++ b/LocusTests/TaskCapsuleModelTests.swift
@@ -1,3 +1,6 @@
+import AppKit
+import ApplicationServices
+import SwiftUI
 import XCTest
 
 @testable import Locus
@@ -9,6 +12,7 @@ final class TaskCapsuleModelTests: XCTestCase {
     private var executor = AgentProfile(name: "Kimi implementer", model: "worker", accessCeiling: .workspaceWrite)
     private var planningRequests: [TaskCapsulePlanningRequest] = []
     private var executionRequests: [TaskCapsule] = []
+    private var openedConversations: [String] = []
 
     override func setUp() async throws {
         try await super.setUp()
@@ -16,6 +20,7 @@ final class TaskCapsuleModelTests: XCTestCase {
         workspace = "/tmp/capsule-tests"
         planningRequests = []
         executionRequests = []
+        openedConversations = []
     }
 
     private var recipe: TaskCapsuleRecipe {
@@ -44,15 +49,16 @@ final class TaskCapsuleModelTests: XCTestCase {
                     createdAt: "2026-09-06T15:00:00Z", updatedAt: "2026-09-06T15:00:00Z")
     }
 
-    private func makeModel() -> TaskCapsuleModel {
+    private func makeModel(profiles: [AgentProfile]? = nil) -> TaskCapsuleModel {
         let model = TaskCapsuleModel()
         model.configure(
             backend: stubbedBackendService(), workspacePathProvider: { self.workspace },
-            profilesProvider: { [self.planner, self.executor] },
+            profilesProvider: { profiles ?? [self.planner, self.executor] },
             activePlanProvider: { nil }, isBusyProvider: { false },
             startPlanning: { self.planningRequests.append($0) },
             startExecution: { self.executionRequests.append($0) },
-            startReview: { _ in }, askPlanner: { _, _ in }
+            startReview: { _ in }, askPlanner: { _, _ in },
+            openConversation: { self.openedConversations.append($0) }
         )
         return model
     }
@@ -68,6 +74,133 @@ final class TaskCapsuleModelTests: XCTestCase {
         XCTAssertNoBackendTraffic()
     }
 
+    func testTaskCapsuleRendersDraftSavedPlanAndSetupAtCompactSizes() async throws {
+        // SwiftUI exposes its virtual nodes after a public accessibility
+        // client reads this test process; native getters alone leave it dormant.
+        let accessibilityReady = expectation(description: "Capsule accessibility tree is ready")
+        DispatchQueue.global(qos: .userInitiated).async {
+            let application = AXUIElementCreateApplication(getpid())
+            XCTAssertEqual(AXUIElementSetMessagingTimeout(application, 0.2), .success)
+            var windows: CFTypeRef?
+            XCTAssertEqual(AXUIElementCopyAttributeValue(application, kAXWindowsAttribute as CFString, &windows), .success)
+            accessibilityReady.fulfill()
+        }
+        await fulfillment(of: [accessibilityReady], timeout: 1)
+        var saved = capsule
+        saved.plan.constraints = ["Keep the character’s face and pose unchanged."]
+        saved.plan.decisions = ["Use a localized edit so the approved background stays intact."]
+        let record = try JSONSerialization.jsonObject(with: JSONEncoder().encode(saved))
+        BackendStub.respond(toPath: "/api/capsules") { _ in ["capsules": [record]] }
+        BackendStub.respond(toPath: "/api/capsules/\(saved.id)") { _ in ["capsule": record] }
+        let model = makeModel()
+        await model.refresh()
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("locus-capsule-renders-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+        for size in [NSSize(width: 940, height: 760), NSSize(width: 680, height: 620)] {
+            let suffix = "\(Int(size.width))x\(Int(size.height))"
+            model.newCapsule()
+            try await renderCapsule(model, size: size, name: "Draft-\(suffix)",
+                                    primaryAction: "capsules.generate", output: output)
+            model.selectedID = saved.id
+            try await renderCapsule(model, size: size, name: "Saved-plan-\(suffix)",
+                                    primaryAction: "capsules.run", output: output)
+            XCTAssertEqual(model.selectedCapsule?.plan.stepDetails.first?.checks, ["Face stays unchanged"])
+            XCTAssertEqual(model.selectedCapsule?.plan.constraints, saved.plan.constraints)
+            try await renderCapsule(model, size: size, name: "Edit-choices-\(suffix)",
+                                    primaryAction: "capsules.saveRecipe", output: output,
+                                    transition: { model.beginEditingRecipe() })
+            model.cancelRecipeEditing()
+        }
+
+        let setup = makeModel(profiles: [])
+        await setup.refresh()
+        try await renderCapsule(setup, size: NSSize(width: 680, height: 620), name: "Setup-680x620",
+                                primaryAction: "capsules.setupModels", output: output)
+        XCTAssertFalse(setup.canGenerate)
+        XCTAssertNotNil(setup.planningUnavailableReason)
+        XCTAssertTrue(planningRequests.isEmpty, "Rendering setup must not start model work")
+        XCTAssertTrue(executionRequests.isEmpty, "Reviewing a saved plan must not execute it")
+        XCTAssertTrue(BackendStub.requests.allSatisfy { $0.httpMethod == "GET" })
+        let artifactLocation = XCTAttachment(string: output.path)
+        artifactLocation.name = "Capsule render artifact directory"
+        artifactLocation.lifetime = .keepAlways
+        add(artifactLocation)
+        print("Capsule render artifacts: \(output.path)")
+    }
+
+    private func renderCapsule(
+        _ model: TaskCapsuleModel, size: NSSize, name: String, primaryAction: String,
+        output: URL, transition: (() -> Void)? = nil
+    ) async throws {
+        let host = NSHostingView(rootView: TaskCapsuleView(model: model).preferredColorScheme(.dark))
+        host.sizingOptions = []
+        host.frame = NSRect(origin: .zero, size: size)
+        let window = NSWindow(contentRect: host.frame, styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.contentView = host
+        window.orderFront(nil)
+        defer { window.orderOut(nil) }
+
+        for _ in 0..<8 {
+            host.layoutSubtreeIfNeeded()
+            try await Task.sleep(for: .milliseconds(30))
+        }
+        if let transition {
+            transition()
+            for _ in 0..<8 {
+                host.layoutSubtreeIfNeeded()
+                try await Task.sleep(for: .milliseconds(30))
+            }
+        }
+        host.layoutSubtreeIfNeeded()
+        host.display()
+        let bitmap = try XCTUnwrap(host.bitmapImageRepForCachingDisplay(in: host.bounds))
+        host.cacheDisplay(in: host.bounds, to: bitmap)
+        let png = try XCTUnwrap(bitmap.representation(using: .png, properties: [:]))
+        try png.write(to: output.appendingPathComponent("\(name).png"))
+        let snapshot = XCTAttachment(data: png, uniformTypeIdentifier: "public.png")
+        snapshot.name = name
+        snapshot.lifetime = .keepAlways
+        add(snapshot)
+
+        XCTAssertEqual(host.bounds.size, size, "\(name) must fit the requested window")
+        XCTAssertEqual(window.contentView?.frame.size, size)
+        XCTAssertEqual(CGFloat(bitmap.pixelsWide), size.width * window.backingScaleFactor, accuracy: 1)
+        XCTAssertEqual(CGFloat(bitmap.pixelsHigh), size.height * window.backingScaleFactor, accuracy: 1)
+        XCTAssertGreaterThan(png.count, 2_000, "\(name) must render visible content")
+
+        var pending: [Any] = [host]
+        var visited = Set<ObjectIdentifier>()
+        var identifiers = Set<String>()
+        var primaryFrame: NSRect?
+        var accessibility: [String] = []
+        while let value = pending.popLast(), visited.count < 800 {
+            guard let node = TranscriptAccessibilityNode(value),
+                  visited.insert(ObjectIdentifier(node.object)).inserted else { continue }
+            if let identifier = node.identifier, !identifier.isEmpty {
+                identifiers.insert(identifier)
+                accessibility.append("\(node.role?.rawValue ?? "unknown") \(identifier) \(NSStringFromRect(node.frame))")
+                if identifier == primaryAction { primaryFrame = node.frame }
+            }
+            pending.append(contentsOf: node.children)
+            if let view = node.object as? NSView { pending.append(contentsOf: view.subviews) }
+        }
+        let metadata = XCTAttachment(string: accessibility.joined(separator: "\n"))
+        metadata.name = "\(name) accessibility"
+        metadata.lifetime = .keepAlways
+        add(metadata)
+        XCTAssertLessThan(visited.count, 800, "Accessibility traversal must finish within its bound")
+        XCTAssertTrue(identifiers.contains(primaryAction), "\(name) must expose the primary action’s own identifier")
+        if let primaryFrame {
+            XCTAssertFalse(primaryFrame.isEmpty)
+            XCTAssertTrue(window.convertToScreen(host.bounds).contains(primaryFrame),
+                          "\(name) must keep its primary action visible inside the window")
+        }
+    }
+
     func testReadOnlyProfileCannotBecomeImplementationDefault() async throws {
         try registerBackend()
         let model = makeModel()
@@ -79,6 +212,37 @@ final class TaskCapsuleModelTests: XCTestCase {
         XCTAssertNotNil(model.recipeError(invalid))
         XCTAssertNil(model.recipeError(recipe))
         XCTAssertNil(recipe.maximumEstimatedCost, "Subscription use must not default to a dollar budget")
+    }
+
+    func testPlanningAvailabilityExplainsTheNextRequiredStep() async throws {
+        try registerBackend()
+        let model = makeModel()
+        XCTAssertFalse(model.canGenerate)
+        XCTAssertTrue(model.planningUnavailableReason?.contains("workspace") == true)
+        await model.refresh()
+        XCTAssertFalse(model.canGenerate)
+        XCTAssertTrue(model.planningUnavailableReason?.contains("Describe your task") == true)
+        model.draftRequest = "Make the requested edits"
+        XCTAssertTrue(model.canGenerate)
+        XCTAssertNil(model.planningUnavailableReason)
+        model.draftRecipe.executorProfileID = planner.id.uuidString
+        XCTAssertFalse(model.canGenerate)
+        XCTAssertEqual(model.planningUnavailableReason, model.recipeError(model.draftRecipe))
+        XCTAssertTrue(planningRequests.isEmpty, "Explaining setup must not start model work")
+    }
+
+    func testContinuePlanningOpensConversationAndPreservesItsPendingRequest() async {
+        let model = makeModel()
+        model.planningStarted(request, sessionID: "planning-session")
+        await model.planningFinished(sessionID: "planning-session", succeeded: true)
+        model.isPresented = true
+        model.openConversation(sessionID: "planning-session")
+        XCTAssertEqual(openedConversations, ["planning-session"])
+        XCTAssertFalse(model.isPresented)
+        XCTAssertNotNil(model.pendingPlanningRequest(for: "planning-session"))
+        XCTAssertTrue(planningRequests.isEmpty)
+        XCTAssertTrue(executionRequests.isEmpty)
+        XCTAssertNoBackendTraffic()
     }
 
     func testInterruptedPlanningNeverSavesSubmittedPlan() async throws {

--- a/LocusTests/TaskCapsuleRoutingTests.swift
+++ b/LocusTests/TaskCapsuleRoutingTests.swift
@@ -146,7 +146,11 @@ final class TaskCapsuleRoutingTests: XCTestCase {
     }
 
     func testEveryGenericCapsuleRecoveryOpensTheSavedPlanWithoutChangingWorkspace() async throws {
-        BackendStub.respond(toPath: "/api/capsules") { _ in ["capsules": []] }
+        let recoveryRefreshes = expectation(description: "Every recovery action refreshes its saved capsules")
+        BackendStub.respond(toPath: "/api/capsules") { _ in
+            recoveryRefreshes.fulfill()
+            return ["capsules": []]
+        }
         let model = AppModel(startImmediately: false, backendOverride: makeService(port: 9))
         let workspace = model.workspacePath
         let capsuleID = UUID().uuidString.lowercased()
@@ -165,6 +169,7 @@ final class TaskCapsuleRoutingTests: XCTestCase {
             ("replay", { model.replayOrchestration(run) }),
             ("duplicate", { model.duplicateOrchestration(run) }),
         ]
+        recoveryRefreshes.expectedFulfillmentCount = actions.count
 
         for (label, action) in actions {
             model.taskCapsules.isPresented = false
@@ -175,7 +180,10 @@ final class TaskCapsuleRoutingTests: XCTestCase {
             XCTAssertEqual(model.workspacePath, workspace, label)
             XCTAssertEqual(model.taskCapsules.workspaceRoot, TaskCapsuleModel.canonicalWorkspace(workspace), label)
         }
-        await model.taskCapsules.refresh()
+        // open() schedules its own refresh. Starting an additional refresh
+        // does not join those requests, which could reach the shared stub
+        // after the next test has reset it and contaminate routing assertions.
+        await fulfillment(of: [recoveryRefreshes], timeout: 5)
         XCTAssertEqual(model.taskCapsules.status,
                        "Review the partial work and ask the planner for an updated plan before running again.")
         XCTAssertTrue(BackendStub.requests.allSatisfy {

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -483,6 +483,17 @@ final class LocusUITests: XCTestCase {
                element.frame.maxY <= self.app.windows.firstMatch.frame.minY {
                 return true
             }
+            // SwiftUI keeps scrolled-out text in the accessibility tree.
+            // XCTest 16 can sample the desktop or Dock at that off-window
+            // frame, producing a contrast failure for pixels the app did not
+            // draw. Visible and partially visible elements still get audited.
+            if issue.auditType == .contrast,
+               let element = issue.element,
+               !element.frame.isEmpty,
+               !element.frame.intersects(self.app.windows.firstMatch.frame) {
+                print("Contrast deferred for off-window element: \(element.value ?? element.label)")
+                return true
+            }
             // XCTest 26 reports SwiftUI Menu and Picker wrappers as missing an
             // action even though the owning native popup is labeled, keyboard
             // operable, and exercised by functional tests in this suite.
@@ -3253,13 +3264,17 @@ final class LocusUITests: XCTestCase {
         add(tree)
         XCTAssertTrue(expanded)
 
-        let source = revealAgentOverviewItem("agentOverview.source")
+        let source = revealAgentOverviewItem("agentOverview.source", fullyVisible: true)
         XCTAssertTrue((source.label + " \(source.value ?? "")").contains("Weekdays at 09:00"))
         let screenshot = XCTAttachment(screenshot: app.screenshot())
         screenshot.name = "Expanded agent configuration"
         screenshot.lifetime = .keepAlways
         add(screenshot)
         try auditCurrentSurface()
+        // Include the heading as well as the instruction in the visible
+        // audit; a merely hittable paragraph can leave its heading clipped.
+        let behavior = revealAgentOverviewItem("agentOverview.behavior", fullyVisible: true)
+        XCTAssertTrue(app.windows.firstMatch.frame.contains(behavior.frame))
         XCTAssertTrue(revealAgentOverviewItem("agentOverview.instruction").exists)
         try auditCurrentSurface()
     }
@@ -3790,17 +3805,21 @@ final class LocusUITests: XCTestCase {
     }
 
     @discardableResult
-    private func revealAgentOverviewItem(_ identifier: String) -> XCUIElement {
+    private func revealAgentOverviewItem(_ identifier: String, fullyVisible: Bool = false) -> XCUIElement {
         let item = anyElement(identifier)
         let panel = anyElement("agentOverview")
         XCTAssertTrue(panel.waitForExistence(timeout: Self.launchContentTimeout))
-        if item.exists && item.isHittable { return item }
+        func isRevealed() -> Bool {
+            guard item.exists, item.isHittable else { return false }
+            return !fullyVisible || panel.frame.intersection(app.windows.firstMatch.frame).contains(item.frame)
+        }
+        if isRevealed() { return item }
         panel.scroll(byDeltaX: 0, deltaY: 2500)
         for _ in 0..<15 {
-            if item.exists && item.isHittable { return item }
+            if isRevealed() { return item }
             panel.scroll(byDeltaX: 0, deltaY: -200)
         }
-        XCTAssertTrue(item.exists, "Could not reach \(identifier)")
+        XCTAssertTrue(fullyVisible ? isRevealed() : item.exists, "Could not reach \(identifier)")
         return item
     }
 

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -2671,6 +2671,35 @@ final class LocusUITests: XCTestCase {
         waitForExpectations(timeout: 3)
     }
 
+    func testBusyTranscriptKeepsBrowserAndDraftAcrossRepeatedExpansion() {
+        app.terminate()
+        app.launchEnvironment["LOCUS_UI_TESTING_PERFORMANCE_TRANSCRIPT"] = "1"
+        app.launchEnvironment["LOCUS_UI_TESTING_WINDOW_WIDTH"] = "1250"
+        app.launchEnvironment["LOCUS_UI_TESTING_WINDOW_HEIGHT"] = "760"
+        app.launch()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        XCTAssertTrue(anyElement("conversation.scroll").waitForExistence(timeout: 10))
+        app.typeKey("5", modifierFlags: .command)
+        let address = anyElement("browser.url")
+        XCTAssertTrue(address.waitForExistence(timeout: 5))
+        address.click()
+        address.typeText("https://example.com/unsent-draft")
+
+        for _ in 0..<3 {
+            anyElement("browser.expand").click()
+            XCTAssertEqual(anyElement("inspector.resizeHandle").label, "Expanded panel width")
+            XCTAssertEqual(address.value as? String, "https://example.com/unsent-draft")
+            app.typeKey("e", modifierFlags: [.command, .option])
+            XCTAssertEqual(anyElement("inspector.resizeHandle").label, "Inspector width")
+            XCTAssertEqual(address.value as? String, "https://example.com/unsent-draft")
+            XCTAssertTrue(anyElement("conversation.scroll").exists)
+        }
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = "Busy transcript after repeated browser expansion"
+        shot.lifetime = .keepAlways
+        add(shot)
+    }
+
     func testInspectorTabsSwitchWithCommandNumberShortcuts() {
         // ⌘2 — Changes, populated from the seeded git status.
         app.typeKey("2", modifierFlags: .command)

--- a/LocusUITests/TaskCapsuleUITests.swift
+++ b/LocusUITests/TaskCapsuleUITests.swift
@@ -39,6 +39,22 @@ final class TaskCapsuleUITests: XCTestCase {
         XCTAssertTrue((element("capsules.request").value as? String ?? "").contains("selected worker"))
     }
 
+    func testExampleStartsAnEditableDraftWithoutRunningAPlan() {
+        openCapsules()
+        let generate = element("capsules.generate")
+        XCTAssertTrue(generate.waitForExistence(timeout: 5))
+        XCTAssertFalse(generate.isEnabled)
+        let nextStep = element("capsules.nextStep")
+        XCTAssertTrue(nextStep.exists)
+        element("capsules.example.Fix a bug").click()
+        XCTAssertTrue((element("capsules.request").value as? String ?? "").contains("[describe the issue]"))
+        XCTAssertTrue(generate.isEnabled)
+        XCTAssertTrue(doneButton.exists, "Choosing an example must leave the draft open for editing")
+        doneButton.click()
+        openCapsules()
+        XCTAssertTrue((element("capsules.request").value as? String ?? "").contains("[describe the issue]"))
+    }
+
     private func openCapsules() {
         app.typeKey("k", modifierFlags: [.command, .option])
         XCTAssertTrue(doneButton.waitForExistence(timeout: 5))

--- a/agent/ollama_code/api/capsules.py
+++ b/agent/ollama_code/api/capsules.py
@@ -20,7 +20,7 @@ def capsule_store(service: ChatService, workspace_root: str = "") -> CapsuleStor
 
 
 def _present(service: ChatService, capsule: dict[str, Any]) -> dict[str, Any]:
-    """Attach current, non-secret usage when the durable run still exists."""
+    """Attach safe usage and conversation links when the durable run still exists."""
     lookup = getattr(getattr(service, "run_store", None), "run", None)
     if not callable(lookup):
         return capsule
@@ -40,6 +40,9 @@ def _present(service: ChatService, capsule: dict[str, Any]) -> dict[str, Any]:
             }
             if isinstance(run.get("state"), str):
                 enriched["state"] = run["state"]
+            session_id = run.get("session_id")
+            if isinstance(session_id, str) and session_id.strip():
+                enriched["session_id"] = session_id
         runs.append(enriched)
     return {**capsule, "runs": runs}
 

--- a/agent/tests/test_capsules.py
+++ b/agent/tests/test_capsules.py
@@ -274,3 +274,36 @@ def test_origin_run_requires_matching_task_and_workspace_and_exposes_only_usage(
         assert len(CapsuleStore(str(workspace)).list()) == 2
     finally:
         client.close()
+
+
+def test_run_conversation_link_requires_available_run_in_capsule_workspace(workspace, payload, tmp_path):
+    store = CapsuleStore(str(workspace))
+    capsule = store.create(payload)
+    store.record_run(capsule["id"], "implementation-run", "execute", "completed")
+    run = {
+        "id": "implementation-run", "session_id": "implementation-task",
+        "workspace_root": str(workspace), "state": "completed",
+    }
+    service = SimpleNamespace(
+        core=SimpleNamespace(cwd=str(workspace), workspace_root=str(workspace)),
+        run_store=SimpleNamespace(run=lambda _id: run),
+    )
+    client = TestClient(server.create_app(chat_service=service))
+    try:
+        def presented_run():
+            response = client.get(f"/api/capsules/{capsule['id']}")
+            assert response.status_code == 200, response.text
+            return response.json()["capsule"]["runs"][0]
+
+        assert presented_run()["session_id"] == "implementation-task"
+        assert "session_id" not in store.get(capsule["id"])["runs"][0]
+        run["workspace_root"] = str(tmp_path / "other-workspace")
+        assert "session_id" not in presented_run()
+        run["workspace_root"] = str(workspace)
+        for invalid_session in (None, "", "   ", 123, {"id": "task"}):
+            run["session_id"] = invalid_session
+            assert "session_id" not in presented_run()
+        run = None
+        assert "session_id" not in presented_run()
+    finally:
+        client.close()


### PR DESCRIPTION
## What this changes

Expanding the browser beside a file-heavy conversation now commits the final layout directly, avoids redundant native web-view resizing, and reuses file metadata during resize gestures. Task Capsules guide model setup, keep the next action visible, and make saved plans, edits, and run history easier to use in compact windows.

This also fixes the two intermittent failures in the v2.5.0 CI run: background capsule refreshes leaking into the next routing test, and XCTest sampling Dock pixels for offscreen text. The accessibility test now reveals the complete behavior card before auditing its text; visible and partially visible elements retain contrast checks.

## How you verified it

- 77 focused Swift tests passed for browser ownership, file links, transcript layout, capsule routing, and capsule models; seven capsule layouts were rendered and visually checked at regular and compact sizes.
- All 11 capsule routing tests passed five consecutive runs after the CI isolation fix (55 executions). The UI test target compiles.
- Full local suites passed: 1,257 Swift tests and 1,944 Python tests, including all capsule backend tests.
- Design-system audit, Ruff, protocol manifest, generated Xcode project check, and whitespace checks pass.
- Local UI automation could not start because macOS timed out enabling automation mode. GitHub's macOS UI matrix will verify the full interaction suite.

The larger capsule view change is intentional: draft setup, saved-plan reading/editing, and history remain owned by the capsule feature. Reviewability signals were reviewed; no new feature state was added to the app composition root.

## Checklist

- [x] Commits are signed off.
- [x] Full local Swift and Python suites pass; GitHub's complete platform matrix is running.
- [x] State and routes follow existing ownership boundaries.
- [x] Advisory reviewability signals reviewed.
- [x] New state/actions stay in the capsule owner; API handlers stay out of server.py.
- [x] Generated Xcode project matches the source configuration.
- [x] No credentials or machine-specific paths added.
- [x] No new dependencies.
- [x] Changelog, documentation, and UI strings updated.
