### PR TITLE
Improve right-panel performance and add sidebar update access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Check for Updates in the sidebar gear menu. Manual-update and App Store
+  builds open their Software Updates settings from the same menu.
+
+### Fixed
+
+- Restoring an expanded right panel no longer stalls beside a large Markdown
+  answer. Long histories retain lazy rendering, and populated chats avoid
+  repeated animated text reflow during panel changes.
+- Divider drags avoid unrelated chat refreshes, and returning to Files reuses
+  pending scans and completed empty indexes.
+
 ## 2.7.0 — 2026-09-08
 
 ### Added

--- a/Docs/PanelPerformanceAudit.md
+++ b/Docs/PanelPerformanceAudit.md
@@ -1,0 +1,69 @@
+# Right-panel performance audit
+
+September 9, 2026. Scope: opening and switching right-side panels, expanding
+and restoring them, and dragging their divider with an existing long chat.
+
+## Changes
+
+| Finding | Change |
+| --- | --- |
+| A four-row chat containing a 36-section Markdown answer entered a sustained SwiftUI layout loop when restoring an expanded panel. Width stabilization alone did not resolve it; removing lazy height estimation for that short transcript did. | Lay out up to 40 presentation rows eagerly, retaining lazy rendering for longer histories. Give both columns resolved widths and give transcript text a finite viewport-based wrapping width. Streaming text also handles unspecified and infinite measurement proposals. |
+| Inspector, sidebar, and expanded-chat widths published through `AppModel` on every pointer event, invalidating unrelated conversation and panel views. | Widths now publish through `WorkspaceLayoutModel`. Views observe that owner directly; commands retain compatibility accessors. Repeated clamped widths do not publish. Settings are saved on release. |
+| `ConversationView.body` allocated and filled an indexed row array for the entire transcript whenever unrelated state refreshed the view. | Indexed rows and session-scoped scroll identities are created once with the immutable transcript snapshot and reused across layout, tab, and selection changes. Session renames preserve their storage; content and session replacements update them coherently. |
+| Spring-driven panel geometry repeatedly rewrapped native text in populated chats. A single large answer can contain many text views despite having few transcript rows. | Panel layout changes use their final geometry immediately at 100 presentation items or 16 KiB of stored answer/reasoning/tool-detail text. Short chats retain the shared panel animation. Reduce Motion also selects immediate layout. The policy is computed at transcript commit time, not during resizing. |
+| Returning to Files while indexing cancelled the waiting task but could leave its detached disk scan running alongside another scan. Empty results also triggered repeated scans. | Reuse an in-flight scan for the same workspace and cache empty completed indexes. Explicit refresh, invalidation, workspace changes, and cancellation retain their generation checks. |
+
+The sidebar gear menu now includes **Check for Updates…** for automatic-update
+builds, connected to the existing update controller and its enabled state.
+Manual and App Store builds expose **Software Updates…**, which opens the
+appropriate Settings page. The compact sidebar receives the same controller.
+
+## Verification
+
+Regression coverage includes a 500-block transcript with 300 divider updates,
+shared row-storage identity, replacement/rename behavior, long-answer layout
+policy, overlapping and empty file scans, saved widths, transcript selection,
+scroll following, the transition between eager and lazy history, and native
+text rewrapping. The UI stress fixture exercises
+Files, Terminal, and repeated Browser expansion/restoration beside a 36-section
+answer, preserving the address draft.
+
+Native and UI runs use an isolated test app identity so the installed Locus
+can remain open. The UI test copy loads its bundled frameworks instead of
+overriding their paths with the build directory. The 36-section stress test
+now completes all three expansion/restoration cycles and preserves the address
+draft; the earlier lazy-only version repeatedly timed out at 120 seconds.
+This comparison demonstrates resolution of that stall, not a general timing
+benchmark. The final native behavior run passed all 148 tests, including the
+600-message virtualization check and the eager/lazy history transition.
+
+All six selected UI tests also passed: long-answer expansion/restoration,
+compact-window overlay sidebar, Context panel state, overflowing panel tabs,
+live resize, and the sidebar update menu. The final run therefore passed
+**154 tests with zero failures**. The Debug build, design-system audit, and
+`git diff --check` passed. Two source observation-boundary checks passed
+directly after the isolated native test host stalled opening the source
+directory; those checks are outside the 154-test total.
+
+The existing live-resize sampler recorded 24 samples on the default 12-section
+fixture: 0.633 ms p95 main-thread work, 5.440 ms maximum, and a settled width of
+1003 points. These are advisory measurements from this machine and test run,
+not display-frame timings or a before/after release benchmark.
+
+The update check itself was not sent to the release server; the UI test
+verified the manual-build Settings destination, and controller unit tests
+covered update availability and configuration.
+
+## Limits
+
+This removes redundant invalidation, allocation, scanning, and intermediate
+animated reflow. Text still needs an exact layout at the final width; a very
+large individual answer can therefore still cost more than a short one.
+Streaming parsing, native browser/terminal rendering, and backend response
+latency have separate owners and are not accelerated by these changes.
+
+The 40-row eager-layout boundary and animation thresholds are conservative
+heuristics. Eager layout trades a bounded number of mounted rows for exact
+heights; long histories retain virtualization. These are not a hardware-specific
+frame-rate guarantee. Tests establish structural savings and correctness;
+they do not establish an end-to-end percentage speedup against a release build.

--- a/Locus/AppFeatureEnvironment.swift
+++ b/Locus/AppFeatureEnvironment.swift
@@ -39,9 +39,29 @@ struct WorkspaceGeometrySnapshot: Equatable {
 @MainActor
 final class WorkspaceLayoutModel: ObservableObject {
     @Published private(set) var isLiveResizing = false
+    @Published private(set) var inspectorWidth = CGFloat(AppSettings.defaultInspectorWidth)
+    @Published private(set) var sidebarWidth = CGFloat(AppSettings.defaultSidebarWidth)
+    @Published private(set) var zoomedChatWidth = CGFloat(AppSettings.defaultZoomedChatWidth)
     private(set) var geometry = WorkspaceGeometrySnapshot.empty
 
     lazy var liveResizeCoordinator = LiveResizeCoordinator(layout: self)
+
+    // Pointer movement belongs to layout, not the application-wide publisher.
+    // Ignore repeated clamped values when the pointer moves past a limit.
+    func setInspectorWidth(_ width: CGFloat) {
+        let width = CGFloat(AppSettings.clampInspectorWidth(Double(width)))
+        if inspectorWidth != width { inspectorWidth = width }
+    }
+
+    func setSidebarWidth(_ width: CGFloat) {
+        let width = CGFloat(AppSettings.clampSidebarWidth(Double(width)))
+        if sidebarWidth != width { sidebarWidth = width }
+    }
+
+    func setZoomedChatWidth(_ width: CGFloat) {
+        let width = CGFloat(AppSettings.clampZoomedChatWidth(Double(width)))
+        if zoomedChatWidth != width { zoomedChatWidth = width }
+    }
 
     func updateGeometry(_ snapshot: WorkspaceGeometrySnapshot) {
         geometry = snapshot

--- a/Locus/AppModel+InspectorLayout.swift
+++ b/Locus/AppModel+InspectorLayout.swift
@@ -289,7 +289,7 @@ extension AppModel {
     /// Live width during a drag. Persistence waits for release so the settings
     /// writer is not restarted on every pointer movement.
     func setSidebarWidth(_ width: CGFloat) {
-        sidebarWidth = CGFloat(AppSettings.clampSidebarWidth(Double(width)))
+        workspaceLayout.setSidebarWidth(width)
     }
 
     func commitSidebarWidth() {
@@ -304,7 +304,7 @@ extension AppModel {
     /// Live width during a drag. Deliberately does not persist — see
     /// `commitInspectorWidth()`.
     func setInspectorWidth(_ width: CGFloat) {
-        inspectorWidth = CGFloat(AppSettings.clampInspectorWidth(Double(width)))
+        workspaceLayout.setInspectorWidth(width)
     }
 
     /// Called once when a drag ends. Writing on every frame would restart the
@@ -316,7 +316,7 @@ extension AppModel {
     /// Live width of the chat column during a zoomed-divider drag. Same
     /// commit-on-release contract as `setInspectorWidth`.
     func setZoomedChatWidth(_ width: CGFloat) {
-        zoomedChatWidth = CGFloat(AppSettings.clampZoomedChatWidth(Double(width)))
+        workspaceLayout.setZoomedChatWidth(width)
     }
 
     func commitZoomedChatWidth() {

--- a/Locus/AppModel+UITestFixtures.swift
+++ b/Locus/AppModel+UITestFixtures.swift
@@ -458,7 +458,10 @@ extension AppModel {
                 )
                 return "- `\(name)` — source file with a description that wraps in a narrow conversation."
             }.joined(separator: "\n")
-            let prose = (0..<12).map { index in
+            let sectionCount = min(max(Int(ProcessInfo.processInfo.environment[
+                "LOCUS_UI_TESTING_PERFORMANCE_SECTIONS"
+            ] ?? "") ?? 12, 1), 60)
+            let prose = (0..<sectionCount).map { index in
                 """
                 ## Performance section \(index + 1)
 

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -351,15 +351,26 @@ final class AppModel: ObservableObject {
             if inspectorCollapsed { setInspectorZoomed(false) }
         }
     }
-    @Published var inspectorWidth: CGFloat = CGFloat(AppSettings.defaultInspectorWidth)  // internal(for: AppModel extension files)
-    @Published var sidebarWidth: CGFloat = CGFloat(AppSettings.defaultSidebarWidth)  // internal(for: AppModel extension files)
+    // Compatibility access for commands and restoration. Views observe the
+    // layout owner directly so a drag does not invalidate every chat row.
+    var inspectorWidth: CGFloat {
+        get { workspaceLayout.inspectorWidth }
+        set { workspaceLayout.setInspectorWidth(newValue) }
+    }
+    var sidebarWidth: CGFloat {
+        get { workspaceLayout.sidebarWidth }
+        set { workspaceLayout.setSidebarWidth(newValue) }
+    }
     /// The panel filling the window with chat squeezed to a column. A focus
     /// mode, deliberately not persisted — relaunch returns to the normal
     /// layout. Only `setInspectorZoomed(_:)` may change it.
     @Published var inspectorZoomed = false  // internal(for: AppModel+UITestFixtures)
     /// The chat column's width while zoomed. The panel takes the remainder,
     /// so this is the value the divider drags in that state.
-    @Published var zoomedChatWidth: CGFloat = CGFloat(AppSettings.defaultZoomedChatWidth)  // internal(for: AppModel extension files)
+    var zoomedChatWidth: CGFloat {
+        get { workspaceLayout.zoomedChatWidth }
+        set { workspaceLayout.setZoomedChatWidth(newValue) }
+    }
     /// Whether un-zooming should reopen the session sidebar it auto-collapsed.
     var restoreSidebarAfterZoom = false  // internal(for: AppModel extension files)
     @Published var planHasUnseenUpdate = false  // internal(for: AppModel extension files)
@@ -962,9 +973,9 @@ final class AppModel: ObservableObject {
 
         // Seeded here rather than in a didSet: assignments inside init skip
         // property observers, so this cannot echo back into persistence.
-        inspectorWidth = CGFloat(loadedSettings.inspectorWidth)
-        sidebarWidth = isUITesting ? 240 : CGFloat(loadedSettings.sidebarWidth)
-        zoomedChatWidth = CGFloat(loadedSettings.inspectorZoomedChatWidth)
+        workspaceLayout.setInspectorWidth(CGFloat(loadedSettings.inspectorWidth))
+        workspaceLayout.setSidebarWidth(isUITesting ? 240 : CGFloat(loadedSettings.sidebarWidth))
+        workspaceLayout.setZoomedChatWidth(CGFloat(loadedSettings.inspectorZoomedChatWidth))
         inspectorCollapsed = loadedSettings.inspectorCollapsed
         sidebarCollapsed = loadedSettings.sidebarCollapsed
         openInspectorTabs = restoredOpenInspectorTabs

--- a/Locus/LocusApp.swift
+++ b/Locus/LocusApp.swift
@@ -688,6 +688,7 @@ private struct RootViewUpdateProbe: NSViewRepresentable {
 /// then own both pointer and accessibility hits, without hiding the workspace.
 private struct CompactSidebarHost: NSViewRepresentable {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var updates: AppUpdateController
 
     func makeNSView(context: Context) -> CompactSidebarHostingView {
         let view = CompactSidebarHostingView(rootView: content(environment: context.environment))
@@ -722,6 +723,7 @@ private struct CompactSidebarHost: NSViewRepresentable {
         AnyView(
             SessionSidebarView()
                 .appFeatureEnvironment(from: model)
+                .environmentObject(updates)
                 .environment(\.colorScheme, environment.colorScheme)
                 .environment(\.dynamicTypeSize, environment.dynamicTypeSize)
                 .environment(\.layoutDirection, environment.layoutDirection)
@@ -779,6 +781,27 @@ final class CompactSidebarHostingView: NSHostingView<AnyView> {
     }
 }
 
+/// Observe the transcript policy in this small modifier, keeping content
+/// commits out of RootView's layout calculations. Large chats take one exact
+/// layout step; short chats retain the panel motion across every entry point.
+private struct WorkspacePanelMotion: ViewModifier {
+    @EnvironmentObject private var transcriptPresentation: TranscriptPresentationModel
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let sidebarCollapsed: Bool
+    let inspectorCollapsed: Bool
+    let inspectorZoomed: Bool
+    let inspectorTab: InspectorTab
+
+    func body(content: Content) -> some View {
+        let immediate = reduceMotion || transcriptPresentation.snapshot.prefersImmediatePanelLayout
+        content
+            .animation(immediate ? nil : LocusMotion.spatial, value: sidebarCollapsed)
+            .animation(immediate ? nil : LocusMotion.spatial, value: inspectorCollapsed)
+            .animation(immediate ? nil : LocusMotion.spatial, value: inspectorZoomed)
+            .animation(immediate ? nil : LocusMotion.spatial, value: inspectorTab)
+    }
+}
+
 struct RootView: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var library: WorkspaceLibraryModel
@@ -817,11 +840,11 @@ struct RootView: View {
                 proxy.size.width - minimumWorkspaceWidth - inspectorReservation - railWidth
             )
             let sidebarWidth = CGFloat(AppSettings.renderedSidebarWidth(
-                Double(model.sidebarWidth),
+                Double(workspaceLayout.sidebarWidth),
                 availableWidth: Double(availableSidebarWidth)
             ))
             let overlaySidebarWidth = CGFloat(AppSettings.renderedSidebarWidth(
-                Double(model.sidebarWidth),
+                Double(workspaceLayout.sidebarWidth),
                 availableWidth: Double(proxy.size.width - railWidth)
             ))
             let widthAfterChrome = proxy.size.width
@@ -834,9 +857,9 @@ struct RootView: View {
                 minimumInspectorWidth,
                 widthAfterChrome - minimumWorkspaceWidth
             )
-            let dockedInspectorWidth = min(model.inspectorWidth, availableInspectorWidth)
+            let dockedInspectorWidth = min(workspaceLayout.inspectorWidth, availableInspectorWidth)
             let zoomedWorkspaceWidth = min(
-                model.zoomedChatWidth,
+                workspaceLayout.zoomedChatWidth,
                 max(minimumWorkspaceWidth, widthAfterChrome - minimumInspectorWidth)
             )
             let workspaceWidth = model.inspectorZoomed && docksInspector
@@ -877,31 +900,18 @@ struct RootView: View {
                             }
                         }
                     )
-                    .frame(
-                        minWidth: 0,
-                        maxWidth: model.inspectorZoomed && docksInspector
-                            ? zoomedWorkspaceWidth
-                            : .infinity
-                    )
-                    .frame(
-                        width: model.inspectorZoomed && docksInspector
-                            ? zoomedWorkspaceWidth
-                            : nil
-                    )
+                    // The root has already resolved every column's width.
+                    // Re-negotiating flexible widths with a long native-text
+                    // transcript can keep the HStack's layout graph cycling
+                    // when an expanded inspector is restored.
+                    .frame(width: workspaceWidth)
                     .layoutPriority(1)
                     .ignoresSafeArea(.container, edges: .top)
 
                     if docksInspector {
                         InspectorView(resizeWidth: model.inspectorZoomed
                             ? zoomedWorkspaceWidth : dockedInspectorWidth)
-                            .frame(
-                                minWidth: model.inspectorZoomed
-                                    ? minimumInspectorWidth
-                                    : dockedInspectorWidth,
-                                maxWidth: model.inspectorZoomed
-                                    ? .infinity
-                                    : dockedInspectorWidth
-                            )
+                            .frame(width: widthAfterChrome - workspaceWidth)
                             .ignoresSafeArea(.container, edges: .top)
                             .transition(LocusMotion.transition(
                                 edge: .trailing,
@@ -927,8 +937,8 @@ struct RootView: View {
                 }
 
                 if inspectorOpen && !docksInspector {
-                    InspectorView(resizeWidth: min(model.inspectorWidth, proxy.size.width - railWidth))
-                        .frame(width: min(model.inspectorWidth, proxy.size.width - railWidth))
+                    InspectorView(resizeWidth: min(workspaceLayout.inspectorWidth, proxy.size.width - railWidth))
+                        .frame(width: min(workspaceLayout.inspectorWidth, proxy.size.width - railWidth))
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
                         .padding(.trailing, railWidth)
                         .shadow(
@@ -984,11 +994,12 @@ struct RootView: View {
                 transaction.disablesAnimations = true
             }
         }
-        // Animate panel expansion and its borrowed sidebar space together,
-        // including browser, rail, and keyboard actions. Divider widths stay
-        // outside animation so they follow the cursor during a resize drag.
-        .animation(LocusMotion.spatial, value: model.sidebarCollapsed)
-        .animation(LocusMotion.spatial, value: model.inspectorZoomed)
+        .modifier(WorkspacePanelMotion(
+            sidebarCollapsed: model.sidebarCollapsed,
+            inspectorCollapsed: model.inspectorCollapsed,
+            inspectorZoomed: model.inspectorZoomed,
+            inspectorTab: model.inspectorTab
+        ))
         .background(LocusTheme.paper)
         .overlay(alignment: .bottomTrailing) {
             if let toast = toastCenter.toast {

--- a/Locus/MessageContent.swift
+++ b/Locus/MessageContent.swift
@@ -511,7 +511,10 @@ struct StreamingPlainTextView: NSViewRepresentable {
         nsView: AppendOnlyTextView,
         context: Context
     ) -> CGSize? {
-        guard let width = proposal.width, width > 0 else { return nil }
+        // Match completed text: unspecified, zero and infinite probes must
+        // use a finite wrapping width rather than AppKit's intrinsic fallback.
+        let width = proposal.width.flatMap { $0.isFinite && $0 > 0 ? $0 : nil }
+            ?? max(nsView.bounds.width, 1)
         nsView.setLiveResizeMeasurementActive(isLiveResizing)
         return CGSize(
             width: width,

--- a/Locus/SessionSidebarView.swift
+++ b/Locus/SessionSidebarView.swift
@@ -425,6 +425,7 @@ enum SidebarIconMetrics {
 
 struct SessionSidebarView: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var updates: AppUpdateController
     @EnvironmentObject private var sessionCatalog: SessionCatalogModel
     @EnvironmentObject private var activityCenter: ActivityCenterModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -1245,6 +1246,14 @@ struct SessionSidebarView: View {
         Menu {
             Button("Settings…") { model.presentSettings() }
                 .accessibilityIdentifier("sidebar.settings")
+            if updates.isAvailable {
+                Button("Check for Updates…") { updates.checkForUpdates() }
+                    .disabled(!updates.canCheckForUpdates)
+                    .accessibilityIdentifier("sidebar.checkForUpdates")
+            } else {
+                Button("Software Updates…") { model.presentSettings(.updates) }
+                    .accessibilityIdentifier("sidebar.softwareUpdates")
+            }
             Button("Usage & Costs…") { model.usageDashboardPresented = true }
                 .accessibilityIdentifier("sidebar.usage")
             Button("Session Checkpoints…") { model.checkpointPresented = true }
@@ -1698,6 +1707,7 @@ struct SessionSidebarView: View {
 
 private struct SidebarResizeHandle: View {
     @EnvironmentObject private var model: AppModel
+    @EnvironmentObject private var workspaceLayout: WorkspaceLayoutModel
     @State private var dragStartWidth: CGFloat?
     @State private var hovering = false
 
@@ -1722,8 +1732,8 @@ private struct SidebarResizeHandle: View {
         .gesture(
             DragGesture(minimumDistance: 1, coordinateSpace: .global)
                 .onChanged { value in
-                    if dragStartWidth == nil { dragStartWidth = model.sidebarWidth }
-                    model.setSidebarWidth((dragStartWidth ?? model.sidebarWidth) + value.translation.width)
+                    if dragStartWidth == nil { dragStartWidth = workspaceLayout.sidebarWidth }
+                    model.setSidebarWidth((dragStartWidth ?? workspaceLayout.sidebarWidth) + value.translation.width)
                 }
                 .onEnded { _ in
                     dragStartWidth = nil
@@ -1736,7 +1746,7 @@ private struct SidebarResizeHandle: View {
         .accessibilityRepresentation {
             Slider(
                 value: Binding(
-                    get: { model.sidebarWidth },
+                    get: { workspaceLayout.sidebarWidth },
                     set: { width in
                         model.setSidebarWidth(width)
                         model.commitSidebarWidth()
@@ -1747,7 +1757,7 @@ private struct SidebarResizeHandle: View {
             ) {
                 Text("Sidebar width")
             }
-            .accessibilityValue("\(Int(model.sidebarWidth)) points")
+            .accessibilityValue("\(Int(workspaceLayout.sidebarWidth)) points")
             .accessibilityHint("Drag to resize. Double-click to reset.")
             .accessibilityIdentifier("sidebar.resize")
         }

--- a/Locus/TranscriptPresentationModel.swift
+++ b/Locus/TranscriptPresentationModel.swift
@@ -17,12 +17,44 @@ struct TranscriptSessionLoadToken: Equatable {
     let requestRevision: UInt64
 }
 
+enum TranscriptScrollTarget: Hashable {
+    case item(UInt64, TranscriptPresentationItem.ID)
+    case end(UInt64)
+}
+
+/// The lazy stack's indexed, session-scoped rows are built once per content
+/// commit. Layout, tab changes and selection can reuse the same array storage.
+struct TranscriptRenderRow: Identifiable, Equatable {
+    let index: Int
+    let item: TranscriptPresentationItem
+    let generation: UInt64
+    var id: TranscriptScrollTarget { .item(generation, item.id) }
+}
+
+enum TranscriptPanelLayoutPolicy {
+    /// A long answer can contain hundreds of native text leaves even when
+    /// history has only a few rows. Avoid rewrapping them at every spring frame.
+    static func prefersImmediateLayout(blocks: [ChatBlock], itemCount: Int) -> Bool {
+        if itemCount >= 100 { return true }
+        var bytes = 0
+        for block in blocks {
+            bytes += block.text.utf8.count
+            bytes += block.reasoningText?.utf8.count ?? 0
+            bytes += block.tool?.detail.utf8.count ?? 0
+            if bytes >= 16_384 { return true }
+        }
+        return false
+    }
+}
+
 struct TranscriptPresentationSnapshot: Equatable {
     let sessionID: String
     let renderToken: TranscriptRenderToken
     let blocks: [ChatBlock]
     let blocksByID: [UUID: ChatBlock]
     let items: [TranscriptPresentationItem]
+    let rows: [TranscriptRenderRow]
+    let prefersImmediatePanelLayout: Bool
     let assistantMarkerItemIDs: Set<TranscriptPresentationItem.ID>
     let assistantActionItemIDs: Set<TranscriptPresentationItem.ID>
     let toolActivityVisibility: ToolActivityVisibility
@@ -37,6 +69,8 @@ struct TranscriptPresentationSnapshot: Equatable {
         blocks: [],
         blocksByID: [:],
         items: [],
+        rows: [],
+        prefersImmediatePanelLayout: false,
         assistantMarkerItemIDs: [],
         assistantActionItemIDs: [],
         toolActivityVisibility: .collapsed,
@@ -132,6 +166,8 @@ final class TranscriptPresentationModel: ObservableObject {
             blocks: previous.blocks,
             blocksByID: previous.blocksByID,
             items: previous.items,
+            rows: previous.rows,
+            prefersImmediatePanelLayout: previous.prefersImmediatePanelLayout,
             assistantMarkerItemIDs: previous.assistantMarkerItemIDs,
             assistantActionItemIDs: previous.assistantActionItemIDs,
             toolActivityVisibility: previous.toolActivityVisibility,
@@ -236,6 +272,12 @@ final class TranscriptPresentationModel: ObservableObject {
                 uniquingKeysWith: { existing, _ in existing }
             ),
             items: items,
+            rows: items.enumerated().map {
+                TranscriptRenderRow(index: $0.offset, item: $0.element, generation: state.sessionGeneration)
+            },
+            prefersImmediatePanelLayout: TranscriptPanelLayoutPolicy.prefersImmediateLayout(
+                blocks: state.blocks, itemCount: items.count
+            ),
             assistantMarkerItemIDs: TranscriptPresentation.assistantMarkerItemIDs(in: items),
             assistantActionItemIDs: TranscriptPresentation.assistantActionItemIDs(in: items),
             toolActivityVisibility: state.toolActivityVisibility,

--- a/Locus/WorkspaceFileModel.swift
+++ b/Locus/WorkspaceFileModel.swift
@@ -38,6 +38,7 @@ final class WorkspaceFileModel: ObservableObject {
     }
     private var canIndexProvider: () -> Bool = { false }
     private var indexedWorkspacePath: String?
+    private var indexingWorkspacePath: String?
     private var indexGeneration = UUID()
     private var indexTask: Task<Void, Never>?
     private var previewTask: Task<Void, Never>?
@@ -72,6 +73,7 @@ final class WorkspaceFileModel: ObservableObject {
         indexGeneration = UUID()
         indexTask?.cancel()
         indexTask = nil
+        indexingWorkspacePath = nil
     }
 
     func refresh(force: Bool = false) {
@@ -83,12 +85,22 @@ final class WorkspaceFileModel: ObservableObject {
         // path. Never walk that broad directory for a result that will be
         // discarded as soon as the real workspace becomes available.
         guard canIndexProvider() else { return }
-        guard force || indexedWorkspacePath != root || files.isEmpty else { return }
+        // Switching back to Files while a scan is running must reuse that
+        // work. Cancelling the waiter does not stop its detached disk scan.
+        // An empty completed index is also a valid cache until invalidation.
+        guard force || (indexedWorkspacePath != root && indexingWorkspacePath != root) else { return }
         indexTask?.cancel()
+        indexingWorkspacePath = root
         let generation = UUID()
         indexGeneration = generation
         let scanner = scanner
         indexTask = Task { [weak self] in
+            defer {
+                if let self, self.indexGeneration == generation {
+                    self.indexTask = nil
+                    self.indexingWorkspacePath = nil
+                }
+            }
             let files = await Task.detached(priority: .utility) {
                 scanner(root)
             }.value
@@ -148,6 +160,8 @@ final class WorkspaceFileModel: ObservableObject {
     func stop() {
         indexGeneration = UUID()
         indexTask?.cancel()
+        indexTask = nil
+        indexingWorkspacePath = nil
         previewTask?.cancel()
     }
 
@@ -155,6 +169,8 @@ final class WorkspaceFileModel: ObservableObject {
     func seed(_ files: [URL], workspacePath: String) {
         indexGeneration = UUID()
         indexTask?.cancel()
+        indexTask = nil
+        indexingWorkspacePath = nil
         indexedWorkspacePath = workspacePath
         self.files = files
     }

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -2889,6 +2889,27 @@ struct TranscriptFollowState: Equatable {
     }
 }
 
+/// Small transcripts need no estimated row heights. In particular, a handful
+/// of very tall Markdown answers can make a lazy stack repeatedly revise its
+/// scroll extent during a width change. Large histories still virtualize.
+private struct TranscriptLayoutStack<Content: View>: View {
+    let itemCount: Int
+    let content: Content
+
+    init(itemCount: Int, @ViewBuilder content: () -> Content) {
+        self.itemCount = itemCount
+        self.content = content()
+    }
+
+    var body: some View {
+        if itemCount <= 40 {
+            VStack(alignment: .leading, spacing: 0) { content }
+        } else {
+            LazyVStack(alignment: .leading, spacing: 0) { content }
+        }
+    }
+}
+
 private struct ConversationView: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var transcriptPresentation: TranscriptPresentationModel
@@ -2907,29 +2928,32 @@ private struct ConversationView: View {
     @State private var deferredSelectionRows: Set<String> = []
 
     var body: some View {
+        GeometryReader { viewport in
+            transcriptContent(viewportWidth: viewport.size.width)
+        }
+    }
+
+    private func transcriptContent(viewportWidth: CGFloat) -> some View {
         let transcript = transcriptPresentation.snapshot
         let items = transcript.items
         let token = transcript.renderToken
-        let rows = items.enumerated().map {
-            TranscriptRenderRow(index: $0.offset, item: $0.element, generation: token.sessionGeneration)
-        }
         let bottomID = TranscriptScrollTarget.end(token.sessionGeneration)
         let predecessorID = items.dropLast().last?.id
-        ScrollViewReader { proxy in
+        return ScrollViewReader { proxy in
             let realizePredecessor: (() -> Void)? = predecessorID.map { id in
                 // Discover the row's leading edge without using its still-
                 // estimated height. Its actual end is measured after layout.
                 { proxy.scrollTo(TranscriptScrollTarget.item(token.sessionGeneration, id), anchor: .top) }
             }
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
+                TranscriptLayoutStack(itemCount: items.count) {
                     if transcript.isEmpty {
                         EmptyConversationView()
                             .environmentObject(model)
                     }
                     // Keep repeating rows directly visible to the lazy
                     // container's ID traversal even before they are realized.
-                    ForEach(rows) { row in
+                    ForEach(transcript.rows) { row in
                         renderRow(row, in: transcript)
                     }
                     if transcript.isEmpty { transcriptEnd(token: token, id: bottomID) }
@@ -2976,7 +3000,11 @@ private struct ConversationView: View {
                     .accessibilityHidden(true)
                     #endif
                 }
-                .frame(maxWidth: 780)
+                // A lazy transcript must get its wrapping width from the
+                // viewport. Letting native text's ideal size participate in
+                // a flexible-width proposal can make restored panels loop
+                // between incompatible row measurements.
+                .frame(width: max(1, min(780, viewportWidth - 48)))
                 .padding(.horizontal, 24)
                 .padding(.top, transcript.isEmpty ? 0 : 24)
                 .frame(maxWidth: .infinity)
@@ -3572,11 +3600,6 @@ struct TranscriptScrollMetrics {
     }
 }
 
-private enum TranscriptScrollTarget: Hashable {
-    case item(UInt64, TranscriptPresentationItem.ID)
-    case end(UInt64)
-}
-
 #if DEBUG
 @MainActor
 private enum TranscriptRowGeometryDiagnostics {
@@ -3600,13 +3623,6 @@ private enum TranscriptRowGeometryDiagnostics {
     }
 }
 #endif
-
-private struct TranscriptRenderRow: Identifiable {
-    let index: Int
-    let item: TranscriptPresentationItem
-    let generation: UInt64
-    var id: TranscriptScrollTarget { .item(generation, item.id) }
-}
 
 enum TranscriptTailLayoutKind: Equatable { case content, end, predecessor }
 

--- a/LocusTests/AppModelObservationBoundaryTests.swift
+++ b/LocusTests/AppModelObservationBoundaryTests.swift
@@ -67,6 +67,45 @@ final class AppModelObservationBoundaryTests: XCTestCase {
         withExtendedLifetime((appSubscription, composerSubscription)) {}
     }
 
+    func testDividerWidthsOnlyPublishLayoutAndPersistOnRelease() {
+        let app = AppModel(startImmediately: false)
+        app.installTranscriptSession("large", blocks: (0..<500).map {
+            ChatBlock(kind: .assistant, text: "Historical answer \($0)")
+        })
+        let savedSettings = app.settings
+        let snapshot = app.transcriptPresentation.snapshot
+        let buildCount = app.transcriptPresentation.snapshotBuildCountForTesting
+        var appPublications = 0
+        var layoutPublications = 0
+        let appSubscription = app.objectWillChange.sink { appPublications += 1 }
+        let layoutSubscription = app.workspaceLayout.objectWillChange.sink { layoutPublications += 1 }
+
+        for step in 0..<100 {
+            app.setInspectorWidth(CGFloat(320 + step))
+            app.setSidebarWidth(CGFloat(200 + step))
+            app.setZoomedChatWidth(CGFloat(400 + step))
+        }
+
+        XCTAssertEqual(appPublications, 0, "Pointer movement must not invalidate the conversation and every panel")
+        XCTAssertGreaterThan(layoutPublications, 0, "The layout must still follow the pointer")
+        XCTAssertEqual(app.settings, savedSettings, "Only release persists the widths")
+        XCTAssertEqual(app.transcriptPresentation.snapshot, snapshot)
+        XCTAssertEqual(app.transcriptPresentation.snapshotBuildCountForTesting, buildCount)
+
+        let beforeNoOp = layoutPublications
+        app.setInspectorWidth(app.inspectorWidth)
+        app.setSidebarWidth(app.sidebarWidth)
+        app.setZoomedChatWidth(app.zoomedChatWidth)
+        XCTAssertEqual(layoutPublications, beforeNoOp)
+        app.commitInspectorWidth()
+        app.commitSidebarWidth()
+        app.commitZoomedChatWidth()
+        XCTAssertEqual(app.settings.inspectorWidth, Double(app.inspectorWidth))
+        XCTAssertEqual(app.settings.sidebarWidth, Double(app.sidebarWidth))
+        XCTAssertEqual(app.settings.inspectorZoomedChatWidth, Double(app.zoomedChatWidth))
+        withExtendedLifetime((appSubscription, layoutSubscription)) {}
+    }
+
     func testTranscriptChildPublicationsAndContentCommitsDoNotRepublishAppModel() {
         let app = AppModel(startImmediately: false)
         app.installTranscriptSession("selected", blocks: [ChatBlock(kind: .assistant, text: "Initial")])

--- a/LocusTests/TranscriptPresentationModelTests.swift
+++ b/LocusTests/TranscriptPresentationModelTests.swift
@@ -248,6 +248,43 @@ final class TranscriptPresentationModelTests: XCTestCase {
         XCTAssertFalse(snapshot.hasPendingPermission)
     }
 
+    func testRenderRowsReuseStorageAndFollowContentAndSessionIdentity() {
+        let model = TranscriptPresentationModel()
+        model.installSession("large", blocks: benchmarkFixture())
+        let original = model.snapshot
+        let address = original.rows.withUnsafeBufferPointer { $0.baseAddress }
+        for _ in 0..<100 {
+            XCTAssertEqual(model.snapshot.rows.withUnsafeBufferPointer { $0.baseAddress }, address,
+                "A layout read must not allocate another full-history row array")
+        }
+        XCTAssertEqual(original.rows.map(\.index), Array(original.items.indices))
+        XCTAssertEqual(original.rows.map(\.item), original.items)
+        XCTAssertEqual(original.rows.last?.id,
+            .item(original.renderToken.sessionGeneration, original.items.last!.id))
+
+        model.rekeySession(from: "large", to: "renamed")
+        XCTAssertEqual(model.snapshot.rows.withUnsafeBufferPointer { $0.baseAddress }, address)
+        model.updateBlocks { $0.append(ChatBlock(kind: .user, text: "Continue")) }
+        XCTAssertEqual(model.snapshot.rows.map(\.item), model.snapshot.items)
+        XCTAssertNotEqual(model.snapshot.rows.last?.id, original.rows.last?.id)
+        let ids = model.snapshot.rows.map(\.id)
+        model.installSession("fresh", blocks: model.snapshot.blocks)
+        XCTAssertTrue(Set(ids).isDisjoint(with: model.snapshot.rows.map(\.id)))
+    }
+
+    func testLongAnswerAndLargeHistoryAvoidAnimatedPanelReflowAndResetForNewChat() {
+        let model = TranscriptPresentationModel()
+        XCTAssertFalse(model.snapshot.prefersImmediatePanelLayout)
+        model.replaceBlocks([ChatBlock(kind: .assistant, text: "A short answer")])
+        XCTAssertFalse(model.snapshot.prefersImmediatePanelLayout)
+        model.replaceBlocks([ChatBlock(kind: .assistant, text: String(repeating: "Long answer. ", count: 2_000))])
+        XCTAssertTrue(model.snapshot.prefersImmediatePanelLayout, "A single large answer needs the same protection as long history")
+        model.replaceBlocks(benchmarkFixture())
+        XCTAssertTrue(model.snapshot.prefersImmediatePanelLayout)
+        model.installSession("new", blocks: [])
+        XCTAssertFalse(model.snapshot.prefersImmediatePanelLayout)
+    }
+
     func testBatchedBlockMutationBuildsAndPublishesExactlyOnce() {
         let model = TranscriptPresentationModel()
         model.replaceBlocks([

--- a/LocusTests/TranscriptRelayoutTests.swift
+++ b/LocusTests/TranscriptRelayoutTests.swift
@@ -531,6 +531,29 @@ final class TranscriptRelayoutTests: XCTestCase {
             "Following the tail must retain lazy history rather than mount the whole transcript")
     }
 
+    func testFollowingSurvivesCrossingTheEagerHistoryBoundaryAndSessionReplacement() throws {
+        let model = makeGrowthModel()
+        model.blocks = (0..<40).map { index in
+            ChatBlock(kind: index.isMultiple(of: 2) ? .user : .assistant,
+                      text: index == 39 ? "Eager history tail" : "Boundary row \(index)")
+        }
+        let host = mount(model, size: NSSize(width: 720, height: 640))
+        let scroll = try XCTUnwrap(transcriptScrollView(in: host))
+        XCTAssertNotNil(waitForRenderedSuffix("Eager history tail", in: scroll))
+
+        model.updateTranscriptBlocks {
+            $0.append(ChatBlock(kind: .user, text: "Continue across the boundary"))
+            $0.append(ChatBlock(kind: .assistant, text: "Lazy history tail"))
+        }
+        XCTAssertNotNil(waitForRenderedSuffix("Lazy history tail", in: scroll))
+
+        model.installTranscriptSession("short-replacement", blocks: [
+            ChatBlock(kind: .user, text: "A replacement chat"),
+            ChatBlock(kind: .assistant, text: "Replacement eager tail"),
+        ])
+        XCTAssertNotNil(waitForRenderedSuffix("Replacement eager tail", in: scroll))
+    }
+
     func testEqualCountNewRowIDsRevealTheReplacementSuffix() throws {
         let model = makeGrowthModel()
         let host = mount(model, size: NSSize(width: 720, height: 640))

--- a/LocusTests/WorkspaceFileModelTests.swift
+++ b/LocusTests/WorkspaceFileModelTests.swift
@@ -107,6 +107,57 @@ final class WorkspaceFileModelTests: XCTestCase {
         XCTAssertNil(model.previewedPath)
         XCTAssertNil(model.previewedContents)
     }
+
+    @MainActor
+    func testRepeatedTabSelectionReusesInFlightScan() async {
+        let root = "/tmp/locus-workspace-files"
+        let old = URL(fileURLWithPath: root).appendingPathComponent("first.md")
+        let current = URL(fileURLWithPath: root).appendingPathComponent("forced.md")
+        let scanner = ControlledWorkspaceIndexScanner(old: old, current: current)
+        let model = WorkspaceFileModel(scanner: { _ in scanner.scan() })
+        model.configure(isUITesting: false, workspacePath: { root }, canIndex: { true })
+        defer { scanner.releaseFirst.signal(); model.stop() }
+
+        model.refresh()
+        await fulfillment(of: [scanner.firstStarted], timeout: 1)
+        for _ in 0..<20 { model.refresh() }
+        scanner.releaseFirst.signal()
+        for _ in 0..<40 where model.files.isEmpty {
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertEqual(model.files, [old], "Tab changes must not replace an in-flight scan")
+        XCTAssertEqual(scanner.callCount, 1)
+
+        model.refresh(force: true)
+        await fulfillment(of: [scanner.secondStarted], timeout: 1)
+        for _ in 0..<40 where model.files != [current] {
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertEqual(model.files, [current], "Explicit refresh still scans again")
+    }
+
+    @MainActor
+    func testEmptyIndexIsCachedUntilInvalidated() async {
+        let root = "/tmp/locus-empty-workspace"
+        let calls = expectation(description: "Exactly two scans: initial and invalidated")
+        calls.expectedFulfillmentCount = 2
+        calls.assertForOverFulfill = true
+        let model = WorkspaceFileModel(scanner: { _ in calls.fulfill(); return [] })
+        model.configure(isUITesting: false, workspacePath: { root }, canIndex: { true })
+        defer { model.stop() }
+        let initial = expectation(description: "Initial empty index committed")
+        let subscription = model.$files.dropFirst().prefix(1).sink { _ in initial.fulfill() }
+        model.refresh()
+        await fulfillment(of: [initial], timeout: 1)
+        for _ in 0..<20 {
+            model.refresh()
+            await Task.yield()
+        }
+        model.invalidateIndex()
+        model.refresh()
+        await fulfillment(of: [calls], timeout: 1)
+        withExtendedLifetime(subscription) {}
+    }
 }
 
 private final class ControlledWorkspaceIndexScanner: @unchecked Sendable {
@@ -116,6 +167,11 @@ private final class ControlledWorkspaceIndexScanner: @unchecked Sendable {
     let releaseFirst = DispatchSemaphore(value: 0)
     private let lock = NSLock()
     private var calls = 0
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
     private let old: URL
     private let current: URL
 

--- a/LocusUITests/LocusUITests.swift
+++ b/LocusUITests/LocusUITests.swift
@@ -1382,6 +1382,24 @@ final class LocusUITests: XCTestCase {
         XCTAssertFalse(anyElement("settings.appStoreUpdates").exists)
     }
 
+    func testSidebarMenuExposesSoftwareUpdatesForThisBuild() {
+        let automatic = ProcessInfo.processInfo.environment["LOCUS_EXPECT_AUTOMATIC_UPDATES"] == "1"
+        revealSidebarForNavigation()
+        anyElement("sidebar.more").click()
+        if automatic {
+            let check = app.menuItems["Check for Updates…"]
+            XCTAssertTrue(check.waitForExistence(timeout: 3))
+            XCTAssertFalse(check.isEnabled, "Fixture launches do not start the updater")
+            app.typeKey(.escape, modifierFlags: [])
+        } else {
+            let updates = app.menuItems["Software Updates…"]
+            XCTAssertTrue(updates.waitForExistence(timeout: 3))
+            updates.click()
+            XCTAssertTrue(anyElement("settings.updateVersion").waitForExistence(timeout: 5))
+            XCTAssertTrue(anyElement("settings.manualUpdates").exists)
+        }
+    }
+
     func testNativeSettingsClosesCleanlyByButtonCommandWAndTrafficLight() {
         let settingsPage = anyElement("settings.page.general")
         let workspace = anyElement("workspace.modelPicker")
@@ -2906,11 +2924,18 @@ final class LocusUITests: XCTestCase {
     func testBusyTranscriptKeepsBrowserAndDraftAcrossRepeatedExpansion() {
         app.terminate()
         app.launchEnvironment["LOCUS_UI_TESTING_PERFORMANCE_TRANSCRIPT"] = "1"
+        app.launchEnvironment["LOCUS_UI_TESTING_PERFORMANCE_SECTIONS"] = "36"
         app.launchEnvironment["LOCUS_UI_TESTING_WINDOW_WIDTH"] = "1250"
         app.launchEnvironment["LOCUS_UI_TESTING_WINDOW_HEIGHT"] = "760"
         app.launch()
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
         XCTAssertTrue(anyElement("conversation.scroll").waitForExistence(timeout: 10))
+        for _ in 0..<2 {
+            app.typeKey("3", modifierFlags: .command)
+            XCTAssertTrue(anyElement("files.search").waitForExistence(timeout: 3))
+            app.typeKey("4", modifierFlags: .command)
+            XCTAssertTrue(anyElement("terminal.output").waitForExistence(timeout: 3))
+        }
         app.typeKey("5", modifierFlags: .command)
         let address = anyElement("browser.url")
         XCTAssertTrue(address.waitForExistence(timeout: 5))


### PR DESCRIPTION
## What this changes

Restoring an expanded right panel beside a large Markdown answer could keep SwiftUI cycling through layout. Short transcripts now use exact row heights, while long histories retain lazy rendering. Divider widths publish through the layout owner, committed transcript rows are reused, and Files reuses in-flight scans and empty indexes. Populated chats skip intermediate animated reflow.

The sidebar gear menu now offers **Check for Updates…** through the existing updater, or **Software Updates…** for manual-update and App Store builds. The compact sidebar receives the same update controller.

## How you verified it

- Debug build and 154 selected native/UI tests passed, including repeated Files/Terminal switching and three Browser expansion/restoration cycles beside a 36-section answer. The address draft survives each cycle.
- Native coverage verifies a 600-message history remains lazy, the transition between eager and lazy history, text selection, scroll following, 300 divider changes with no app-wide publications, row identity, and scan coalescing.
- Design-system audit and whitespace checks passed. Reviewed the advisory architecture report; no boundary signals.
- Full local Locus native suite passed: 1,425 tests. Full Python suite passed: 2,142 tests. GitHub Python and wallet-signer checks also passed; the broader platform/UI matrix remains in progress. No Python or dependency changes.
- Timing scope and thresholds are documented in `Docs/PanelPerformanceAudit.md`; no release-wide percentage speedup is claimed.

## Checklist

- [x] Commit signed off.
- [x] Full local Locus Swift and Python suites pass, plus six focused UI tests. Broader GitHub platform/UI checks are still running.
- [x] New width state belongs to `WorkspaceLayoutModel`; no new API handlers.
- [x] Advisory reviewability signals reviewed; existing large files changed within their current feature responsibilities.
- [x] No project layout or dependency changes; project regeneration and dependency notices are not applicable.
- [x] No credentials or personal local paths added; temporary test fixtures follow existing conventions.
- [x] User-visible changes have an Unreleased changelog entry.
- [x] Audit documentation and UI strings describe the implemented behavior.
