### PR TITLE
Enable automatic updates for released wallet-free Locus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,12 +175,28 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
           app="$RUNNER_TEMP/locus-standard-release/Build/Products/$EDITION_CONFIGURATION/Locus.app"
           python3 Tools/AuditAppEdition.py "$app" --edition locus --allow-missing-runtime
+      - name: Released Locus update controls
+        if: matrix.scheme == 'Locus'
+        run: >-
+          xcodebuild test
+          -project Locus.xcodeproj
+          -scheme LocusReleaseUpdates
+          -configuration Release
+          -destination 'platform=macOS'
+          -derivedDataPath "$RUNNER_TEMP/locus-release-update-ui"
+          -only-testing:LocusUITests/LocusUITests/testUpdatesSettingsMatchTheBuildDistribution
+          CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=
+          ENABLE_HARDENED_RUNTIME=NO
+          ENABLE_TESTABILITY=YES
+          LOCUS_DIRECT_ENTITLEMENTS=Config/LocusDirectAdHoc.entitlements
       - name: Retain standard unit-test evidence
         if: always() && matrix.scheme == 'Locus'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: locus-standard-macos15-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/locus-standard-tests/Logs/Test/*.xcresult/**
+          path: |
+            ${{ runner.temp }}/locus-standard-tests/Logs/Test/*.xcresult/**
+            ${{ runner.temp }}/locus-release-update-ui/Logs/Test/*.xcresult/**
           if-no-files-found: error
           retention-days: 90
 

--- a/Config/LocusRelease-Info.plist
+++ b/Config/LocusRelease-Info.plist
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>io.sparktales.locus.mcp-oauth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>locus</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>io.sparktales.locus.google-oauth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(LOCUS_GOOGLE_OAUTH_REVERSED_CLIENT_ID)</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
+	<key>LSMultipleInstancesProhibited</key>
+	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Allow websites you approve in the Locus browser to use the camera.</string>
+	<key>LocusComponentFeedURL</key>
+	<string>https://github.com/nahid-sparktales/locus/releases/latest/download/components.json</string>
+	<key>LocusSourceRevision</key>
+	<string>$(LOCUS_SOURCE_REVISION)</string>
+	<key>LocusGitHubOAuthClientID</key>
+	<string>$(LOCUS_GITHUB_OAUTH_CLIENT_ID)</string>
+	<key>LocusGoogleOAuthClientID</key>
+	<string>$(LOCUS_GOOGLE_OAUTH_CLIENT_ID)</string>
+	<key>LocusGoogleOAuthCallbackScheme</key>
+	<string>$(LOCUS_GOOGLE_OAUTH_REVERSED_CLIENT_ID)</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_locus-remote._tcp</string>
+	</array>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>Locus needs access to your Documents folder to open coding workspaces and start the local Ollama agent.</string>
+	<key>NSDownloadsFolderUsageDescription</key>
+	<string>Locus needs access to save browser downloads and open files or projects you choose from Downloads.</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>© 2026 SparkTales Inc.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Locus uses your private network only when you enable Mobile Access and pair a phone.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Locus uses the microphone for dictation, voice conversations, and websites you explicitly allow.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Locus turns speech into editable dictation or voice messages when you use a voice control.</string>
+	<key>SUAllowsAutomaticUpdates</key>
+	<true/>
+	<key>SUAutomaticallyUpdate</key>
+	<true/>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUEnableSystemProfiling</key>
+	<false/>
+	<key>SUPublicEDKey</key>
+	<string>S/F9z1jR20s26+oHOxVjFend/ajDH04OY8Ietw+IDl4=</string>
+	<key>SURequireSignedFeed</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>86400</integer>
+	<key>SUScheduledImpatientCheckInterval</key>
+	<integer>604800</integer>
+	<key>SUVerifyUpdateBeforeExtraction</key>
+	<true/>
+	<key>LocusEdition</key>
+	<string>locus</string>
+	<key>LocusUpdateMode</key>
+	<string>automatic</string>
+	<key>SUFeedURL</key>
+	<string>https://github.com/nahid-sparktales/locus/releases/latest/download/appcast-locus.xml</string>
+</dict>
+</plist>

--- a/Docs/Editions.md
+++ b/Docs/Editions.md
@@ -66,11 +66,81 @@ The local Locus artifact is placed under `output/wallet-free/` as `Locus.app` an
 installation. Ollama/model downloads and hosted-provider accounts remain optional
 user configuration.
 
-Both local editions have `LocusUpdateMode=manual` and no app update feed. They
-never start Sparkle or honor old automatic-update preferences. The independently
-verified Codex component feed remains available. Separate public app feeds,
-LocusX Google registration, and public wallet migration are deferred.
-Do not publish these local artifacts through the old appcast.
+Development Locus builds and every LocusX configuration have
+`LocusUpdateMode=manual` and no app update feed. They never start Sparkle or honor
+old automatic-update preferences. Locus's `Release` configuration selects
+`Config/LocusRelease-Info.plist` and enables the separate standard-app feed.
+The independently verified Codex component feed remains available in both direct
+editions. LocusX updates, Google registration, and public wallet migration remain
+deferred. Never publish wallet-free Locus through the old appcast.
+
+## Automatic Locus releases
+
+Released Locus uses
+`https://github.com/nahid-sparktales/locus/releases/latest/download/appcast-locus.xml`.
+It checks daily, downloads updates in the background, and installs on quit.
+Sparkle may remind users after a week or ask for administrator approval when
+installation needs it. Existing user opt-outs remain effective. Tests never
+start the updater. The app reads and validates its edition, identity, update
+mode and feed from its sealed bundle; a saved legacy feed URL cannot override it.
+
+**One manual upgrade is required:** 2.6.0 and earlier manual builds cannot fetch
+this change themselves. Wallet-era installations continue to see their unchanged
+legacy feed. Installing new Locus preserves its existing chats, accounts,
+settings and browser data without importing or deleting wallet data.
+
+1. At release time, choose a build greater than 26 and greater than every build
+   already in the Locus feed. Update the version and changelog and commit the
+   generated project. This updater implementation itself does not bump versions.
+2. Run the Python release tests, native updater tests and focused update-settings
+   UI tests for Locus Debug and Release, LocusX, and the App Store edition. Build
+   and audit all three editions in separate DerivedData directories. A complete
+   deliverable must include its runtime; `LOCUS_BUNDLE_MODE=skip` is compile-only.
+   Use scheme `LocusReleaseUpdates` for the Release UI check: it excludes unit
+   tests that rely on Debug-only instrumentation. The focused method is
+   `LocusUITests/LocusUITests/testUpdatesSettingsMatchTheBuildDistribution`.
+3. In a fresh staging directory, place verified `components.json` and all its
+   referenced archives. Copy `appcast.xml` from tag `v2.6.0` without changing its
+   bytes. Its SHA-256 must be
+   `fabc1d4450afce04a5931bde6dc9630994f7748d512d73a8a600630b52696ece`.
+   Do not stage an existing `appcast-locus.xml`: the generator retrieves and
+   verifies the current Locus feed itself, preserving only that feed's history.
+4. Use the existing SparkTales Developer ID and Sparkle Keychain account
+   `io.sparktales`, the pinned Sparkle 2.9.6 tools, and the notarization credentials
+   described below. Build scheme `Locus`, configuration `Release`, with its full
+   runtime from the clean release revision, then package:
+
+   ```sh
+   LOCUS_NOTARIZE=1 Tools/PackageRelease.sh \
+     /absolute/path/Locus.app /absolute/staging/Locus-macOS.zip
+   ```
+
+   For the **first** Locus feed only, also set
+   `LOCUS_APPCAST_INITIAL_CHANNEL=locus`. Initialization requires HTTP 404 from
+   the new feed endpoint. HTTP errors, transport failures, and invalid existing
+   signatures fail packaging; initialization never discards an existing feed.
+   The generator's explicit mode is
+   `Tools/GenerateAppcast.sh <zip> <new appcast-locus.xml> locus`.
+5. The packager checks wallet exclusion, identity, Developer ID signatures,
+   arm64 architecture, test-bundle exclusion, notarization, stapling, and the ZIP
+   round trip. Feed entries use signed, version-pinned `Locus-macOS.zip` URLs,
+   never a `latest` archive URL. Both the feed and archive signatures must verify.
+   The legacy feed is checked again after generation and must remain unchanged.
+6. Before publication, exercise a signed update between two increasing builds
+   in an isolated macOS test account. Use a private fixture build/feed for this
+   rehearsal; production routing remains pinned. Verify daily/default settings,
+   preserved opt-outs, background download, installation on quit, relaunch, and
+   retained data. Also exercise settings/note-save failures and active-work
+   cleanup. Do not run this rehearsal against a user's installed application.
+7. Upload `Locus-macOS.zip`, **both** `appcast-locus.xml` and the unchanged
+   `appcast.xml`, `components.json`, and every component archive to one draft
+   release. Review before publishing as latest. Verify the public asset hashes,
+   both feed endpoints and signatures, and the component endpoint after publishing.
+
+To withdraw a faulty update, restore the previous valid signed Locus feed and
+verify the endpoint again; never alter the legacy feed. Already-updated apps
+need a corrective release with a higher build. Do not delete archives referenced
+by retained feeds. A rollback feed cannot undo an update already installed.
 
 ## Public manual Locus releases
 
@@ -82,14 +152,15 @@ this manual release.
 
 1. Commit the version, build number, changelog, and generated project. Run the
    Python and standard native tests. Build scheme `Locus`, configuration
-   `Release`, from that clean revision in separate DerivedData with the full
+   `Release`, explicitly overriding `INFOPLIST_FILE=Locus/Info.plist` and
+   `LOCUS_UPDATE_MODE=manual`, from that clean revision in separate DerivedData with the full
    bundled runtime (`LOCUS_BUNDLE_MODE=skip` must not be set). Audit the complete
    app with `Tools/AuditAppEdition.py --edition locus`.
 2. Prepare a release staging directory containing `components.json` and every
    referenced component archive. Copy the previous release's pair if unchanged,
    or run `Tools/PackageComponents.sh`. Run `Tools/VerifyComponentAssets.sh`.
-3. Copy the previous public release's signed `appcast.xml` into staging without
-   changing its bytes. For the 2.5.0 release, retain the feed from tag `v2.4.0`.
+3. Copy the signed `appcast.xml` from tag `v2.6.0` into staging without
+   changing its bytes.
    This file remains necessary because older installed apps request
    `releases/latest/download/appcast.xml`. Every enclosure must point to a
    version-pinned prior release archive. Never point it at the new ZIP or a
@@ -117,7 +188,8 @@ this manual release.
    bundles. It does not generate or promote an
    appcast. Builds without notarization remain private verification artifacts.
 6. Upload `Locus-macOS.zip`, the unchanged `appcast.xml`, `components.json`, and
-   every referenced component archive into one draft GitHub release before
-   publishing it as latest. Verify the asset hashes and the public latest
-   component/feed endpoints after publication. The release notes must identify
-   this as a manual wallet-free download; older apps retain their existing feed.
+   every referenced component archive into one draft GitHub release. Once the
+   automatic Locus feed is live, publish manual-only releases as **non-latest**
+   downloads so they cannot remove `appcast-locus.xml` from the latest release.
+   Verify asset hashes after publication. The release notes must identify this
+   as a manual wallet-free download; older apps retain their existing feed.

--- a/Locus.xcodeproj/project.pbxproj
+++ b/Locus.xcodeproj/project.pbxproj
@@ -4969,7 +4969,7 @@
 				CODE_SIGN_ENTITLEMENTS = "$(LOCUS_DIRECT_ENTITLEMENTS)";
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = Locus/Info.plist;
+				INFOPLIST_FILE = "Config/LocusRelease-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -4979,7 +4979,7 @@
 				LOCUS_GITHUB_OAUTH_CLIENT_ID = Iv23liCL3tit1VOgBjWF;
 				LOCUS_GOOGLE_OAUTH_CLIENT_ID = "976511349544-lvn16ildgj3pu9pd3e45qgoueg17seov.apps.googleusercontent.com";
 				LOCUS_GOOGLE_OAUTH_REVERSED_CLIENT_ID = "com.googleusercontent.apps.976511349544-lvn16ildgj3pu9pd3e45qgoueg17seov";
-				LOCUS_UPDATE_MODE = manual;
+				LOCUS_UPDATE_MODE = automatic;
 				PRODUCT_BUNDLE_IDENTIFIER = io.sparktales.locus;
 				PRODUCT_MODULE_NAME = Locus;
 				PRODUCT_NAME = Locus;

--- a/Locus.xcodeproj/xcshareddata/xcschemes/LocusReleaseUpdates.xcscheme
+++ b/Locus.xcodeproj/xcshareddata/xcschemes/LocusReleaseUpdates.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4896638691C4AFF8C4B6701D"
+               BuildableName = "Locus.app"
+               BlueprintName = "Locus"
+               ReferencedContainer = "container:Locus.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4896638691C4AFF8C4B6701D"
+            BuildableName = "Locus.app"
+            BlueprintName = "Locus"
+            ReferencedContainer = "container:Locus.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "54F38C8317FB3757358B2EBD"
+               BuildableName = "LocusUITests.xctest"
+               BlueprintName = "LocusUITests"
+               ReferencedContainer = "container:Locus.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "LOCUS_EXPECT_AUTOMATIC_UPDATES"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4896638691C4AFF8C4B6701D"
+            BuildableName = "Locus.app"
+            BlueprintName = "Locus"
+            ReferencedContainer = "container:Locus.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4896638691C4AFF8C4B6701D"
+            BuildableName = "Locus.app"
+            BlueprintName = "Locus"
+            ReferencedContainer = "container:Locus.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Locus/AppUpdateController.swift
+++ b/Locus/AppUpdateController.swift
@@ -6,6 +6,22 @@ import AppKit
 import Sparkle
 #endif
 
+/// Only the released standard app can opt into the new feed. Read this from
+/// the sealed bundle, never UserDefaults (which may retain the legacy feed).
+struct AppUpdateConfiguration: Equatable {
+    static let locusFeedURL = "https://github.com/nahid-sparktales/locus/releases/latest/download/appcast-locus.xml"
+
+    let feedURL: String
+
+    init?(info: [String: Any]) {
+        guard info["LocusEdition"] as? String == "locus",
+              info["CFBundleIdentifier"] as? String == "io.sparktales.locus",
+              info["LocusUpdateMode"] as? String == "automatic",
+              info["SUFeedURL"] as? String == Self.locusFeedURL else { return nil }
+        feedURL = Self.locusFeedURL
+    }
+}
+
 @MainActor
 protocol AppUpdateRelaunchHandling: AnyObject {
     func shouldAllowUpdateRelaunch() -> Bool
@@ -62,6 +78,7 @@ final class AppUpdateController: ObservableObject {
         startImmediately: Bool = true,
         distribution: Distribution? = nil,
         updateMode: UpdateMode? = nil,
+        bundleInfo: [String: Any]? = nil,
         driver: AppUpdateDriving? = nil
     ) {
         #if LOCUS_DIRECT_DOWNLOAD
@@ -70,17 +87,19 @@ final class AppUpdateController: ObservableObject {
         let resolvedDistribution = distribution ?? .appStore
         #endif
         self.distribution = resolvedDistribution
-        let resolvedMode = updateMode ?? .configured(
-            bundleValue: Bundle.main.object(forInfoDictionaryKey: "LocusUpdateMode") as? String
-        )
+        let info = bundleInfo ?? Bundle.main.infoDictionary ?? [:]
+        let configuration = AppUpdateConfiguration(info: info)
+        let requestedMode = updateMode ?? .configured(bundleValue: info["LocusUpdateMode"] as? String)
+        let resolvedMode: UpdateMode = requestedMode == .automatic && configuration != nil ? .automatic : .manual
         self.updateMode = resolvedMode
 
         if let driver {
             self.driver = driver
         } else {
             #if LOCUS_DIRECT_DOWNLOAD
-            if resolvedDistribution == .directDownload && resolvedMode == .automatic {
-                self.driver = SparkleUpdateDriver(startImmediately: startImmediately)
+            if resolvedDistribution == .directDownload && resolvedMode == .automatic,
+               let configuration {
+                self.driver = SparkleUpdateDriver(configuration: configuration, startImmediately: startImmediately)
             } else {
                 self.driver = AppStoreUpdateDriver()
             }
@@ -136,11 +155,12 @@ private final class AppStoreUpdateDriver: AppUpdateDriving {
 
 #if LOCUS_DIRECT_DOWNLOAD
 @MainActor
-private final class SparkleUpdateDriver: NSObject, AppUpdateDriving, SPUUpdaterDelegate {
+final class SparkleUpdateDriver: NSObject, AppUpdateDriving, SPUUpdaterDelegate {
     var stateDidChange: (() -> Void)?
     weak var relaunchHandler: AppUpdateRelaunchHandling?
 
     private var controller: SPUStandardUpdaterController!
+    private let configuration: AppUpdateConfiguration
     private var canCheckObservation: AnyCancellable?
     private var automaticCheckObservation: AnyCancellable?
     private var automaticDownloadObservation: AnyCancellable?
@@ -149,7 +169,8 @@ private final class SparkleUpdateDriver: NSObject, AppUpdateDriving, SPUUpdaterD
     private var requestedSafetyUpdate = false
     #endif
 
-    init(startImmediately: Bool) {
+    init(configuration: AppUpdateConfiguration, startImmediately: Bool) {
+        self.configuration = configuration
         super.init()
         controller = SPUStandardUpdaterController(
             startingUpdater: startImmediately,
@@ -212,12 +233,6 @@ private final class SparkleUpdateDriver: NSObject, AppUpdateDriving, SPUUpdaterD
         }
     }
 
-    func feedURLString(for updater: SPUUpdater) -> String? {
-        guard WalletCandidateUpdateAuthority.isCandidate() else { return nil }
-        if requestedSafetyUpdate { return Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String }
-        return WalletCandidateUpdateAuthority.selection()?.feedURL
-    }
-
     func allowedChannels(for updater: SPUUpdater) -> Set<String> {
         if requestedSafetyUpdate { return [] }
         guard let channel = WalletCandidateUpdateAuthority.selection()?.channel else { return [] }
@@ -250,6 +265,16 @@ private final class SparkleUpdateDriver: NSObject, AppUpdateDriving, SPUUpdaterD
         requestedSafetyUpdate = false
     }
     #endif
+
+    func feedURLString(for updater: SPUUpdater) -> String? {
+        #if LOCUS_WALLET
+        if WalletCandidateUpdateAuthority.isCandidate() {
+            if requestedSafetyUpdate { return Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String }
+            return WalletCandidateUpdateAuthority.selection()?.feedURL
+        }
+        #endif
+        return configuration.feedURL
+    }
 
     func updater(
         _ updater: SPUUpdater,

--- a/LocusTests/AppUpdateControllerTests.swift
+++ b/LocusTests/AppUpdateControllerTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 @testable import Locus
+#if LOCUS_DIRECT_DOWNLOAD
+import Sparkle
+#endif
 
 @MainActor
 private final class FakeUpdateDriver: AppUpdateDriving {
@@ -27,6 +30,90 @@ private final class FakeUpdateDriver: AppUpdateDriving {
 
 @MainActor
 final class AppUpdateControllerTests: XCTestCase {
+    private var automaticInfo: [String: Any] {
+        [
+            "LocusEdition": "locus", "CFBundleIdentifier": "io.sparktales.locus",
+            "LocusUpdateMode": "automatic", "SUFeedURL": AppUpdateConfiguration.locusFeedURL,
+            "SUEnableAutomaticChecks": true, "SUAutomaticallyUpdate": true,
+            "SUAllowsAutomaticUpdates": true,
+        ]
+    }
+
+    func testInvalidBundleConfigurationCannotEnableUpdatesEvenWithSavedPreferences() {
+        for key in ["LocusEdition", "CFBundleIdentifier", "LocusUpdateMode", "SUFeedURL"] {
+            for value in [nil, "", "unknown"] as [String?] {
+                var info = automaticInfo
+                info[key] = value
+                let driver = FakeUpdateDriver()
+                let controller = AppUpdateController(
+                    distribution: .directDownload, updateMode: .automatic,
+                    bundleInfo: info, driver: driver
+                )
+                XCTAssertNil(AppUpdateConfiguration(info: info))
+                XCTAssertFalse(controller.isAvailable)
+                controller.checkForUpdates()
+                controller.setAutomaticallyChecksForUpdates(false)
+                controller.setAutomaticallyDownloadsUpdates(false)
+                XCTAssertEqual(driver.checkCount, 0)
+                XCTAssertTrue(driver.automaticallyChecksForUpdates)
+                XCTAssertTrue(driver.automaticallyDownloadsUpdates)
+            }
+        }
+        var info = automaticInfo
+        info["SUFeedURL"] = "https://github.com/nahid-sparktales/locus/releases/latest/download/appcast.xml"
+        XCTAssertNil(AppUpdateConfiguration(info: info))
+        info = automaticInfo
+        info["LocusEdition"] = "locusx"
+        info["CFBundleIdentifier"] = "io.sparktales.locusx"
+        XCTAssertNil(AppUpdateConfiguration(info: info))
+    }
+
+    func testValidBundleConfigurationEnablesUpdatesWithoutAnOverride() {
+        let controller = AppUpdateController(
+            distribution: .directDownload, bundleInfo: automaticInfo,
+            driver: FakeUpdateDriver(automaticChecks: false, automaticDownloads: false)
+        )
+        XCTAssertTrue(controller.isAvailable)
+        XCTAssertFalse(controller.automaticallyChecksForUpdates)
+        XCTAssertFalse(controller.automaticallyDownloadsUpdates)
+    }
+
+    #if LOCUS_DIRECT_DOWNLOAD
+    func testSparkleUsesSealedFeedAndRetainsSavedOptOuts() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".app")
+        let contents = directory.appendingPathComponent("Contents")
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        let identifier = "io.sparktales.updater-tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: identifier))
+        defer {
+            defaults.removePersistentDomain(forName: identifier)
+            try? FileManager.default.removeItem(at: directory)
+        }
+        var info = automaticInfo
+        info["CFBundleIdentifier"] = identifier
+        info["CFBundleName"] = "Updater Test"
+        info["CFBundleVersion"] = "27"
+        try PropertyListSerialization.data(fromPropertyList: info, format: .xml, options: 0)
+            .write(to: contents.appendingPathComponent("Info.plist"))
+        let bundle = try XCTUnwrap(Bundle(url: directory))
+        let driver = SparkleUpdateDriver(
+            configuration: try XCTUnwrap(AppUpdateConfiguration(info: automaticInfo)), startImmediately: false
+        )
+        let userDriver = SPUStandardUserDriver(hostBundle: bundle, delegate: nil)
+        let updater = SPUUpdater(hostBundle: bundle, applicationBundle: bundle, userDriver: userDriver, delegate: driver)
+        XCTAssertTrue(updater.automaticallyChecksForUpdates)
+        XCTAssertTrue(updater.automaticallyDownloadsUpdates)
+        defaults.set("https://github.com/nahid-sparktales/locus/releases/latest/download/appcast.xml", forKey: "SUFeedURL")
+        updater.automaticallyChecksForUpdates = false
+        updater.automaticallyDownloadsUpdates = false
+        let relaunched = SPUUpdater(hostBundle: bundle, applicationBundle: bundle, userDriver: userDriver, delegate: driver)
+        XCTAssertEqual(relaunched.feedURL?.absoluteString, AppUpdateConfiguration.locusFeedURL)
+        XCTAssertFalse(relaunched.automaticallyChecksForUpdates)
+        XCTAssertFalse(relaunched.automaticallyDownloadsUpdates)
+        XCTAssertFalse(relaunched.canCheckForUpdates, "Tests must never start Sparkle")
+    }
+    #endif
+
     func testManualUpdatesIgnorePreviouslyEnabledUpdaterPreferences() {
         let driver = FakeUpdateDriver()
         let controller = AppUpdateController(
@@ -72,6 +159,7 @@ final class AppUpdateControllerTests: XCTestCase {
             startImmediately: false,
             distribution: .directDownload,
             updateMode: .automatic,
+            bundleInfo: automaticInfo,
             driver: driver
         )
 
@@ -95,6 +183,7 @@ final class AppUpdateControllerTests: XCTestCase {
             startImmediately: false,
             distribution: .directDownload,
             updateMode: .automatic,
+            bundleInfo: automaticInfo,
             driver: driver
         )
 
@@ -114,6 +203,7 @@ final class AppUpdateControllerTests: XCTestCase {
             startImmediately: false,
             distribution: .directDownload,
             updateMode: .automatic,
+            bundleInfo: automaticInfo,
             driver: driver
         )
 
@@ -131,6 +221,8 @@ final class AppUpdateControllerTests: XCTestCase {
         let controller = AppUpdateController(
             startImmediately: false,
             distribution: .appStore,
+            updateMode: .automatic,
+            bundleInfo: automaticInfo,
             driver: driver
         )
 
@@ -154,6 +246,7 @@ final class AppUpdateControllerTests: XCTestCase {
             startImmediately: false,
             distribution: .directDownload,
             updateMode: .automatic,
+            bundleInfo: automaticInfo,
             driver: driver
         )
         let lifecycle = ApplicationLifecycleCoordinator()

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -1225,11 +1225,15 @@ final class LocusUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Reusable workflows"].exists)
     }
 
-    func testUpdatesSettingsShowManualLocalControls() {
+    func testUpdatesSettingsMatchTheBuildDistribution() {
+        let automatic = ProcessInfo.processInfo.environment["LOCUS_EXPECT_AUTOMATIC_UPDATES"] == "1"
         app.menuBars.menuBarItems[productName].firstMatch.click()
         XCTAssertTrue(app.menuItems["Settings…"].waitForExistence(timeout: 3))
-        XCTAssertFalse(app.menuItems["Check for Updates…"].exists,
-            "Manual local editions must not offer the legacy app-feed command")
+        XCTAssertEqual(app.menuItems["Check for Updates…"].exists, automatic)
+        if automatic {
+            XCTAssertFalse(app.menuItems["Check for Updates…"].isEnabled,
+                "UI tests expose the controls without starting Sparkle")
+        }
         app.typeKey(.escape, modifierFlags: [])
 
         anyElement("workspace.modelPicker").click()
@@ -1242,10 +1246,12 @@ final class LocusUITests: XCTestCase {
         updatesPage.click()
 
         XCTAssertTrue(anyElement("settings.updateVersion").waitForExistence(timeout: 3))
-        XCTAssertTrue(anyElement("settings.manualUpdates").waitForExistence(timeout: 3))
-        XCTAssertFalse(anyElement("settings.automaticUpdateChecks").exists)
-        XCTAssertFalse(anyElement("settings.automaticUpdateDownloads").exists)
-        XCTAssertFalse(anyElement("settings.checkForUpdates").exists)
+        let expected = automatic ? "settings.automaticUpdateChecks" : "settings.manualUpdates"
+        XCTAssertTrue(anyElement(expected).waitForExistence(timeout: 3))
+        XCTAssertEqual(anyElement("settings.manualUpdates").exists, !automatic)
+        XCTAssertEqual(anyElement("settings.automaticUpdateChecks").exists, automatic)
+        XCTAssertEqual(anyElement("settings.automaticUpdateDownloads").exists, automatic)
+        XCTAssertEqual(anyElement("settings.checkForUpdates").exists, automatic)
         XCTAssertFalse(anyElement("settings.appStoreUpdates").exists)
     }
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,15 @@ target is also wallet-free. Existing wallet files and Keychain entries are left
 untouched; wallet data is not automatically imported or migrated. LocusX Gmail sign-in
 is unavailable until its separate Google OAuth registration is configured.
 
-Current editions use **manual app updates**. They do not start the legacy
-app updater, including when old automatic-update preferences are present.
-The previous signed feed stays available to older apps and does not automatically
-move them to the new edition. Separate automatic update feeds remain unconfigured. See the
+Locus release builds support **automatic app updates**: daily checks, background
+downloads, and installation when the app quits. Settings preserves your existing
+update preferences and includes a manual check button. Development builds and
+LocusX remain manual; App Store builds update through the store.
+
+Existing manual installations, including 2.6.0, need one manual upgrade to the
+first update-enabled release. The new Locus feed is separate from the preserved
+legacy feed, so older wallet-era apps are not automatically moved to wallet-free
+Locus. See the
 [editions guide](Docs/Editions.md) for build boundaries and profile details.
 
 ## Models and requirements

--- a/Tools/AuditAppEdition.py
+++ b/Tools/AuditAppEdition.py
@@ -10,6 +10,8 @@ import re
 import subprocess
 from pathlib import Path
 
+from LocusUpdateFeed import validate_configuration
+
 
 class AuditError(RuntimeError):
     pass
@@ -105,10 +107,17 @@ def audit(app: Path, edition: str, allow_missing_runtime: bool = False) -> dict:
     require(edition in schemes, "MCP callback scheme is missing")
     require(({"locus", "locusx"} - {edition}).isdisjoint(schemes), "Other edition's callback is registered")
     mode = info.get("LocusUpdateMode")
-    require(mode in {"manual", "appStore"}, "Local artifact must use manual or App Store updates")
-    require("SUFeedURL" not in info, "Local artifact still registers an app update feed")
+    require(mode in {"manual", "automatic", "appStore"}, "Unknown app update mode")
+    if mode == "automatic":
+        try:
+            validate_configuration(info)
+        except ValueError as exc:
+            raise AuditError(str(exc)) from exc
+    else:
+        require("SUFeedURL" not in info, "Local artifact still registers an app update feed")
+    require(mode != "appStore" or edition == "locus", "Only Locus supports App Store distribution")
     sparkle = contents / "Frameworks/Sparkle.framework"
-    require(sparkle.is_dir() == (mode == "manual"), "Sparkle does not match distribution")
+    require(sparkle.is_dir() == (mode != "appStore"), "Sparkle does not match distribution")
     runtime = contents / "Resources/AgentRuntime/source/ollama_code"
     require(allow_missing_runtime or runtime.is_dir(), "Bundled backend source is missing")
     if runtime.is_dir():

--- a/Tools/AuditDistribution.sh
+++ b/Tools/AuditDistribution.sh
@@ -807,40 +807,7 @@ else
             echo "error: local edition must not register an update feed" >&2; exit 1
         }
     else
-    expected_feed="https://github.com/nahid-sparktales/locus/releases/latest/download/appcast.xml"
-    [[ "$(/usr/bin/plutil -extract SUFeedURL raw -o - "${app}/Contents/Info.plist")" \
-        == "${expected_feed}" ]] || {
-        echo "error: direct-download update feed does not match ${expected_feed}" >&2
-        exit 1
-    }
-    [[ "$(/usr/bin/plutil -extract SUPublicEDKey raw -o - "${app}/Contents/Info.plist")" \
-        == "S/F9z1jR20s26+oHOxVjFend/ajDH04OY8Ietw+IDl4=" ]] || {
-        echo "error: direct-download Sparkle public key is missing or unexpected" >&2
-        exit 1
-    }
-    for boolean_key in \
-        SUAllowsAutomaticUpdates \
-        SUEnableAutomaticChecks \
-        SUAutomaticallyUpdate \
-        SURequireSignedFeed \
-        SUVerifyUpdateBeforeExtraction
-    do
-        [[ "$(/usr/bin/plutil -extract "${boolean_key}" raw -o - \
-            "${app}/Contents/Info.plist")" == "true" ]] || {
-            echo "error: direct-download updater requires ${boolean_key}=true" >&2
-            exit 1
-        }
-    done
-    [[ "$(/usr/bin/plutil -extract SUEnableSystemProfiling raw -o - \
-        "${app}/Contents/Info.plist")" == "false" ]] || {
-        echo "error: direct-download updater must disable anonymous system profiling" >&2
-        exit 1
-    }
-    [[ "$(/usr/bin/plutil -extract SUScheduledCheckInterval raw -o - \
-        "${app}/Contents/Info.plist")" == "86400" ]] || {
-        echo "error: direct-download updater must check every 24 hours" >&2
-        exit 1
-    }
+        python3 "${repo_root}/Tools/LocusUpdateFeed.py" configuration "${info_plist}"
     fi
     /usr/bin/codesign --verify --deep --strict "${sparkle}" || {
         echo "error: Sparkle.framework or a nested updater helper has an invalid signature" >&2

--- a/Tools/GenerateAppcast.sh
+++ b/Tools/GenerateAppcast.sh
@@ -4,14 +4,25 @@
 # it is never accepted on the command line or written inside the repository.
 set -euo pipefail
 
-zip_path="${1:?usage: GenerateAppcast.sh <Locus-macOS.zip> <new appcast.xml> <stable|canary>}"
+zip_path="${1:?usage: GenerateAppcast.sh <Locus-macOS.zip> <new feed.xml> <locus|stable|canary>}"
 appcast_out="${2:?set an explicit new channel-specific appcast output}"
-update_channel="${3:?set the explicit stable or canary update channel}"
-[[ "${update_channel}" == "stable" || "${update_channel}" == "canary" ]] || {
+update_channel="${3:?set the explicit locus, stable, or canary update channel}"
+[[ "${update_channel}" == "locus" || "${update_channel}" == "stable" || "${update_channel}" == "canary" ]] || {
     echo "error: unsupported update channel" >&2; exit 1
 }
 [[ ! -e "${appcast_out}" ]] || { echo "error: appcast output already exists" >&2; exit 1; }
 repo_root="${0:A:h:h}"
+feed_filename="appcast.xml"
+validation_tool="${repo_root}/Tools/WalletUpdateChannel.py"
+validation_arguments=("${update_channel}")
+if [[ "${update_channel}" == "locus" ]]; then
+    feed_filename="appcast-locus.xml"
+    validation_tool="${repo_root}/Tools/LocusUpdateFeed.py"
+    validation_arguments=()
+fi
+[[ "${appcast_out:t}" == "${feed_filename}" ]] || {
+    echo "error: ${update_channel} feed output must be named ${feed_filename}" >&2; exit 1
+}
 sparkle_version="2.9.6"
 sparkle_revision="ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a"
 sparkle_archive_sha256="52bf9e88cdd972fc0c81501377a880e90d47031bd8ca5462488f843e2609e192"
@@ -34,7 +45,7 @@ first_updater_build=17
 # Missing components fail a public (notarized) run outright; a feed-generation
 # dry run only warns, so it does not require building the component first.
 if ! "${repo_root}/Tools/VerifyComponentAssets.sh" "${zip_path:h}" >/dev/null; then
-    if [[ "${LOCUS_NOTARIZE:-0}" == "1" ]]; then
+    if [[ "${LOCUS_NOTARIZE:-0}" == "1" || "${update_channel}" == "locus" ]]; then
         echo "error: refusing to prepare a public appcast without the component assets above." >&2
         exit 1
     fi
@@ -96,6 +107,12 @@ info="${app}/Contents/Info.plist"
     echo "error: local editions cannot be published through the legacy appcast" >&2
     exit 1
 }
+if [[ "${update_channel}" == "locus" ]]; then
+    python3 "${repo_root}/Tools/AuditAppEdition.py" "${app}" --edition locus
+    python3 "${repo_root}/Tools/VerifyLegacyAppcast.py" "${zip_path:h}/appcast.xml" "${info}" >/dev/null
+elif [[ "$(/usr/bin/plutil -extract LocusEdition raw -o - "${info}" 2>/dev/null || true)" == "locus" ]]; then
+    echo "error: wallet-free Locus must use the separate locus feed" >&2; exit 1
+fi
 /usr/bin/codesign --verify --deep --strict "${app}" || {
     echo "error: archived app has an invalid code-signature seal" >&2
     exit 1
@@ -138,7 +155,7 @@ embedded_public_key="$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "${info
     echo "error: archived app has unexpected bundle identifier ${bundle_identifier}" >&2
     exit 1
 }
-python3 "${repo_root}/Tools/WalletUpdateChannel.py" plan "${info}" "${update_channel}" > "${stage}/update-plan.json"
+python3 "${validation_tool}" plan "${info}" "${validation_arguments[@]}" > "${stage}/update-plan.json"
 feed_url="$(/usr/bin/plutil -extract feedURL raw -o - "${stage}/update-plan.json")"
 archive_url="$(/usr/bin/plutil -extract archiveURL raw -o - "${stage}/update-plan.json")"
 if [[ "${update_channel}" == "stable" \
@@ -181,7 +198,7 @@ sparkle_info="${app}/Contents/Frameworks/Sparkle.framework/Resources/Info.plist"
     echo "error: archived app does not contain Sparkle ${sparkle_version}" >&2
     exit 1
 }
-[[ ! -e "${app}/Contents/PlugIns/LocusTests.xctest" ]] || {
+[[ -z "$(/usr/bin/find "${app}" -name '*.xctest' -print)" ]] || {
     echo "error: update archive contains an embedded test bundle" >&2
     exit 1
 }
@@ -214,27 +231,36 @@ notes="${archive_dir}/Locus-macOS.md"
 if (( build > first_updater_build )) || [[ "${update_channel}" == "canary" ]]; then
     echo "Fetching the current signed feed so release history is preserved…"
     http_status="$(/usr/bin/curl --location --show-error --proto '=https' --proto-redir '=https' \
-        --write-out '%{http_code}' "${feed_url}" --output "${archive_dir}/appcast.xml")"
-    if [[ "${http_status}" == "404" && "${update_channel}" == "canary" \
+        --write-out '%{http_code}' "${feed_url}" --output "${archive_dir}/${feed_filename}")"
+    if [[ "${update_channel}" == "locus" ]]; then
+        history_action="$(python3 "${validation_tool}" history-action "${http_status}" "${LOCUS_APPCAST_INITIAL_CHANNEL:-}")"
+    else
+        history_action="verify"
+    fi
+    if [[ "${history_action}" == "initialize" ]] || [[ "${http_status}" == "404" && "${update_channel}" == "canary" \
         && "${LOCUS_APPCAST_INITIAL_CHANNEL:-}" == "canary" ]]; then
-        /bin/rm "${archive_dir}/appcast.xml"
+        /bin/rm "${archive_dir}/${feed_filename}"
     elif [[ "${http_status}" == "200" ]]; then
-        "${sign_update}" --account "${sparkle_key_account}" --verify "${archive_dir}/appcast.xml" >/dev/null || {
+        "${sign_update}" --account "${sparkle_key_account}" --verify "${archive_dir}/${feed_filename}" >/dev/null || {
             echo "error: previous channel feed signature is invalid" >&2; exit 1
         }
-        python3 "${repo_root}/Tools/WalletUpdateChannel.py" verify-feed "${archive_dir}/appcast.xml" "${update_channel}"
+        python3 "${validation_tool}" verify-feed "${archive_dir}/${feed_filename}" "${validation_arguments[@]}"
     else
         echo "error: channel history is unavailable; first canary requires explicit initialization and HTTP 404" >&2; exit 1
     fi
 fi
-if [[ -f "${archive_dir}/appcast.xml" ]]; then
-    previous_build="$(/usr/bin/xmllint --xpath \
-        'string(/*[local-name()="rss"]/*[local-name()="channel"]/*[local-name()="item"][1]/*[local-name()="version"])' \
-        "${archive_dir}/appcast.xml")"
-    [[ "${previous_build}" == <-> && "${build}" -gt "${previous_build}" ]] || {
-        echo "error: build ${build} must be greater than published build ${previous_build:-unknown}" >&2
-        exit 1
-    }
+if [[ -f "${archive_dir}/${feed_filename}" ]]; then
+    if [[ "${update_channel}" == "locus" ]]; then
+        python3 "${validation_tool}" verify-feed "${archive_dir}/${feed_filename}" --newer-build "${build}"
+    else
+        previous_build="$(/usr/bin/xmllint --xpath \
+            'string(/*[local-name()="rss"]/*[local-name()="channel"]/*[local-name()="item"][1]/*[local-name()="version"])' \
+            "${archive_dir}/${feed_filename}")"
+        [[ "${previous_build}" == <-> && "${build}" -gt "${previous_build}" ]] || {
+            echo "error: build ${build} must be greater than published build ${previous_build:-unknown}" >&2
+            exit 1
+        }
+    fi
 fi
 
 download_prefix="${archive_url%Locus-macOS.zip}"
@@ -250,9 +276,9 @@ channel_arguments=()
     --link "https://locushost.co" \
     "${archive_dir}"
 
-generated="${archive_dir}/appcast.xml"
+generated="${archive_dir}/${feed_filename}"
 /usr/bin/xmllint --noout "${generated}"
-python3 "${repo_root}/Tools/WalletUpdateChannel.py" verify-feed "${generated}" "${update_channel}" --info "${info}"
+python3 "${validation_tool}" verify-feed "${generated}" "${validation_arguments[@]}" --info "${info}"
 latest_build="$(/usr/bin/xmllint --xpath \
     'string(/*[local-name()="rss"]/*[local-name()="channel"]/*[local-name()="item"][1]/*[local-name()="version"])' \
     "${generated}")"

--- a/Tools/LocusUpdateFeed.py
+++ b/Tools/LocusUpdateFeed.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Validate the separate wallet-free Locus feed without signing or publishing."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import plistlib
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+FEED_URL = "https://github.com/nahid-sparktales/locus/releases/latest/download/appcast-locus.xml"
+RELEASE_ROOT = "https://github.com/nahid-sparktales/locus/releases/download"
+PUBLIC_KEY = "S/F9z1jR20s26+oHOxVjFend/ajDH04OY8Ietw+IDl4="
+SPARKLE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+LAST_MANUAL_BUILD = 26
+AUTOMATIC_KEYS = (
+    "SUAllowsAutomaticUpdates", "SUAutomaticallyUpdate", "SUEnableAutomaticChecks",
+    "SURequireSignedFeed", "SUVerifyUpdateBeforeExtraction",
+)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def validate_configuration(info: dict) -> None:
+    require(
+        info.get("LocusEdition") == "locus"
+        and info.get("CFBundleIdentifier") == "io.sparktales.locus"
+        and info.get("CFBundleName") == "Locus"
+        and info.get("CFBundleExecutable") == "Locus"
+        and info.get("LocusUpdateMode") == "automatic",
+        "automatic updates require wallet-free Locus with its original identity",
+    )
+    require(info.get("SUFeedURL") == FEED_URL, "Locus must use its separate appcast-locus.xml feed")
+    require(info.get("SUPublicEDKey") == PUBLIC_KEY, "unexpected Locus update public key")
+    for key in AUTOMATIC_KEYS:
+        require(info.get(key) is True, f"automatic Locus requires {key}=true")
+    require(info.get("SUEnableSystemProfiling") is False, "system profiling must remain disabled")
+    require(info.get("SUScheduledCheckInterval") == 86400, "Locus must check daily")
+    require(info.get("SUScheduledImpatientCheckInterval") == 604800, "Locus must retain its weekly reminder")
+    require(
+        not any(key.startswith(("LocusWallet", "LocusCanary", "LocusReown", "LocusPhantom")) for key in info),
+        "wallet configuration cannot enter the Locus feed",
+    )
+
+
+def release_identity(version: str, build: str) -> None:
+    require(bool(re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version)), "invalid Locus release version")
+    require(bool(re.fullmatch(r"[0-9]+", build)), "invalid Locus release build")
+    require(int(build) > LAST_MANUAL_BUILD, "automatic Locus releases must exceed build 26")
+
+
+def plan(info: dict) -> dict:
+    validate_configuration(info)
+    version, build = str(info.get("CFBundleShortVersionString", "")), str(info.get("CFBundleVersion", ""))
+    release_identity(version, build)
+    return {
+        "channel": "locus", "feedURL": FEED_URL,
+        "archiveURL": f"{RELEASE_ROOT}/v{version}/Locus-macOS.zip",
+        "version": version, "build": build, "candidate": False,
+    }
+
+
+def verify_feed(path: Path, *, expected: dict | None = None, newer_build: int | None = None) -> None:
+    data = path.read_bytes()
+    require(0 < len(data) <= 8 * 1024 * 1024, "invalid Locus appcast size")
+    require(b"<!DOCTYPE" not in data.upper() and b"<!ENTITY" not in data.upper(), "appcast declarations are unavailable")
+    root = ET.fromstring(data)
+    require(root.tag == "rss" and len(root.findall("channel")) == 1, "invalid Locus appcast root")
+    items = root.findall("channel/item")
+    require(0 < len(items) <= 128, "empty or oversized Locus appcast history")
+    require(list(root.iter("item")) == items, "appcast contains an item outside its channel")
+    require(not list(root.iter(f"{{{SPARKLE}}}channel")), "Locus feed cannot contain wallet or prerelease channels")
+    builds: set[int] = set()
+    enclosures = []
+    for item in items:
+        versions = item.findall(f"{{{SPARKLE}}}shortVersionString")
+        numbers = item.findall(f"{{{SPARKLE}}}version")
+        require(len(versions) == len(numbers) == 1, "ambiguous Locus release identity")
+        version, build = versions[0].text or "", numbers[0].text or ""
+        release_identity(version, build)
+        require(int(build) not in builds, "duplicate Locus release build")
+        builds.add(int(build))
+        entries = item.findall("enclosure")
+        require(len(entries) == 1, "ambiguous Locus archive")
+        enclosure = entries[0]
+        require(
+            enclosure.get("url") == f"{RELEASE_ROOT}/v{version}/Locus-macOS.zip",
+            "Locus archive must use its version-pinned release URL",
+        )
+        length = enclosure.get("length", "")
+        require(bool(re.fullmatch(r"[0-9]+", length)) and int(length) > 0, "invalid archive length")
+        try:
+            signature = base64.b64decode(enclosure.get(f"{{{SPARKLE}}}edSignature", ""), validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise ValueError("invalid archive signature") from exc
+        require(len(signature) == 64, "missing or invalid archive signature")
+        enclosures.append(enclosure)
+    require(list(root.iter("enclosure")) == enclosures, "appcast contains an unvalidated archive or delta")
+    if newer_build is not None:
+        require(newer_build > max(builds), "new Locus build must exceed every published build")
+    if expected is not None:
+        newest = items[0]
+        require(
+            newest.findtext(f"{{{SPARKLE}}}version") == expected["build"]
+            and newest.findtext(f"{{{SPARKLE}}}shortVersionString") == expected["version"]
+            and enclosures[0].get("url") == expected["archiveURL"]
+            and int(expected["build"]) == max(builds),
+            "generated Locus feed does not lead with the packaged release",
+        )
+
+
+def history_action(http_status: str, initial_channel: str) -> str:
+    if http_status == "200":
+        return "verify"
+    require(http_status == "404" and initial_channel == "locus",
+            "Locus history unavailable; initialization requires LOCUS_APPCAST_INITIAL_CHANNEL=locus and HTTP 404")
+    return "initialize"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="operation", required=True)
+    for name in ("configuration", "plan"):
+        command = commands.add_parser(name)
+        command.add_argument("info", type=Path)
+    command = commands.add_parser("verify-feed")
+    command.add_argument("path", type=Path)
+    command.add_argument("--info", type=Path)
+    command.add_argument("--newer-build", type=int)
+    command = commands.add_parser("history-action")
+    command.add_argument("http_status")
+    command.add_argument("initial_channel")
+    args = parser.parse_args()
+    try:
+        if args.operation == "history-action":
+            print(history_action(args.http_status, args.initial_channel))
+        elif args.operation == "verify-feed":
+            expected = plan(plistlib.loads(args.info.read_bytes())) if args.info else None
+            verify_feed(args.path, expected=expected, newer_build=args.newer_build)
+        else:
+            info = plistlib.loads(args.info.read_bytes())
+            if args.operation == "plan":
+                print(json.dumps(plan(info)))
+            else:
+                validate_configuration(info)
+    except (OSError, ValueError, ET.ParseError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/PackageRelease.sh
+++ b/Tools/PackageRelease.sh
@@ -44,8 +44,17 @@ if [[ "${public_manual_release}" == "1" ]]; then
 elif [[ "${update_mode}" == "manual" && "${LOCUS_NOTARIZE:-0}" == "1" ]]; then
     echo "error: local editions require a separate release/feed setup before publication" >&2; exit 1
 fi
+public_locus_release=0
+if [[ "${edition}" == "locus" && "${update_mode}" == "automatic" && "${LOCUS_NOTARIZE:-0}" == "1" ]]; then
+    public_locus_release=1
+    # Validate routing and the first publishable build before changing the app.
+    python3 "${repo_root}/Tools/LocusUpdateFeed.py" plan "${info_plist}" >/dev/null
+    [[ ! -e "${zip_out:h}/appcast-locus.xml" ]] || {
+        echo "error: new Locus feed output already exists" >&2; exit 1
+    }
+fi
 legacy_feed_sha=""
-if [[ "${public_manual_release}" == "1" ]]; then
+if [[ "${public_manual_release}" == "1" || "${public_locus_release}" == "1" ]]; then
     legacy_feed_sha="$(python3 "${repo_root}/Tools/VerifyLegacyAppcast.py" \
         "${zip_out:h}/appcast.xml" "${info_plist}")"
 fi
@@ -437,7 +446,10 @@ fi
 /usr/bin/shasum -a 256 "${zip_out}"
 /bin/ls -lh "${zip_out}"
 if [[ "${LOCUS_NOTARIZE:-0}" == "1" ]]; then
-    if [[ "${public_manual_release}" == "1" ]]; then
+    if [[ "${public_locus_release}" == "1" ]]; then
+        "${repo_root}/Tools/GenerateAppcast.sh" "${zip_out}" "${zip_out:h}/appcast-locus.xml" locus
+    fi
+    if [[ "${public_manual_release}" == "1" || "${public_locus_release}" == "1" ]]; then
         # Recheck both signature and bytes after the notarization wait. Never
         # rewrite or re-sign the feed copied from the prior public release.
         final_feed_sha="$(python3 "${repo_root}/Tools/VerifyLegacyAppcast.py" \
@@ -445,9 +457,15 @@ if [[ "${LOCUS_NOTARIZE:-0}" == "1" ]]; then
         [[ "${final_feed_sha}" == "${legacy_feed_sha}" ]] || {
             echo "error: preserved legacy appcast changed during packaging" >&2; exit 1
         }
-        echo "Preserved the signed legacy appcast; this manual release is not offered by Sparkle."
+        echo "Preserved the signed legacy appcast; this release is never offered on the old feed."
     else
         "${repo_root}/Tools/GenerateAppcast.sh" "${zip_out}" "${zip_out:h}/appcast.xml" stable
+    fi
+    # Recheck companion assets after signing/notarization, before declaring the
+    # staging directory ready to upload.
+    "${repo_root}/Tools/VerifyComponentAssets.sh" "${zip_out:h}" >/dev/null
+    if [[ "${public_locus_release}" == "1" ]]; then
+        echo "Include the new appcast-locus.xml alongside the preserved appcast.xml."
     fi
     echo "Upload Locus-macOS.zip, appcast.xml, components.json, and" \
         "${(j:, :)component_archives} to the same draft GitHub release."

--- a/Tools/VerifyLegacyAppcast.py
+++ b/Tools/VerifyLegacyAppcast.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Read-only gate for retaining an old signed feed beside a manual Locus release.
+"""Read-only gate for retaining the legacy feed beside a wallet-free Locus release.
 
 Old installed apps still request releases/latest/download/appcast.xml. Every
 enclosure must remain pinned to an earlier release, never the new latest ZIP.
@@ -18,10 +18,15 @@ import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from LocusUpdateFeed import validate_configuration
+
 SPARKLE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
 PUBLIC_KEY = "S/F9z1jR20s26+oHOxVjFend/ajDH04OY8Ietw+IDl4="
 KEY_ACCOUNT = "io.sparktales"
 RELEASE_ROOT = "https://github.com/nahid-sparktales/locus/releases/download"
+# The exact signed feed retained by public v2.6.0. Automatic Locus must never
+# replace this with a newly signed feed, even one that contains older builds.
+LEGACY_FEED_SHA256 = "fabc1d4450afce04a5931bde6dc9630994f7748d512d73a8a600630b52696ece"
 
 
 def require(condition: bool, message: str) -> None:
@@ -35,12 +40,17 @@ def version_tuple(value: str) -> tuple[int, ...]:
 
 
 def validate(feed: bytes, info: dict) -> None:
+    automatic = info.get("LocusUpdateMode") == "automatic"
     require(
         info.get("LocusEdition") == "locus"
-        and info.get("LocusUpdateMode") == "manual"
+        and info.get("LocusUpdateMode") in {"manual", "automatic"}
         and info.get("CFBundleIdentifier") == "io.sparktales.locus",
-        "preserving the legacy feed is limited to wallet-free manual Locus",
+        "preserving the legacy feed is limited to wallet-free Locus",
     )
+    if automatic:
+        validate_configuration(info)
+        require(hashlib.sha256(feed).hexdigest() == LEGACY_FEED_SHA256,
+                "legacy appcast must remain byte-for-byte identical to v2.6.0")
     current_version = version_tuple(str(info.get("CFBundleShortVersionString", "")))
     current_build = str(info.get("CFBundleVersion", ""))
     require(current_build.isascii() and current_build.isdecimal(), "invalid release build")

--- a/agent/tests/test_app_edition_artifact.py
+++ b/agent/tests/test_app_edition_artifact.py
@@ -8,6 +8,7 @@ import pytest
 from artifact_fixtures import make_synthetic_app, write_info
 
 ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "Tools"))
 SPEC = importlib.util.spec_from_file_location("app_edition_audit", ROOT / "Tools/AuditAppEdition.py")
 audit = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(audit)

--- a/agent/tests/test_locus_update_feed.py
+++ b/agent/tests/test_locus_update_feed.py
@@ -1,0 +1,217 @@
+"""Release configuration, feed isolation and publication gates, all offline."""
+
+import base64
+import plistlib
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+from artifact_fixtures import make_synthetic_app, write_info
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "Tools"))
+import AuditAppEdition as audit  # noqa: E402
+import LocusUpdateFeed as feed  # noqa: E402
+
+
+def release_info(**changes):
+    info = plistlib.loads((ROOT / "Config/LocusRelease-Info.plist").read_bytes())
+    info.update(
+        CFBundleName="Locus", CFBundleExecutable="Locus", CFBundleIdentifier="io.sparktales.locus",
+        CFBundleShortVersionString="2.7.0", CFBundleVersion="27",
+    )
+    info.update(changes)
+    return info
+
+
+def appcast(tmp_path, builds=(27,), **enclosure_changes):
+    root = ET.Element("rss")
+    channel = ET.SubElement(root, "channel")
+    for build in builds:
+        item = ET.SubElement(channel, "item")
+        ET.SubElement(item, f"{{{feed.SPARKLE}}}version").text = str(build)
+        ET.SubElement(item, f"{{{feed.SPARKLE}}}shortVersionString").text = f"2.{build - 20}.0"
+        attributes = {
+            "url": f"{feed.RELEASE_ROOT}/v2.{build - 20}.0/Locus-macOS.zip", "length": "123",
+            f"{{{feed.SPARKLE}}}edSignature": base64.b64encode(b"x" * 64).decode(),
+        }
+        attributes.update(enclosure_changes)
+        ET.SubElement(item, "enclosure", attributes)
+    path = tmp_path / "appcast-locus.xml"
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+    return path
+
+
+def test_release_plist_changes_only_the_explicit_update_configuration():
+    development = plistlib.loads((ROOT / "Locus/Info.plist").read_bytes())
+    release = plistlib.loads((ROOT / "Config/LocusRelease-Info.plist").read_bytes())
+    assert release.pop("SUFeedURL") == feed.FEED_URL
+    assert release["LocusUpdateMode"] == "automatic"
+    release["LocusUpdateMode"] = "manual"
+    for key in ("SUAllowsAutomaticUpdates", "SUAutomaticallyUpdate", "SUEnableAutomaticChecks"):
+        assert release[key] is True
+        release[key] = False
+    assert release == development
+    for name in ("LocusX", "LocusExperimental"):
+        info = plistlib.loads((ROOT / f"Config/{name}-Info.plist").read_bytes())
+        assert info["LocusUpdateMode"] == "manual"
+        assert "SUFeedURL" not in info
+    mas = plistlib.loads((ROOT / "Config/LocusMAS-Info.plist").read_bytes())
+    assert mas["LocusUpdateMode"] == "appStore"
+    assert not any(key.startswith("SU") for key in mas)
+
+
+def test_release_plan_uses_only_the_new_feed_and_pinned_zip():
+    result = feed.plan(release_info())
+    assert result["feedURL"] == feed.FEED_URL
+    assert result["archiveURL"] == f"{feed.RELEASE_ROOT}/v2.7.0/Locus-macOS.zip"
+    assert result["candidate"] is False
+
+
+@pytest.mark.parametrize("field,value", [
+    ("LocusEdition", "locusx"), ("CFBundleIdentifier", "io.sparktales.locusx"),
+    ("CFBundleName", "LocusX"), ("CFBundleExecutable", "LocusX"),
+    ("LocusUpdateMode", "manual"), ("LocusUpdateMode", "appStore"),
+    ("SUFeedURL", feed.FEED_URL.replace("appcast-locus.xml", "appcast.xml")),
+    ("SUFeedURL", "https://example.invalid/appcast-locus.xml"),
+    ("SUFeedURL", ""), ("SUPublicEDKey", "unknown"),
+    ("SURequireSignedFeed", False), ("SUVerifyUpdateBeforeExtraction", False),
+    ("SUAutomaticallyUpdate", "true"), ("SUEnableSystemProfiling", True),
+    ("SUScheduledCheckInterval", 60), ("LocusWalletCandidateArchiveURL", "https://example.invalid/candidate.zip"),
+])
+def test_automatic_artifact_rejects_wrong_identity_routing_and_security(tmp_path, monkeypatch, field, value):
+    app, _ = make_synthetic_app(tmp_path)
+    write_info(app, release_info(**{field: value}))
+    monkeypatch.setattr(audit, "inspect_output", lambda _: "_main\n")
+    with pytest.raises((audit.AuditError, ValueError)):
+        audit.audit(app, "locus")
+
+
+def test_audit_accepts_automatic_locus_before_a_release_version_bump(tmp_path, monkeypatch):
+    app, _ = make_synthetic_app(tmp_path)
+    info = release_info(CFBundleVersion="26", CFBundleShortVersionString="2.6.0")
+    write_info(app, info)
+    monkeypatch.setattr(audit, "inspect_output", lambda _: "_main\n")
+    assert audit.audit(app, "locus")["passed"]
+    with pytest.raises(ValueError, match="exceed build 26"):
+        feed.plan(info)
+
+
+@pytest.mark.parametrize("build", ["", "26", "24", "-1", "27.1", "not-a-build"])
+def test_only_new_numeric_builds_are_publishable(build):
+    with pytest.raises(ValueError):
+        feed.plan(release_info(CFBundleVersion=build))
+
+
+def test_feed_preserves_separate_history_and_matches_the_packaged_app(tmp_path):
+    path = appcast(tmp_path, (29, 28, 27))
+    expected = feed.plan(release_info(CFBundleVersion="29", CFBundleShortVersionString="2.9.0"))
+    feed.verify_feed(path, expected=expected)
+    feed.verify_feed(path, newer_build=30)
+    with pytest.raises(ValueError, match="packaged release"):
+        feed.verify_feed(path, expected=feed.plan(release_info()))
+
+
+def test_build_must_exceed_every_entry_even_when_history_is_unordered(tmp_path):
+    path = appcast(tmp_path, (27, 30, 28))
+    with pytest.raises(ValueError, match="every published build"):
+        feed.verify_feed(path, newer_build=29)
+
+
+@pytest.mark.parametrize("builds", [(27, 27), (26,), ()])
+def test_feed_rejects_duplicates_manual_history_and_empty_history(tmp_path, builds):
+    with pytest.raises(ValueError):
+        feed.verify_feed(appcast(tmp_path, builds))
+
+
+@pytest.mark.parametrize("changes", [
+    {"url": feed.FEED_URL},
+    {"url": f"{feed.RELEASE_ROOT}/v2.8.0/Locus-macOS.zip"},
+    {"url": f"{feed.RELEASE_ROOT}/v2.7.0/LocusX-macOS.zip"},
+    {"url": f"{feed.RELEASE_ROOT}/v2.7.0/Locus-macOS.zip?latest=1"},
+    {"url": "https://github.com/nahid-sparktales/locus/releases/latest/download/Locus-macOS.zip"},
+    {"length": "0"}, {f"{{{feed.SPARKLE}}}edSignature": ""},
+    {f"{{{feed.SPARKLE}}}edSignature": "garbage"},
+])
+def test_feed_rejects_unpinned_archives_and_missing_signatures(tmp_path, changes):
+    with pytest.raises(ValueError):
+        feed.verify_feed(appcast(tmp_path, **changes))
+
+
+@pytest.mark.parametrize("mutation", ["channel", "extra_archive", "extra_item", "dtd", "invalid_xml"])
+def test_feed_rejects_wallet_channels_and_ambiguous_xml(tmp_path, mutation):
+    path = appcast(tmp_path)
+    root = ET.parse(path).getroot()
+    if mutation == "channel":
+        ET.SubElement(root.find("channel/item"), f"{{{feed.SPARKLE}}}channel").text = "canary"
+    elif mutation == "extra_archive":
+        ET.SubElement(root, "enclosure", {"url": "https://example.invalid/unverified.zip"})
+    elif mutation == "extra_item":
+        ET.SubElement(root, "item")
+    ET.ElementTree(root).write(path)
+    if mutation == "dtd":
+        path.write_bytes(b'<!DOCTYPE rss [<!ENTITY injected "update">]>' + path.read_bytes())
+    elif mutation == "invalid_xml":
+        path.write_bytes(b"<rss>")
+    with pytest.raises((ValueError, ET.ParseError)):
+        feed.verify_feed(path)
+
+
+@pytest.mark.parametrize("status,initial", [("404", ""), ("404", "canary"), ("500", "locus"), ("000", "locus"), ("403", "locus")])
+def test_first_feed_requires_explicit_initialization_and_a_real_404(status, initial):
+    with pytest.raises(ValueError, match="initialization requires"):
+        feed.history_action(status, initial)
+
+
+def test_existing_feed_must_be_verified_even_during_initialization():
+    assert feed.history_action("404", "locus") == "initialize"
+    assert feed.history_action("200", "locus") == "verify"
+    assert feed.history_action("200", "") == "verify"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS release scripts")
+@pytest.mark.parametrize("channel,filename", [("locus", "appcast.xml"), ("stable", "appcast-locus.xml"), ("canary", "appcast-locus.xml")])
+def test_generator_rejects_cross_feed_outputs_before_using_signing_keys(tmp_path, channel, filename):
+    result = subprocess.run(
+        ["zsh", str(ROOT / "Tools/GenerateAppcast.sh"), str(tmp_path / "Locus-macOS.zip"), str(tmp_path / filename), channel],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "feed output must be named" in result.stderr
+    assert not (tmp_path / filename).exists()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS release scripts")
+def test_generator_requires_component_assets_before_using_signing_keys(tmp_path):
+    (tmp_path / "Locus-macOS.zip").touch()
+    result = subprocess.run(
+        ["zsh", str(ROOT / "Tools/GenerateAppcast.sh"), str(tmp_path / "Locus-macOS.zip"), str(tmp_path / "appcast-locus.xml"), "locus"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "without the component assets" in result.stderr
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS release scripts")
+@pytest.mark.parametrize("changes,expected", [
+    ({"CFBundleVersion": "26"}, "exceed build 26"),
+    ({"SUFeedURL": feed.FEED_URL.replace("appcast-locus", "appcast")}, "separate appcast-locus.xml"),
+    ({"SUPublicEDKey": "wrong"}, "public key"),
+    ({}, "cannot preserve legacy appcast"),
+])
+def test_automatic_public_packaging_rejects_invalid_staging_before_mutating_app(tmp_path, changes, expected):
+    app, _ = make_synthetic_app(tmp_path)
+    write_info(app, release_info(**changes))
+    plist = app / "Contents/Info.plist"
+    original = plist.read_bytes()
+    result = subprocess.run(
+        ["zsh", str(ROOT / "Tools/PackageRelease.sh"), str(app), str(tmp_path / "Locus-macOS.zip")],
+        env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin", "LOCUS_NOTARIZE": "1"},
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert expected in result.stderr
+    assert plist.read_bytes() == original
+    assert not (tmp_path / "Locus-macOS.zip").exists()

--- a/agent/tests/test_manual_release_packaging.py
+++ b/agent/tests/test_manual_release_packaging.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "Tools"))
 SPEC = importlib.util.spec_from_file_location("legacy_appcast", ROOT / "Tools/VerifyLegacyAppcast.py")
 legacy = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(legacy)
@@ -63,11 +64,11 @@ def test_legacy_feed_cannot_offer_the_new_manual_build(version, build):
 
 
 @pytest.mark.parametrize("changes", [
-    {"LocusEdition": "locusx"}, {"LocusUpdateMode": "automatic"},
+    {"LocusEdition": "locusx"}, {"LocusUpdateMode": "unknown"},
     {"CFBundleIdentifier": "io.sparktales.locusx"},
 ])
 def test_legacy_feed_preservation_cannot_publish_another_edition(changes):
-    with pytest.raises(ValueError, match="wallet-free manual Locus"):
+    with pytest.raises(ValueError, match="wallet-free Locus"):
         legacy.validate(feed(), info(**changes))
 
 
@@ -238,3 +239,23 @@ def test_manual_public_archive_requires_canonical_app_name(signed_app):
     app.rename(renamed)
     with pytest.raises(ValueError, match="contain Locus.app"):
         public_app.verify(renamed)
+
+
+def test_automatic_release_preserves_only_the_frozen_legacy_feed(verifier, monkeypatch):
+    from test_locus_update_feed import release_info
+
+    path, tools, _ = verifier
+    original = path.read_bytes()
+    monkeypatch.setattr(legacy, "LEGACY_FEED_SHA256", hashlib.sha256(original).hexdigest())
+    assert legacy.verify(path, release_info(), tools) == legacy.LEGACY_FEED_SHA256
+    path.write_bytes(original + b"\n")
+    with pytest.raises(ValueError, match="byte-for-byte identical to v2.6.0"):
+        legacy.verify(path, release_info(), tools)
+
+
+def test_automatic_release_cannot_preserve_legacy_feed_with_legacy_routing(verifier):
+    from test_locus_update_feed import release_info
+
+    path, tools, _ = verifier
+    with pytest.raises(ValueError, match="separate appcast-locus.xml"):
+        legacy.verify(path, release_info(SUFeedURL="https://github.com/nahid-sparktales/locus/releases/latest/download/appcast.xml"), tools)

--- a/project.yml
+++ b/project.yml
@@ -297,6 +297,9 @@ targets:
       configs:
         Debug:
           CODE_SIGN_STYLE: Automatic
+        Release:
+          INFOPLIST_FILE: Config/LocusRelease-Info.plist
+          LOCUS_UPDATE_MODE: automatic
     scheme:
       testTargets:
         - LocusTests
@@ -495,6 +498,19 @@ targets:
         TEST_TARGET_NAME: LocusMAS
         GENERATE_INFOPLIST_FILE: YES
 schemes:
+  # Release UI verification must not compile the Debug-only unit-test helpers.
+  LocusReleaseUpdates:
+    build:
+      targets:
+        Locus: all
+    run:
+      config: Release
+    test:
+      config: Release
+      environmentVariables:
+        LOCUS_EXPECT_AUTOMATIC_UPDATES: "1"
+      targets:
+        - LocusUITests
   LocusExperimental:
     build:
       targets:


### PR DESCRIPTION
## Summary

Enables automatic app updates for released wallet-free Locus through a separate, signed Sparkle feed, while keeping every other configuration manual and leaving the legacy wallet-era feed untouched.

- **Release configuration:** the `Locus` target's `Release` configuration now uses `Config/LocusRelease-Info.plist` (`LocusUpdateMode=automatic`, `SUFeedURL` = `releases/latest/download/appcast-locus.xml`, daily checks, background downloads, signed-feed and pre-extraction verification, no system profiling). Debug builds, LocusX, and LocusExperimental stay manual; the App Store build updates through the store.
- **Updater:** `AppUpdateConfiguration` validates edition, bundle identifier, update mode and feed from the sealed bundle, so a saved legacy feed URL in UserDefaults can never redirect the updater; the Sparkle driver takes its feed from that configuration and only the LocusX candidate path consults the wallet update authority.
- **Release tooling:** new `Tools/LocusUpdateFeed.py` validates the release configuration, plans version-pinned archive URLs, verifies feed history (no wallet channels, no unvalidated enclosures, strictly increasing builds), and gates first-feed initialization on an explicit HTTP 404. `GenerateAppcast.sh` gains the `locus` channel, `PackageRelease.sh` runs it for notarized automatic releases, `AuditAppEdition.py`/`AuditDistribution.sh` accept the automatic mode, and `VerifyLegacyAppcast.py` pins the legacy `appcast.xml` to its v2.6.0 bytes for automatic releases.
- **CI:** the standard native job adds a Release-configuration UI check through the new `LocusReleaseUpdates` scheme (`testUpdatesSettingsMatchTheBuildDistribution`), which asserts the update controls match the build's distribution without starting Sparkle.
- **Docs:** `Docs/Editions.md` gains the automatic-release procedure (one manual upgrade is required from 2.6.0 and earlier) and the README describes the new behaviour.

## Verification

- `agent/tests/test_locus_update_feed.py`, `test_manual_release_packaging.py`, `test_app_edition_artifact.py`: 133 passed; ruff clean; zsh syntax checks pass for the three release scripts.
- `LocusTests.AppUpdateControllerTests`: 14 passed (injected host); `FeatureLogicTests`: 291 passed.
- Debug `build-for-testing` succeeds; the Release configuration built through `LocusReleaseUpdates` embeds the automatic-update plist and passes `Tools/AuditAppEdition.py --edition locus --allow-missing-runtime` (see the CI job for the Release UI check, which cannot run locally with Developer Mode off).

## Notes

- This changes no version or build number; the first automatic release must use a build greater than 26 and follow the procedure in `Docs/Editions.md`.
- Based on `main` after #77; the README keeps both that PR's docs link and the new update text.
