### PR TITLE
Restore smooth browser expansion animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ### Fixed
 
-- Expanding the browser avoids repeated transcript layout and file lookups,
-  improving responsiveness in conversations with many file links.
+- Browser resizing avoids redundant native layout and repeated file lookups;
+  panel expansion and restoration keep their smooth transition.
 
 ## 2.5.0 — 2026-09-06
 

--- a/Locus/AppModel+InspectorLayout.swift
+++ b/Locus/AppModel+InspectorLayout.swift
@@ -220,18 +220,6 @@ extension AppModel {
     /// without the window growing.
     func setInspectorZoomed(_ zoomed: Bool) {
         guard zoomed != inspectorZoomed else { return }
-        // Commit the destination geometry once. Animating this width reflows
-        // every visible Markdown leaf and the live web page on every frame.
-        // Disable implicit sidebar animations too: zoom borrows its space in
-        // the same transaction, and restoring it must be just as immediate.
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            applyInspectorZoomed(zoomed)
-        }
-    }
-
-    private func applyInspectorZoomed(_ zoomed: Bool) {
         if zoomed {
             guard !justChatEnabled else { return }
             if openInspectorTabs.isEmpty {

--- a/Locus/LocusApp.swift
+++ b/Locus/LocusApp.swift
@@ -970,10 +970,11 @@ struct RootView: View {
                 transaction.disablesAnimations = true
             }
         }
-        // Manual sidebar toggles animate; inspector zoom commits its final
-        // geometry without interpolating expensive transcript/WebKit layout.
-        // Divider widths stay outside animation so they follow the cursor.
+        // Animate panel expansion and its borrowed sidebar space together,
+        // including browser, rail, and keyboard actions. Divider widths stay
+        // outside animation so they follow the cursor during a resize drag.
         .animation(LocusMotion.spatial, value: model.sidebarCollapsed)
+        .animation(LocusMotion.spatial, value: model.inspectorZoomed)
         .background(LocusTheme.paper)
         .overlay(alignment: .bottomTrailing) {
             if let toast = toastCenter.toast {


### PR DESCRIPTION
## What this changes

Restore the smooth spring transition when expanding or restoring the browser and other inspector tabs. The shared layout animates all button and keyboard entry points. Native frame coalescing and file metadata caching remain in place; manual divider dragging and Reduce Motion still suppress animation.

## How you verified it

Existing app layout, browser host, and Reduce Motion tests pass. The design-system audit and whitespace checks pass. This is a narrow animation correction; no backend behavior or dependencies changed.

## Checklist

- [x] Signed-off commit.
- [x] Relevant Swift tests and design audit pass.
- [x] Existing ownership boundaries preserved; no new feature state.
- [x] Small diff reviewed; no credentials, dependencies, or machine-specific paths added.
- [x] Changelog updated; no project generation needed.
