### PR TITLE
Name the Solana fee-evidence bound that failed and wait for it in the local-validator test

### DIFF
--- a/Locus/WalletSolanaRPCClient.swift
+++ b/Locus/WalletSolanaRPCClient.swift
@@ -3070,7 +3070,22 @@ actor WalletSolanaRPCClient {
         let raw = try await rpc(
             method: "getRecentPrioritizationFees", params: [writableAccounts]
         )
-        guard let rows = raw as? [Any], !rows.isEmpty, rows.count <= 150 else {
+        // A node's prioritization-fee cache lists at most 150 recent blocks,
+        // and only blocks that carried a non-vote transaction. Every shape
+        // outside that documented envelope fails closed, but each bound is
+        // named separately: an endpoint with no fee evidence is a different
+        // fault from one returning more history than the protocol produces.
+        guard let rows = raw as? [Any] else {
+            throw WalletRPCError.invalidResponse(
+                "getRecentPrioritizationFees did not return an array"
+            )
+        }
+        guard !rows.isEmpty else {
+            throw WalletRPCError.invalidResponse(
+                "getRecentPrioritizationFees returned no recent fee evidence"
+            )
+        }
+        guard rows.count <= 150 else {
             throw WalletRPCError.invalidResponse(
                 "getRecentPrioritizationFees returned excessive data"
             )

--- a/LocusTests/WalletGatewayTests.swift
+++ b/LocusTests/WalletGatewayTests.swift
@@ -6571,6 +6571,86 @@ final class WalletGatewayTests: XCTestCase {
         _ = try await client.recheck(intentID: "capped-priority", packet: packet)
     }
 
+    func testSolanaPriorityFeeEvidenceNamesTheBoundThatFailed() async throws {
+        let payer = "3Cy3YNTFywCmxoxt8n7UH6hg6dLo5uACowX3CFceaSnx"
+        let recipient = WalletSolanaBase58.encode(Data(repeating: 7, count: 32))
+        let blockhash = WalletSolanaBase58.encode(Data(repeating: 9, count: 32))
+        var recentFees: Any = [] as [Any]
+        let client = makeSolanaRPCClient { request in
+            let object = try XCTUnwrap(
+                try JSONSerialization.jsonObject(
+                    with: walletRPCRequestBody(request)
+                ) as? [String: Any]
+            )
+            let method = try XCTUnwrap(object["method"] as? String)
+            let result: Any
+            switch method {
+            case "getGenesisHash":
+                result = WalletNetworkCatalog.solanaDevnet.identity.value
+            case "getLatestBlockhash":
+                result = [
+                    "context": ["slot": 42],
+                    "value": ["blockhash": blockhash, "lastValidBlockHeight": 500],
+                ]
+            case "getFeeForMessage":
+                result = ["context": ["slot": 42], "value": 5_000]
+            case "getRecentPrioritizationFees":
+                result = recentFees
+            case "simulateTransaction":
+                result = [
+                    "context": ["slot": 42],
+                    "value": [
+                        "err": NSNull(), "innerInstructions": [], "logs": [],
+                        "unitsConsumed": 750,
+                    ],
+                ]
+            case "getBlockHeight":
+                result = 450
+            default:
+                throw URLError(.unsupportedURL)
+            }
+            return try JSONSerialization.data(withJSONObject: [
+                "jsonrpc": "2.0", "id": object["id"]!, "result": result,
+            ])
+        }
+        let request = WalletPrepareRequest(
+            networkID: WalletNetworkCatalog.solanaDevnet.id,
+            accountID: "locus-vault-solana-0", source: .human,
+            action: .nativeTransfer(recipient: recipient, amountBaseUnits: "1"),
+            maximumFeeBaseUnits: "6000"
+        )
+        func rows(_ count: Int) -> [[String: Any]] {
+            (0..<count).map { ["slot": 1_000 + $0, "prioritizationFee": 0] }
+        }
+
+        // 150 blocks is the documented depth of a node's fee cache, and the
+        // pinned local validator fills exactly that many, so the ceiling is
+        // inclusive.
+        recentFees = rows(150)
+        let packet = try await client.prepare(request: request, feePayer: payer)
+        XCTAssertEqual(packet.computeUnitPriceMicroLamports, "0")
+        XCTAssertEqual(packet.feeQuoteBaseUnits, "5000")
+
+        // Each bound fails closed under its own name. An idle validator that
+        // has confirmed no non-vote transaction answers with an empty list,
+        // which must never read as "excessive".
+        let outsideBounds: [(payload: Any, expected: String)] = [
+            ([] as [Any], "returned no recent fee evidence"),
+            (rows(151), "returned excessive data"),
+            (["slot": 1_000, "prioritizationFee": 0] as [String: Any],
+             "did not return an array"),
+        ]
+        for (payload, expected) in outsideBounds {
+            recentFees = payload
+            do {
+                _ = try await client.prepare(request: request, feePayer: payer)
+                XCTFail("Fee evidence outside the reviewed bounds must fail closed.")
+            } catch WalletRPCError.invalidResponse(let message) {
+                XCTAssertTrue(message.contains(expected), message)
+            }
+        }
+    }
+
     func testSolanaProviderRejectsMaliciousGenesisBeforePreparation() async throws {
         let client = makeSolanaRPCClient { request in
             let object = try XCTUnwrap(

--- a/LocusWalletChainTests/WalletSolanaIntegrationTests.swift
+++ b/LocusWalletChainTests/WalletSolanaIntegrationTests.swift
@@ -161,6 +161,17 @@ final class WalletSolanaIntegrationTests: XCTestCase {
         try await waitForBalance(
             minimum: 5_000_000_000, address: Self.signer, client: client
         )
+        // Agave's prioritization-fee cache lists only optimistically confirmed
+        // slots that carried a non-vote transaction, and its bank tracker
+        // publishes the confirmed bank before queueing that slot to the
+        // cache's service thread. So a confirmed airdrop balance does not yet
+        // imply fee evidence, and an idle validator answers with an empty
+        // list no matter how many slots it has produced. Wait for the
+        // airdrop's own row so the client's reviewed non-empty bound is met
+        // deterministically instead of by winning a thread race.
+        try await waitForPrioritizationFeeEvidence(
+            writableAccounts: [Self.signer, Self.recipient], endpoint: endpoint
+        )
         let recipientBefore = try await client.balance(address: Self.recipient)
 
         let request = WalletPrepareRequest(
@@ -478,6 +489,30 @@ final class WalletSolanaIntegrationTests: XCTestCase {
             domain: "WalletSolanaIntegrationTests", code: 2,
             userInfo: [NSLocalizedDescriptionKey:
                 "The local validator airdrop did not finalize."]
+        )
+    }
+
+    private func waitForPrioritizationFeeEvidence(
+        writableAccounts: [String],
+        endpoint: String
+    ) async throws {
+        for _ in 0..<100 {
+            let raw = try await solanaRPC(
+                endpoint: endpoint, method: "getRecentPrioritizationFees",
+                params: [writableAccounts]
+            )
+            if let rows = raw as? [Any], !rows.isEmpty {
+                // The validator keeps at most 150 blocks of fee history; the
+                // client's ceiling mirrors that documented depth exactly.
+                XCTAssertLessThanOrEqual(rows.count, 150)
+                return
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        throw NSError(
+            domain: "WalletSolanaIntegrationTests", code: 3,
+            userInfo: [NSLocalizedDescriptionKey:
+                "The local validator published no prioritization-fee evidence."]
         )
     }
 


### PR DESCRIPTION
## Summary

The swift job's "Pinned Solana local-validator integration" step flaked on main run [34175286346](https://github.com/nahid-sparktales/locus/actions/runs/34175286346) with `invalidResponse("getRecentPrioritizationFees returned excessive data")`, on a tree that had passed the same step an hour earlier on its PR run and touched no wallet code. The error message was wrong about the cause, and the test was racing the validator. This PR names each fee-evidence bound separately and makes the local harness wait for the evidence it needs, without loosening any bound.

## What the pinned validator actually returns

I probed the pinned agave `solana-test-validator` 4.1.2 directly (`probe_fees.py`, results below) and read the matching sources (`runtime/src/prioritization_fee_cache.rs`, `rpc/src/optimistically_confirmed_bank_tracker.rs` at v4.1.2):

- The fee cache only ever holds slots that carried a **non-vote transaction**, and only after the optimistically-confirmed-bank tracker has queued that slot to the cache's service thread. An idle validator answers `[]` no matter how many slots it has produced (probe: still 0 rows at slot 10 and beyond).
- The tracker publishes the confirmed bank **before** it queues the fee finalization, so `getBalance` at `confirmed` commitment can show the airdrop before its slot is in the cache. The test waited for exactly that balance and then called `prepare` immediately. On a loaded runner it lost that thread race: the failing test ran for 1.26 s, right after the airdrop confirmed, and the guard's empty-array branch fired under the "excessive data" label.
- The cache is capped at `MAX_NUM_RECENT_BLOCKS = 150` with `while cache.len() >= 150 { pop_first() }` before every insert. 165 airdrops in distinct slots drove the row count to exactly 150 and never past it.

| Probe phase | Observation |
|---|---|
| Quiet validator, slots 0 through 10+ | 0 rows every sample |
| One airdrop | balance at `processed` +0.45 s with 0 rows; `confirmed` +0.53 s with 1 row `{slot, prioritizationFee: 0}` |
| 165 airdrops, one per slot | rows climb 1 → 150, then hold at 150 with the window sliding |

## Decision

Keep the 150-row ceiling exactly as reviewed. The reference node cannot exceed it, so truncating a longer answer to "the most recent 150" would only tolerate a shape no honest endpoint produces, and the guard exists to reject exactly that. The nondeterminism was never about slot count, so "wait for enough slots" is the wrong primitive too. Instead:

- **Client** (`Locus/WalletSolanaRPCClient.swift`): the single guard becomes three, each with its own message: `did not return an array`, `returned no recent fee evidence`, `returned excessive data`. Every shape outside the bounds still fails closed for production endpoints. Nothing else in the fee plan changes.
- **Harness** (`LocusWalletChainTests/WalletSolanaIntegrationTests.swift`): after the airdrop balance is confirmed, `waitForPrioritizationFeeEvidence` polls `getRecentPrioritizationFees` for the exact writable accounts the client will query until the airdrop's own row is present (bounded like `waitForBalance`), and asserts the count stays within the documented 150. The reviewed non-empty bound becomes a deterministic precondition instead of a race the test usually wins.
- **Unit test** (`LocusTests/WalletGatewayTests.swift`): `testSolanaPriorityFeeEvidenceNamesTheBoundThatFailed` proves the ceiling is inclusive at 150 rows and that `[]`, 151 rows, and a non-array each fail under their own name.

## Verification

- `Tools/RunWalletSolanaTests.sh` run locally the way CI does, against the pinned 4.1.2 validator with `CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=` and the ad-hoc entitlements: three consecutive runs, each on a freshly reset validator, passed all 5 `WalletSolanaIntegrationTests` with 0 failures (the transfer test took 15.2 s, 17.2 s, and 17.5 s, versus 1.26 s to the failure on CI).
- `LocusXTests/WalletGatewayTests` Solana fee tests (new test plus the two existing priority-fee tests): all 3 pass (`-scheme LocusX -only-testing:LocusXTests/WalletGatewayTests/...`).
- `xcodegen generate` leaves `project.pbxproj` unchanged (no new files).
