### PR TITLE
Add Duo planning and execution mode

### DIFF
--- a/Docs/DuoMode.md
+++ b/Docs/DuoMode.md
@@ -1,0 +1,69 @@
+# Duo mode
+
+Duo uses one model to prepare a plan and another to implement it. It runs in
+the current conversation and shares Task Capsules' saved plans, verification,
+usage limits, and recovery.
+
+## Using v1
+
+1. Select **Duo** in the composer’s Work menu.
+2. Choose **Plan with** and **Build with** from your connected accounts and
+   installed models. The pair is remembered; specialist setup is unnecessary.
+3. Describe the change. Planning is read-only, and clarification stays with
+   the planner.
+4. Review the saved plan in the conversation. **Revise** opens the composer
+   for your feedback. **Accept & build** starts the chosen builder.
+5. The builder implements and verifies the plan. Follow-up messages use that
+   same builder. **New plan** starts another planning cycle.
+
+The selected mode remains Duo while its phase changes. The task keeps its
+chosen model pair even if the ordinary model picker or default Duo pair changes.
+Switching to Work returns ordinary messages to the normal model selection.
+Model choices do not grant additional tool permissions.
+
+Stopped builds offer **Resume**, **Ask planner for help**, and **Review recovery**.
+Recovery opens the existing capsule controls for uncertain actions, checks,
+usage, and requirements that need human review. Restart restores saved state
+without starting model calls. A running build is shown as paused until its
+saved attempt is refreshed. A failed plan save can be retried from the card.
+
+Before execution, the runtime checks the approved revision and the plan's
+declared source files. Repeated acceptance of the same handoff cannot create
+another run, including when requests arrive concurrently or after restart.
+As in Task Capsules, source fingerprints cover declared files, not the entire
+repository. Unavailable accounts stop the stage instead of choosing a fallback.
+
+## Scope and implementation
+
+- V1 supports interactive regular workspace tasks. Automations and specialist
+  mode menus continue to use the existing non-Duo modes.
+- `DuoModel` persists task phases, the approved capsule, pending planning data,
+  and credential-free model profiles. Production uses application preferences;
+  tests use isolated or in-memory state.
+- `DuoComposerView` supplies the two model choices, plan acceptance, revision,
+  and recovery controls. `AppModel` resolves exact account routes per dispatch.
+- Planning and execution continue to use the backend's `plan` and `work`
+  contracts. Unaccepted plan revisions use planning calls; explicit help with
+  a build uses the capsule's bounded planner-escalation allowance.
+- The execution reservation stores a stable handoff ID in the capsule's run
+  history within the existing SQLite write transaction. Duplicate reservations
+  are rejected before another attempt or model call is created.
+- Executor follow-ups require a completed saved attempt and carry the original
+  request and approved plan. They have separate run records; new follow-up work
+  does not rewrite the original capsule's completion evidence.
+- The stronger model is not automatically used for implementation, final
+  synthesis, or review. Existing capsule recovery and optional review remain
+  available through its detailed view.
+
+## Suggested next iterations
+
+1. **Measure model pairs.** Compare successful completion, retries, elapsed
+   time, and total available usage across planning and execution. Recommend
+   defaults from measured results. Keep subscription usage distinct from API
+   price estimates.
+2. **Optional final planner review.** Let users enable one bounded review of
+   the builder's diff and test evidence, with any repair performed by the builder.
+3. **Better blocker handoffs.** Package the failed check, relevant changes,
+   and the builder's attempted fixes when the user requests planner help.
+4. **Named pairs.** Add reusable choices such as a preferred coding pair and
+   a local-only pair after there is evidence that users need several defaults.

--- a/Locus.xcodeproj/project.pbxproj
+++ b/Locus.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00140A283710F25563FD5C18 /* CompanionWireTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622AFAF0F2B7F699AB240371 /* CompanionWireTypes.swift */; };
+		00223BCA9D608BE0202B90FC /* DuoComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A551954B8AF7809312CE68 /* DuoComposerView.swift */; };
 		0059A51AF244147172CFCF16 /* WalletFuzzHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CED0304B6C9E2C66E36C76 /* WalletFuzzHost.swift */; };
 		011C9BD85BA0B362E8C1F05E /* CompanionGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CE2B724F913964929108E5 /* CompanionGateway.swift */; };
 		013D8F646D4B970BB4B01212 /* AppModel+ToastFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FCAE1E8B009CE43FD465A3 /* AppModel+ToastFacade.swift */; };
@@ -105,6 +106,7 @@
 		10685499B0254BC46F22CCEB /* AppModel+UITestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = A65C8C0698978C8CF184FCA3 /* AppModel+UITestFixtures.swift */; };
 		1068A2BD0C9A19A191DF0036 /* CompanionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A2C2357DB9117DF77AA7E7 /* CompanionProtocol.swift */; };
 		108F04AD35177E251816FC78 /* TaskCapsuleTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8ADBF6F317252F03078BBE9 /* TaskCapsuleTypes.swift */; };
+		109AF22C512FD9E528DBC839 /* DuoComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A551954B8AF7809312CE68 /* DuoComposerView.swift */; };
 		10A507EFF1128CECEBB0CCF2 /* RemoteEndpointTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EE3ED166C864419A854532 /* RemoteEndpointTester.swift */; };
 		10D2156FCEDE7B7BCEC43613 /* WalletConnectCryptoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC2FF3F9FFB4044B70086D7 /* WalletConnectCryptoProvider.swift */; };
 		1111A926F1C03465152F231D /* AppModel+OrchestrationRunsFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E3D606BE661E35AB2E9606 /* AppModel+OrchestrationRunsFacade.swift */; };
@@ -144,6 +146,7 @@
 		1838F8C9ABC24EF5DB47DC4C /* LandingFlowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E292075DE9F84B3C78158F /* LandingFlowModel.swift */; };
 		183A6DE2ED120A9FCCABCA7B /* AppModel+LandingFlowFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494AA2883078C54BAF0BF14C /* AppModel+LandingFlowFacade.swift */; };
 		187387B8930454559D9E0BEA /* WalletDappTransactionDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2CEA5D7039D64E8E279C78 /* WalletDappTransactionDecoder.swift */; };
+		18944B9DCA2DD0556FBC5752 /* DuoMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D115FE7DDE634FFF940A29AE /* DuoMode.swift */; };
 		18B0E2B058AD64179D8D2E4F /* JSONBridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18DF12402ABC3DF35FEADFC /* JSONBridging.swift */; };
 		18E48098BF13F823AA003B03 /* MarkdownTextKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374021875E8ACFCCC20B5D90 /* MarkdownTextKit.swift */; };
 		1932D9D59265AD4F4D66C401 /* AppModel+ModelRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A9C26F8D798CFAC0AC1169 /* AppModel+ModelRouter.swift */; };
@@ -387,6 +390,7 @@
 		46DD3294268F30428BBB1759 /* InteractiveAnswerDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC3D72AF9571D9A1906E499 /* InteractiveAnswerDocument.swift */; };
 		473A0EEF2BC977577C962850 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0204C24A0102A8D20E3A23CE /* Theme.swift */; };
 		47B3CDF21F3C3571F1583A71 /* ProviderAccountsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B40E69DB26D5BD1E2411C89 /* ProviderAccountsModel.swift */; };
+		47C3782F3771A47689835501 /* DuoComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A551954B8AF7809312CE68 /* DuoComposerView.swift */; };
 		47C9A7865900BA0B547C6EBB /* AppEdition.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49790784A452F1C5786860D /* AppEdition.swift */; };
 		47EBE14BEC70C38213A9B687 /* AgentManagementPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9101B0FC031593F78262CC9 /* AgentManagementPresentation.swift */; };
 		482040C006E65D3644FBD472 /* QuestionPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160A256D1C92F0937B961AB8 /* QuestionPromptView.swift */; };
@@ -394,6 +398,7 @@
 		48BD3B6277F1F074589C4A1F /* BrowserBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D7A27ACF9B37EC8F79B9D7 /* BrowserBridge.swift */; };
 		491257B406F09500DA83F9A1 /* AppUpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE792B67295C1B0196FC71 /* AppUpdateController.swift */; };
 		491ECFC9EF82513DC5BF6E6A /* PinnedSummaryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535F3FB7D434799FB66DADAA /* PinnedSummaryModel.swift */; };
+		494D6912A5D0A47A37AD6EF1 /* DuoMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D115FE7DDE634FFF940A29AE /* DuoMode.swift */; };
 		494EA6813C4FD79269724B78 /* AccountEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FD1471F0D2805148D40887 /* AccountEditorView.swift */; };
 		49BF0C5B81AF34373026C462 /* AppModel+AgentInspectorFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD2C38322FD76F1641174D0 /* AppModel+AgentInspectorFixtures.swift */; };
 		49F0C605A917B94FBFCCD74F /* AppModel+OptionalQuestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10380F5BBBBE6D681FCED4C0 /* AppModel+OptionalQuestions.swift */; };
@@ -422,7 +427,9 @@
 		4ECEFA778E1D5AD0A82705FA /* AppModel+WorkspaceProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF7C32F369DF7295D8B8077 /* AppModel+WorkspaceProfiles.swift */; };
 		4FBFD784FC4BA11066C9239A /* WalletConnectDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615928980C39345E4A0DE168 /* WalletConnectDriver.swift */; };
 		4FC230C8586C4286AAA377E1 /* AppModel+OrchestrationRunsFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E3D606BE661E35AB2E9606 /* AppModel+OrchestrationRunsFacade.swift */; };
+		50367394DAFC374362B65530 /* DuoComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A551954B8AF7809312CE68 /* DuoComposerView.swift */; };
 		505AD1704AEFE3A4DF830600 /* ComposerWorkflowPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA782425EED25AF7E54297D6 /* ComposerWorkflowPopover.swift */; };
+		506DDBB7B2C9824F4E1ABA2B /* DuoMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D115FE7DDE634FFF940A29AE /* DuoMode.swift */; };
 		50B4B8A6C955F6356428F4A0 /* AppModel+IdentityVault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1BFE5AA4712B9E94D6C4EC /* AppModel+IdentityVault.swift */; };
 		50C5929E50BECE89ECAE55D9 /* SlashCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78188AFFEC80498E68C2EE3A /* SlashCommands.swift */; };
 		5126CD5294FBD8AAB46BDA5D /* NotebookUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35B07054C35DB3A45C4F717 /* NotebookUITests.swift */; };
@@ -959,6 +966,7 @@
 		C78192C01E3F304B42AA06DA /* OutputsLibraryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8744B144B8FFDE5CAF58BF58 /* OutputsLibraryStore.swift */; };
 		C7C996EB5D0E44B1B1CC7856 /* AgentInspectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF91974AE687AB29AEF3513 /* AgentInspectorModel.swift */; };
 		C818F87A8F5467990AB0F410 /* WalletConnections.bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 96814A957D6A0D49B8E49966 /* WalletConnections.bundle.js */; };
+		C857F53E418AACD77AB22546 /* DuoModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A776F486ABB33978D4191DC /* DuoModeTests.swift */; };
 		C878B1EE0046D9C203A7FEA5 /* ActivityCenterModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A6B77A929CA91E6E421529 /* ActivityCenterModelTests.swift */; };
 		C8A2EBDF6FCE424BE8FD7FD5 /* AppModel+ResponseOutputFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396C4535C45E729833627F88 /* AppModel+ResponseOutputFixtures.swift */; };
 		C8CE5CB81A94DF13254C7B14 /* SessionOutputWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DDCC477A47A2FB0E5FF77D2 /* SessionOutputWatcherTests.swift */; };
@@ -988,6 +996,7 @@
 		CD0952494138CDDBDCBA802A /* AppModel+SettingsAndProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B115BC8D846B904BD7A381 /* AppModel+SettingsAndProvider.swift */; };
 		CD11B0056D5797A2BA9C5062 /* BrowserInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A65386A2C6C14183D519D510 /* BrowserInput.swift */; };
 		CD25E93B7A7C3F2C8E2BCB0C /* WalletRecoveryXPCClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8566E23502F03462F5C1EFDD /* WalletRecoveryXPCClient.swift */; };
+		CD3728281B1D1253165D1E25 /* DuoMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D115FE7DDE634FFF940A29AE /* DuoMode.swift */; };
 		CD4DA1A62230C23DC2BDDB56 /* IdentityVaultStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0254E0825A63A8D542C4C5DD /* IdentityVaultStore.swift */; };
 		CD5FB66D63F293316CAB7B7C /* AppLifecycleJournal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81270ABC0C4D667173248A3F /* AppLifecycleJournal.swift */; };
 		CD8C2585289B9253317D7D3F /* AgentManagementPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2638F444CF15996577237A9E /* AgentManagementPresentationTests.swift */; };
@@ -1171,6 +1180,7 @@
 		F1FA7ADE9F5F57AB84A2D886 /* WorkspaceFileViewerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DA82E9A9DD4E4C835FD984 /* WorkspaceFileViewerTests.swift */; };
 		F2182B328075C489B3869BA0 /* BrowserAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502310F907C376034E4FE9E3 /* BrowserAnnotation.swift */; };
 		F22C6C15FD2D71BDEF31E718 /* NotebookCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D50CEE9ADA01A42ADBBB63A /* NotebookCatalog.swift */; };
+		F233B6CDB49B59D16BBD681E /* DuoModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A776F486ABB33978D4191DC /* DuoModeTests.swift */; };
 		F34B4E6CD5FA8011863AF8BE /* GoalRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED8A0344BFA876DAEAC402F /* GoalRoutingTests.swift */; };
 		F36F2DB334F0BE4F7BA377E1 /* InspectorRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D508444E398AA3AB5441198 /* InspectorRail.swift */; };
 		F409B08F556CC1032101C4B0 /* TerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95947ACE0751337457A57CD /* TerminalSession.swift */; };
@@ -1335,6 +1345,7 @@
 		002312B5082A52E6C32866FD /* AppModel+ChatWorkers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+ChatWorkers.swift"; sourceTree = "<group>"; };
 		005F300A2BA98F36F1DF154C /* AgentInstructionsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInstructionsModelTests.swift; sourceTree = "<group>"; };
 		00A37D5FE4583645B552296C /* SessionSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSidebarView.swift; sourceTree = "<group>"; };
+		00A551954B8AF7809312CE68 /* DuoComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuoComposerView.swift; sourceTree = "<group>"; };
 		01CC51562DC9D45DE8CC92E2 /* WalletSolanaRPCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSolanaRPCClient.swift; sourceTree = "<group>"; };
 		01EE3ED166C864419A854532 /* RemoteEndpointTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteEndpointTester.swift; sourceTree = "<group>"; };
 		0204C24A0102A8D20E3A23CE /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -1388,6 +1399,7 @@
 		17A2C2357DB9117DF77AA7E7 /* CompanionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionProtocol.swift; sourceTree = "<group>"; };
 		1848343E1C619FEB8D805CF5 /* OptionalQuestionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalQuestionModel.swift; sourceTree = "<group>"; };
 		1A7536131C96359528103360 /* WalletSignerService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = WalletSignerService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A776F486ABB33978D4191DC /* DuoModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuoModeTests.swift; sourceTree = "<group>"; };
 		1AFF112DFD138A58ACB32658 /* GitWorkspaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceModel.swift; sourceTree = "<group>"; };
 		1BAF351A940527DD975AFC95 /* ToastCenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastCenterTests.swift; sourceTree = "<group>"; };
 		1BBAE276C6EEC0680C848F97 /* QuestionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionModels.swift; sourceTree = "<group>"; };
@@ -1662,6 +1674,7 @@
 		CF3D3389D598BBECBE77E38F /* InspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorView.swift; sourceTree = "<group>"; };
 		CFD0205FA722D64452114722 /* EventAutomationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAutomationModel.swift; sourceTree = "<group>"; };
 		D095B47B9746E5A9518B378A /* ComposerActionLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerActionLayoutTests.swift; sourceTree = "<group>"; };
+		D115FE7DDE634FFF940A29AE /* DuoMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuoMode.swift; sourceTree = "<group>"; };
 		D22A9EC84DF55DCD1BC0375A /* NotebookCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookCommands.swift; sourceTree = "<group>"; };
 		D24DBC53D478768A5D6CE7FD /* TaskCapsuleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskCapsuleView.swift; sourceTree = "<group>"; };
 		D2CED0304B6C9E2C66E36C76 /* WalletFuzzHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletFuzzHost.swift; sourceTree = "<group>"; };
@@ -1860,6 +1873,7 @@
 				8EB8D5DA2649A27A3EBA878A /* CompanionGatewayDispatchTests.swift */,
 				D095B47B9746E5A9518B378A /* ComposerActionLayoutTests.swift */,
 				A491778F1D037D27577933D6 /* ConnectorCredentialStoreTests.swift */,
+				1A776F486ABB33978D4191DC /* DuoModeTests.swift */,
 				8DA74AD4E22D8B98449672B3 /* EvaluationsModelTests.swift */,
 				0DABDD16528EA9C1AC509C49 /* EventAutomationTests.swift */,
 				49E9BC1C9E1C566EF4F45ED2 /* ExtensionsModelTests.swift */,
@@ -2111,6 +2125,8 @@
 				280F024C977F01FE6DD9754A /* DisplaySynchronizedFlushDriver.swift */,
 				FAE95B12D4CC3E3AFB18920D /* DocumentPreviewView.swift */,
 				B313AE68C7413C99043DC025 /* DocumentReference.swift */,
+				00A551954B8AF7809312CE68 /* DuoComposerView.swift */,
+				D115FE7DDE634FFF940A29AE /* DuoMode.swift */,
 				5D4452FAF6D288142B4A7D97 /* EvaluationsModel.swift */,
 				CFD0205FA722D64452114722 /* EventAutomationModel.swift */,
 				7184FC675F98588E23686E11 /* EventAutomationsView.swift */,
@@ -3098,6 +3114,8 @@
 				E3B6737A2EEE5E689031843D /* DisplaySynchronizedFlushDriver.swift in Sources */,
 				A7DE1CDE297F0018D2913E60 /* DocumentPreviewView.swift in Sources */,
 				210D76D68EDFA5DD820DEB60 /* DocumentReference.swift in Sources */,
+				50367394DAFC374362B65530 /* DuoComposerView.swift in Sources */,
+				494D6912A5D0A47A37AD6EF1 /* DuoMode.swift in Sources */,
 				25AEA36D28EE65564ABBD8F2 /* EvaluationsModel.swift in Sources */,
 				06ADE2CCB492F5CE875C332B /* EventAutomationModel.swift in Sources */,
 				78A8DEBD85F233EB06360042 /* EventAutomationModels.swift in Sources */,
@@ -3297,6 +3315,7 @@
 				BA82D0A66F95D3D2BC2A436D /* CompanionGatewayDispatchTests.swift in Sources */,
 				BB87CEC02C10F72888D8E304 /* ComposerActionLayoutTests.swift in Sources */,
 				D98BCC0E77D5BFF2F65B3AEA /* ConnectorCredentialStoreTests.swift in Sources */,
+				C857F53E418AACD77AB22546 /* DuoModeTests.swift in Sources */,
 				7D574CD4392C1B789A8677E3 /* EvaluationsModelTests.swift in Sources */,
 				35AD522E6466693DCA95C608 /* EventAutomationTests.swift in Sources */,
 				FD75A463593C71F5D357C59C /* ExtensionsModelTests.swift in Sources */,
@@ -3463,6 +3482,8 @@
 				F0CF3AC449C1C0ABC9F54E25 /* DisplaySynchronizedFlushDriver.swift in Sources */,
 				348A993BC1517CACAF12958B /* DocumentPreviewView.swift in Sources */,
 				E77B6C3A0E472B2E665BEB46 /* DocumentReference.swift in Sources */,
+				00223BCA9D608BE0202B90FC /* DuoComposerView.swift in Sources */,
+				506DDBB7B2C9824F4E1ABA2B /* DuoMode.swift in Sources */,
 				A69A590FDE2C024480D9873F /* EvaluationsModel.swift in Sources */,
 				E67550109750DDEA67D1557A /* EventAutomationModel.swift in Sources */,
 				C8F9725AB843BD6489E25643 /* EventAutomationModels.swift in Sources */,
@@ -3700,6 +3721,8 @@
 				D227A7079971F898D2E3F4C9 /* DisplaySynchronizedFlushDriver.swift in Sources */,
 				F61A2D9941C7435E4059BF75 /* DocumentPreviewView.swift in Sources */,
 				3EA53D005A4EB3C74EBE5B1A /* DocumentReference.swift in Sources */,
+				109AF22C512FD9E528DBC839 /* DuoComposerView.swift in Sources */,
+				18944B9DCA2DD0556FBC5752 /* DuoMode.swift in Sources */,
 				8D64027366EE0D317354F550 /* EvaluationsModel.swift in Sources */,
 				F1E33EDA1731AA01F6BFCF9C /* EventAutomationModel.swift in Sources */,
 				69930BEA7D31BBDA2909AD2A /* EventAutomationModels.swift in Sources */,
@@ -3897,6 +3920,7 @@
 				90667593E38291947FC2EEC8 /* CompanionGatewayDispatchTests.swift in Sources */,
 				9B3486B25AE385D73BBC4CFE /* ComposerActionLayoutTests.swift in Sources */,
 				DB725BA127D4A485F716DB25 /* ConnectorCredentialStoreTests.swift in Sources */,
+				F233B6CDB49B59D16BBD681E /* DuoModeTests.swift in Sources */,
 				44B0AF0AC178238FA8858BF9 /* EvaluationsModelTests.swift in Sources */,
 				3363CC1EDAF1B2F2037819A7 /* EventAutomationTests.swift in Sources */,
 				8A75BFCF7265D35E382E669F /* ExtensionsModelTests.swift in Sources */,
@@ -4074,6 +4098,8 @@
 				C32242B97D1825A26407D109 /* DisplaySynchronizedFlushDriver.swift in Sources */,
 				E34D1270EA77F64F7CF3CCE3 /* DocumentPreviewView.swift in Sources */,
 				9F24D8C0EE8A4D376931714D /* DocumentReference.swift in Sources */,
+				47C3782F3771A47689835501 /* DuoComposerView.swift in Sources */,
+				CD3728281B1D1253165D1E25 /* DuoMode.swift in Sources */,
 				0F6E9659DD293134A89BB907 /* EvaluationsModel.swift in Sources */,
 				96ED1BFCB63D3E8FA6CD7E2C /* EventAutomationModel.swift in Sources */,
 				F6DB356BCD7966465DECFB95 /* EventAutomationModels.swift in Sources */,

--- a/Locus/AgentTeams.swift
+++ b/Locus/AgentTeams.swift
@@ -114,7 +114,7 @@ struct AgentModeOverlays: Codable, Hashable {
         switch mode {
         case .ask: ask
         case .work: work
-        case .plan: plan
+        case .plan, .duo: plan
         case .grill: grill
         }
     }

--- a/Locus/AgentTeamsSettingsView.swift
+++ b/Locus/AgentTeamsSettingsView.swift
@@ -1449,7 +1449,7 @@ private struct AgentBehaviorEditor: View {
     @ViewBuilder
     private var promptPreview: some View {
         Picker("Preview mode", selection: $previewMode) {
-            ForEach(WorkMode.allCases) { Text($0.title).tag($0) }
+            ForEach(WorkMode.automationCases) { Text($0.title).tag($0) }
         }
         .pickerStyle(.segmented)
         .accessibilityIdentifier("settings.behavior.preview.mode")

--- a/Locus/AppModel+BackendEvents.swift
+++ b/Locus/AppModel+BackendEvents.swift
@@ -13,6 +13,11 @@ extension AppModel {
         guard let type = event["type"] as? String else { return }
         if source == nil || source === backend {
             goals.handleEvent(event, sessionID: event["session_id"] as? String ?? currentSessionID)
+            let owner = event["session_id"] as? String ?? currentSessionID
+            if taskCapsules.activeStageSessions[owner] != nil {
+                duo.handleEvent(event, sessionID: owner)
+                taskCapsules.handleEvent(event, sessionID: owner)
+            }
         }
         if handleOptionalQuestionEvent(event, sessionID: event["session_id"] as? String ?? currentSessionID) { return }
         if ["identity_action_request", "identity_context_request", "identity_cancelled"].contains(type) {
@@ -925,6 +930,9 @@ extension AppModel {
         defer { transcriptSessionMetadataDidBecomeReady() }
         pendingTranscriptTransition = nil
         let previousSessionID = currentSessionID
+        defer {
+            if previousSessionID != currentSessionID, duoTask != nil { selectedMode = .duo }
+        }
         let isDuplicateAcknowledgement = currentSessionID == info.sessionID
             && !pendingSessionReset
             && !pendingRetry

--- a/Locus/AppModel+ChatWorkers.swift
+++ b/Locus/AppModel+ChatWorkers.swift
@@ -489,6 +489,9 @@ extension AppModel {
     private func handleWorkerEvent(_ event: [String: Any], runtime: ChatWorkerRuntime) {
         goals.handleEvent(event, sessionID: runtime.sessionID)
         if handleOptionalQuestionEvent(event, sessionID: runtime.sessionID) { return }
+        if taskCapsules.activeStageSessions[runtime.sessionID] != nil {
+            duo.handleEvent(event, sessionID: runtime.sessionID)
+        }
         taskCapsules.handleEvent(event, sessionID: runtime.sessionID)
         if let type = event["type"] as? String,
            ["identity_action_request", "identity_context_request", "identity_cancelled"].contains(type) {

--- a/Locus/AppModel+SendPipeline.swift
+++ b/Locus/AppModel+SendPipeline.swift
@@ -33,7 +33,12 @@ extension AppModel {
         capsuleDispatch explicitCapsuleDispatch: TaskCapsuleDispatch? = nil
     ) {
         guard admitTranscriptInput() else { return }
-        let pendingCapsule = taskCapsules.pendingPlanningRequest(for: currentSessionID)
+        if selectedMode == .duo, explicitCapsuleDispatch == nil, !isBusy, !hasPendingPermission {
+            sendDuo(rawText, includeAttachments: includeAttachments)
+            return
+        }
+        let pendingCapsule = (selectedMode != .duo && duoTask != nil)
+            ? nil : taskCapsules.pendingPlanningRequest(for: currentSessionID)
         let capsuleDispatch = explicitCapsuleDispatch ?? pendingCapsule.flatMap(capsulePlanningDispatch)
         if pendingCapsule != nil, capsuleDispatch == nil { return }
         if capsuleDispatch != nil, isBusy || hasPendingPermission {
@@ -894,6 +899,8 @@ extension AppModel {
     }
 
     func drainQueuedMessages() {
+        if selectedMode == .duo, let phase = duoTask?.phase,
+           phase != .planning && phase != .completed { return }
         guard canAcceptTranscriptInput, !goals.isDiscardingUserInput(sessionID: currentSessionID),
               !isBusy, !hasPendingPermission, !planApprovalPending,
               pendingUserQuestion == nil, !queuedMessages.isEmpty else {
@@ -989,6 +996,10 @@ extension AppModel {
 
     func retryLastResponse() {
         guard admitTranscriptInput() else { return }
+        if selectedMode == .duo {
+            showToast("Use Duo's Resume, Revise, or New plan action to continue")
+            return
+        }
         guard !isBusy, !hasPendingPermission,
               blocks.contains(where: { $0.kind == .user })
         else { return }

--- a/Locus/AppModel+TaskCapsules.swift
+++ b/Locus/AppModel+TaskCapsules.swift
@@ -31,10 +31,18 @@ extension AppModel {
     }
 
     func configureTaskCapsules() {
+        taskCapsules.didSavePlan = { [weak self] capsule, request in
+            self?.duo.planSaved(capsule, request: request)
+        }
+        taskCapsules.didFailToSavePlan = { [weak self] request in
+            guard let self, let id = request.originSessionID, var task = duo.saved.tasks[id] else { return }
+            task.error = "The plan could not be saved. Retry saving before accepting it."
+            duo.put(task)
+        }
         taskCapsules.configure(
             backend: backend,
             workspacePathProvider: { [weak self] in self?.workspacePath ?? "" },
-            profilesProvider: { [weak self] in self?.agentProfiles ?? [] },
+            profilesProvider: { [weak self] in self?.capsuleProfiles ?? [] },
             profileLabelProvider: { [weak self] profile in
                 let account = self?.providerAccounts.first { $0.id == profile.route.accountID }
                 return "\(profile.name) · \(profile.model) · \(account?.displayName ?? "Local Ollama")"
@@ -101,23 +109,25 @@ extension AppModel {
     }
 
     func capsulePlanningDispatch(_ request: TaskCapsulePlanningRequest) -> TaskCapsuleDispatch? {
-        var context: [String: Any] = ["stage": request.capsuleID == nil ? "plan" : "escalate",
+        let stage = request.capsuleID == nil || request.revisionOnly == true ? "plan" : "escalate"
+        var context: [String: Any] = ["stage": stage,
                                       "call_limit": request.recipe.planningCallLimit]
         if let id = request.capsuleID { context["id"] = id }
         if let revision = request.expectedRevision { context["revision"] = revision }
-        if request.capsuleID != nil, let runID = request.originRunID {
+        if stage == "escalate", let runID = request.originRunID {
             context["continuation_of_run_id"] = runID
         }
         return capsuleDispatch(profileID: request.recipe.plannerProfileID, context: context, mode: .plan)
     }
 
-    func startCapsuleStage(_ capsule: TaskCapsule, stage: String, resumeAttemptID: String? = nil, checksOnly: Bool = false) {
+    func startCapsuleStage(_ capsule: TaskCapsule, stage: String, resumeAttemptID: String? = nil, checksOnly: Bool = false, handoffID: String? = nil) {
         guard !isIdentityTask, !isBusy, !hasPendingPermission, isAgentOnline,
               TaskCapsuleModel.canonicalWorkspace(capsule.workspaceRoot) == TaskCapsuleModel.canonicalWorkspace(workspacePath) else {
             taskCapsules.error = "Open an idle regular task in this capsule's workspace and connect the agent."
             return
         }
         var context: [String: Any] = ["id": capsule.id, "revision": capsule.revision, "stage": stage]
+        if let handoffID { context["handoff_id"] = handoffID }
         if let resumeAttemptID {
             context["resume_attempt_id"] = resumeAttemptID
             context["checks_only"] = checksOnly
@@ -145,8 +155,8 @@ extension AppModel {
              consumeMatchingDraft: false, allowLocalCommands: false, capsuleDispatch: dispatch)
     }
 
-    private func capsuleDispatch(profileID: String, context: [String: Any], mode: WorkMode) -> TaskCapsuleDispatch? {
-        guard let profile = agentProfiles.first(where: { $0.id.uuidString.caseInsensitiveCompare(profileID) == .orderedSame }),
+    func capsuleDispatch(profileID: String, context: [String: Any], mode: WorkMode) -> TaskCapsuleDispatch? {
+        guard let profile = capsuleProfiles.first(where: { $0.id.uuidString.caseInsensitiveCompare(profileID) == .orderedSame }),
               let resolved = capsuleProvider(profile) else { return nil }
         return TaskCapsuleDispatch(profile: profile, provider: resolved.provider, accountID: resolved.accountID,
                                    providerBody: resolved.body, context: context, mode: mode)
@@ -188,7 +198,7 @@ extension AppModel {
     }
 
     private func capsuleProfilePayload(id: String) -> [String: Any]? {
-        guard let profile = agentProfiles.first(where: { $0.id.uuidString.caseInsensitiveCompare(id) == .orderedSame }),
+        guard let profile = capsuleProfiles.first(where: { $0.id.uuidString.caseInsensitiveCompare(id) == .orderedSame }),
               let resolved = capsuleProvider(profile) else { return nil }
         var route = resolved.body
         if resolved.provider == "ollama" { route["host"] = lastOllamaHost }

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -94,6 +94,7 @@ final class AppModel: ObservableObject {
     let landingFlow = LandingFlowModel()
     let runs = OrchestrationRunsModel()
     let taskCapsules = TaskCapsuleModel()
+    let duo: DuoModel
     let goals = GoalModel()
     let optionalQuestions = OptionalQuestionModel()
     let soloCollaboration = SoloCollaborationModel()
@@ -246,6 +247,7 @@ final class AppModel: ObservableObject {
     func finishTranscriptInputLoad(_ token: TranscriptSessionLoadToken) {
         guard transcriptPresentation.ownsSessionLoad(token) else { return }
         transcriptInputState = sessionInfo?.sessionID == currentSessionID ? .ready : .unavailable
+        if transcriptInputState == .ready, duoTask != nil { selectedMode = .duo }
     }
 
     func failTranscriptInputLoad(_ token: TranscriptSessionLoadToken) {
@@ -771,12 +773,14 @@ final class AppModel: ObservableObject {
         credentialStore: (any CredentialStoring)? = nil,
         mcpCredentialStore: (any MCPCredentialStoring)? = nil,
         browserAutofillVault: BrowserAutofillVault? = nil,
-        connectorCredentialStore: (any ConnectorCredentialStoring)? = nil
+        connectorCredentialStore: (any ConnectorCredentialStoring)? = nil,
+        duoOverride: DuoModel? = nil
     ) {
         let isUITesting = ProcessInfo.processInfo.environment["LOCUS_UI_TESTING"] == "1"
         self.isUITesting = isUITesting
         let persistenceEnabled = startImmediately && !isUITesting
         self.persistenceEnabled = persistenceEnabled
+        duo = duoOverride ?? DuoModel(defaults: persistenceEnabled ? .standard : nil)
         identityVault = IdentityVaultModel(
             store: persistenceEnabled ? IdentityVaultStore() : IdentityVaultStore(inMemory: ()),
             defaults: persistenceEnabled ? .standard : nil

--- a/Locus/AutomationWorkflowEditorView.swift
+++ b/Locus/AutomationWorkflowEditorView.swift
@@ -258,7 +258,7 @@ private struct WorkflowStepCard: View {
         Picker("Work mode", selection: Binding(
             get: { step.mode ?? .work }, set: { step.mode = $0 }
         )) {
-            ForEach(WorkMode.allCases) { Text($0.title).tag($0) }
+            ForEach(WorkMode.automationCases) { Text($0.title).tag($0) }
         }
         VStack(alignment: .leading, spacing: 5) {
             HStack {

--- a/Locus/ComposerView.swift
+++ b/Locus/ComposerView.swift
@@ -327,6 +327,10 @@ struct ComposerView: View {
             // be typed or sent until the request is answered, and the keyboard
             // drives the answer. The draft lives on the model, so it survives
             // the editor unmounting and is back the moment the panel clears.
+            if model.selectedMode == .duo, !model.isIdentityTask {
+                DuoComposerView(duo: model.duo, capsules: model.taskCapsules)
+                    .frame(maxWidth: 740)
+            }
             if model.canAcceptTranscriptInput, let request = model.activePermissionRequest {
                 PermissionPromptView(request: request)
                     .frame(maxWidth: 740)
@@ -1376,6 +1380,7 @@ struct ComposerView: View {
         case .work: "Ask Locus to work on something…"
         case .plan: "Describe what you want to plan…"
         case .grill: "What should we stress-test?"
+        case .duo: "What should Duo plan and build?"
         }
     }
 

--- a/Locus/ComposerWorkflowPopover.swift
+++ b/Locus/ComposerWorkflowPopover.swift
@@ -20,6 +20,7 @@ struct ComposerWorkflowPopover: View {
 
     private var availableChoices: [Choice] {
         var choices: [Choice] = [.mode(.work), .mode(.plan), .mode(.grill)]
+        if !model.isIdentityTask { choices.insert(.mode(.duo), at: 2) }
         if model.canStartGoal { choices.append(.goal) }
         if !model.isIdentityTask { choices.append(.capsules) }
         choices.append(.teams)
@@ -31,6 +32,7 @@ struct ComposerWorkflowPopover: View {
         case .ask: "bubble.left"
         case .work: "sparkles"
         case .plan: "list.bullet.clipboard"
+        case .duo: "person.2"
         case .grill: "questionmark.bubble"
         }
     }
@@ -43,7 +45,7 @@ struct ComposerWorkflowPopover: View {
                 .padding(.top, 7)
                 .padding(.bottom, 6)
 
-            ForEach([WorkMode.work, .plan, .grill]) { mode in
+            ForEach([WorkMode.work, .plan] + (model.isIdentityTask ? [] : [.duo]) + [.grill]) { mode in
                 row(
                     mode.title,
                     choice: .mode(mode),
@@ -144,6 +146,7 @@ struct ComposerWorkflowPopover: View {
         switch mode {
         case .work: "Let Locus choose the approach and get it done."
         case .plan: "Review a plan before making changes."
+        case .duo: "Plan with one model. Accept, then build with another."
         case .grill: "Sharpen your idea with one question at a time."
         case .ask: mode.description
         }

--- a/Locus/DuoComposerView.swift
+++ b/Locus/DuoComposerView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+struct DuoComposerView: View {
+    @EnvironmentObject private var model: AppModel
+    @ObservedObject var duo: DuoModel
+    @ObservedObject var capsules: TaskCapsuleModel
+
+    private var task: DuoTask? { model.duoTask }
+    private var locked: Bool { task != nil || model.isBusy || model.hasPendingPermission }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) { choices }
+            if let task {
+                HStack {
+                    Text(status(task)).font(.locus(size: 11, weight: .semibold))
+                    Spacer()
+                    if !model.isBusy, task.phase != .executing {
+                        Button("New plan") { model.newDuoPlan() }
+                            .accessibilityIdentifier("duo.newPlan")
+                    }
+                }
+                if let capsule = task.capsule, task.phase == .ready {
+                    Text(capsule.plan.title).font(.locus(size: 13, weight: .semibold))
+                    DisclosureGroup("Review plan · \(capsule.plan.steps.count) steps") {
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 9) {
+                                Text(capsule.plan.summary)
+                                ForEach(Array(capsule.plan.decisions.enumerated()), id: \.offset) { _, item in Text("Decision: \(item)") }
+                                ForEach(Array(capsule.plan.constraints.enumerated()), id: \.offset) { _, item in Text("Constraint: \(item)") }
+                                if capsule.plan.stepDetails.isEmpty {
+                                    ForEach(Array(capsule.plan.steps.enumerated()), id: \.offset) { index, item in Text("\(index + 1). \(item)") }
+                                } else {
+                                    ForEach(capsule.plan.stepDetails) { step in
+                                        Text(step.title).bold()
+                                        Text(step.instructions)
+                                        if !step.files.isEmpty { Text("Files: " + step.files.joined(separator: ", ")) }
+                                        ForEach(Array(step.checks.enumerated()), id: \.offset) { _, check in Text("Check: \(check)") }
+                                        ForEach(Array(step.acceptanceChecks.enumerated()), id: \.offset) { _, check in
+                                            if let requirement = check["requirement"]?.string { Text("Check: \(requirement)") }
+                                        }
+                                    }
+                                }
+                                ForEach(Array(capsule.plan.tests.enumerated()), id: \.offset) { _, item in Text("Verify: \(item)") }
+                                ForEach(Array(capsule.plan.acceptanceChecks.enumerated()), id: \.offset) { _, check in
+                                    if let requirement = check["requirement"]?.string { Text("Verify: \(requirement)") }
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .textSelection(.enabled)
+                            .padding(.vertical, 6)
+                        }.frame(maxHeight: 240)
+                    }
+                    .accessibilityIdentifier("duo.plan")
+                    HStack {
+                        Button("Accept & build") { model.acceptDuo() }
+                            .buttonStyle(.borderedProminent)
+                            .accessibilityIdentifier("duo.accept")
+                        Button("Revise") { model.reviseDuo() }
+                            .accessibilityIdentifier("duo.revise")
+                    }.disabled(model.isBusy || model.hasPendingPermission || !model.isAgentOnline)
+                } else if task.phase == .paused {
+                    HStack {
+                        Button("Resume") { model.acceptDuo(resume: true) }.accessibilityIdentifier("duo.resume")
+                        Button("Ask planner for help") {
+                            model.reviseDuo(feedback: "Inspect the partial work and the failed checks. Resolve the blocker and submit an updated plan for acceptance.")
+                        }
+                        Button("Review recovery") { model.openDuoRecovery() }
+                    }.disabled(model.isBusy || model.hasPendingPermission || !model.isAgentOnline)
+                } else if task.phase == .saving, !model.isBusy {
+                    Button("Retry saving plan") { Task { await model.saveDuoPlanAgain() } }
+                        .disabled(capsules.isSaving)
+                }
+                if let error = task.error { Text(error).foregroundStyle(.red) }
+            } else {
+                Text("Review the plan, then accept to start the builder.")
+                    .foregroundStyle(LocusTheme.muted)
+            }
+            if let error = capsules.error { Text(error).foregroundStyle(.red) }
+        }
+        .font(.locus(size: 10))
+        .padding(12)
+        .locusCard(radius: 12)
+        .accessibilityIdentifier("duo.panel")
+        .task(id: model.currentSessionID) { await model.refreshDuo() }
+        .onChange(of: model.isBusy) { if !model.isBusy { Task { await model.refreshDuo() } } }
+        .onChange(of: capsules.isPresented) { if !capsules.isPresented { Task { await model.refreshDuo() } } }
+    }
+
+    @ViewBuilder private var choices: some View {
+        choice(planner: true, profile: task?.planner ?? duo.saved.planner)
+        Image(systemName: "arrow.right").foregroundStyle(LocusTheme.muted).accessibilityHidden(true)
+        choice(planner: false, profile: task?.executor ?? duo.saved.executor)
+    }
+
+    private func choice(planner: Bool, profile: AgentProfile?) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(planner ? "Plan with" : "Build with").foregroundStyle(LocusTheme.muted)
+            if locked {
+                Text(model.duoLabel(profile)).lineLimit(1).truncationMode(.middle)
+                    .help(model.duoLabel(profile))
+                    .accessibilityIdentifier(planner ? "duo.planner" : "duo.executor")
+            } else {
+                Menu {
+                    ForEach(model.modelPickerSections) { section in
+                        Section(section.title) {
+                            ForEach(section.models, id: \.self) { name in
+                                Button(name) { model.selectDuoModel(account: section.account, model: name, planner: planner) }
+                            }
+                            if let message = section.emptyMessage { Text(message) }
+                        }
+                    }
+                } label: {
+                    Text(model.duoLabel(profile)).lineLimit(1).truncationMode(.middle)
+                }
+                .accessibilityIdentifier(planner ? "duo.planner" : "duo.executor")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func status(_ task: DuoTask) -> String {
+        switch task.phase {
+        case .planning: "Planning · \(task.planner.model)"
+        case .saving: "Saving plan"
+        case .ready: "Ready to build · \(task.executor.model)"
+        case .executing: "Building · \(task.executor.model)"
+        case .paused: "Build paused · \(task.executor.model)"
+        case .completed: "Follow-ups use \(task.executor.model)"
+        }
+    }
+}

--- a/Locus/DuoMode.swift
+++ b/Locus/DuoMode.swift
@@ -1,0 +1,292 @@
+import Combine
+import Foundation
+
+enum DuoPhase: String, Codable {
+    case planning, saving, ready, executing, paused, completed
+}
+
+/// Routes contain account identifiers, never credentials. The saved pair is
+/// independent of the ordinary model picker and of later default-pair edits.
+struct DuoTask: Codable {
+    var sessionID: String
+    var workspaceRoot: String
+    var planner: AgentProfile
+    var executor: AgentProfile
+    var phase: DuoPhase = .planning
+    var request: TaskCapsulePlanningRequest
+    var capsule: TaskCapsule?
+    var submittedPlan: PlanDocument?
+    var handoffID = UUID().uuidString
+    var activeRunID: String?
+    var error: String?
+}
+
+@MainActor
+final class DuoModel: ObservableObject {
+    struct Saved: Codable {
+        var planner: AgentProfile?
+        var executor: AgentProfile?
+        var tasks: [String: DuoTask] = [:]
+        // Keep routes available to capsules from earlier Duo tasks as well.
+        var profiles: [AgentProfile] = []
+    }
+
+    @Published private(set) var saved: Saved
+    private let defaults: UserDefaults?
+    private static let key = "locus.duo.v1"
+
+    init(defaults: UserDefaults? = .standard) {
+        self.defaults = defaults
+        saved = defaults?.data(forKey: Self.key).flatMap { try? JSONDecoder().decode(Saved.self, from: $0) } ?? Saved()
+        // Reopening restores a decision, never an automatic model call.
+        for id in Array(saved.tasks.keys) where saved.tasks[id]?.phase == .executing {
+            saved.tasks[id]?.phase = .paused
+        }
+    }
+
+    func task(sessionID: String, workspace: String) -> DuoTask? {
+        guard let task = saved.tasks[sessionID],
+              task.workspaceRoot == TaskCapsuleWorkspace.canonicalPath(workspace) else { return nil }
+        return task
+    }
+
+    func setChoice(_ profile: AgentProfile, planner: Bool) {
+        if planner { saved.planner = profile } else { saved.executor = profile }
+        remember(profile)
+        persist()
+    }
+
+    func put(_ task: DuoTask) {
+        saved.tasks[task.sessionID] = task
+        remember(task.planner)
+        remember(task.executor)
+        persist()
+    }
+
+    func remove(sessionID: String) {
+        saved.tasks[sessionID] = nil
+        persist()
+    }
+
+    private func remember(_ profile: AgentProfile) {
+        if !saved.profiles.contains(where: { $0.id == profile.id }) { saved.profiles.append(profile) }
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(saved) { defaults?.set(data, forKey: Self.key) }
+    }
+
+    func planSaved(_ capsule: TaskCapsule, request: TaskCapsulePlanningRequest) {
+        guard let id = request.originSessionID, var task = saved.tasks[id],
+              task.phase == .planning || task.phase == .saving,
+              task.workspaceRoot == capsule.workspaceRoot,
+              task.request.originRunID == request.originRunID,
+              task.request.recipe == request.recipe else { return }
+        task.capsule = capsule
+        task.submittedPlan = nil
+        task.phase = .ready
+        task.handoffID = UUID().uuidString
+        task.activeRunID = nil
+        task.error = nil
+        put(task)
+    }
+
+    func handleEvent(_ event: [String: Any], sessionID: String) {
+        guard var task = saved.tasks[sessionID] else { return }
+        let type = event["type"] as? String
+        if let runID = event["run_id"] as? String,
+           type != "run_started", type != "capsule_stage",
+           let active = task.activeRunID, runID != active { return }
+        switch type {
+        case "run_started", "capsule_stage":
+            guard task.phase == .planning || task.phase == .executing else { return }
+            task.activeRunID = event["run_id"] as? String ?? task.activeRunID
+            if task.phase == .planning { task.request.originRunID = task.activeRunID }
+        case "plan_ready" where task.phase == .planning:
+            if let raw = event["plan"], let data = try? JSONSerialization.data(withJSONObject: raw),
+               let plan = try? JSONDecoder().decode(PlanDocument.self, from: data) {
+                task.submittedPlan = plan
+            }
+        case "capsule_progress":
+            guard event["capsule_id"] as? String == task.capsule?.id,
+                  let raw = event["attempt"], let data = try? JSONSerialization.data(withJSONObject: raw),
+                  let attempt = try? JSONDecoder().decode(CapsuleAttempt.self, from: data) else { return }
+            task.capsule?.attempts.removeAll { $0.id == attempt.id }
+            task.capsule?.attempts.insert(attempt, at: 0)
+            task.phase = attempt.state == "completed" ? .completed : attempt.state == "running" ? .executing : .paused
+        case "error" where task.phase == .planning || task.phase == .executing:
+            task.error = event["message"] as? String
+        case "turn_done":
+            if task.phase == .planning, task.submittedPlan != nil,
+               (event["reason"] as? String ?? "complete") == "complete" {
+                task.phase = .saving
+            } else if task.phase == .executing {
+                task.phase = .paused
+            }
+        default: return
+        }
+        put(task)
+    }
+}
+
+extension AppModel {
+    var duoTask: DuoTask? { duo.task(sessionID: currentSessionID, workspace: workspacePath) }
+    var capsuleProfiles: [AgentProfile] { agentProfiles + duo.saved.profiles }
+
+    func selectDuoModel(account: ProviderAccount?, model: String, planner: Bool) {
+        let subscription = account == nil || account?.kind == .chatGPT || account?.kind == .kimiCode
+        let profile = AgentProfile(name: planner ? "Duo planner" : "Duo builder",
+            route: account.map { .providerAccount($0.id) } ?? .localOllama, model: model,
+            role: planner ? .planner : .implementer,
+            accessCeiling: planner ? .readOnly : .workspaceWrite,
+            metering: subscription ? .selfHosted : .metered)
+        duo.setChoice(profile, planner: planner)
+    }
+
+    func duoLabel(_ profile: AgentProfile?) -> String {
+        guard let profile else { return "Choose model" }
+        let account = Self.capsuleAccount(profile: profile, accounts: providerAccounts)
+        return "\(profile.model) · \(account?.displayName ?? (profile.route == .localOllama ? "Ollama" : "Unavailable account"))"
+    }
+
+    /// All Duo messages leave this method with an explicit, temporary route.
+    /// The backend continues to receive its existing plan/work modes.
+    func sendDuo(_ text: String, includeAttachments: Bool) {
+        guard !isIdentityTask, !currentSessionID.isEmpty, isAgentOnline,
+              !isBusy, !hasPendingPermission else {
+            showToast("Open an idle, connected regular task to use Duo")
+            return
+        }
+        guard goals.goal(for: currentSessionID)?.status != .active else {
+            showToast("Pause the current goal before using Duo")
+            return
+        }
+        let prompt = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else { showToast("Describe what you want Duo to build"); return }
+        taskCapsules.error = nil
+        if var task = duoTask {
+            switch task.phase {
+            case .ready:
+                reviseDuo(feedback: prompt)
+            case .saving:
+                showToast("Save the finished plan before continuing")
+            case .paused, .executing:
+                showToast("Resume the build or ask the planner for help before continuing")
+            case .planning:
+                guard let dispatch = capsulePlanningDispatch(task.request) else { return }
+                task.submittedPlan = nil
+                task.activeRunID = nil
+                task.error = nil
+                if task.request.capsuleID != nil, task.request.originRunID == nil,
+                   taskCapsules.pendingPlanningRequest(for: currentSessionID) == nil {
+                    task.request.blocker = "\(task.request.blocker ?? "")\n\nRequested revision: \(prompt)"
+                    duo.put(task)
+                    startCapsulePlanning(task.request)
+                    if draftText.trimmingCharacters(in: .whitespacesAndNewlines) == prompt { draftText = "" }
+                    return
+                }
+                if taskCapsules.pendingPlanningRequest(for: currentSessionID) == nil {
+                    taskCapsules.planningStarted(task.request, sessionID: currentSessionID)
+                }
+                task.error = nil
+                duo.put(task)
+                send(prompt, preservingDraftOnFailure: true, includeAttachments: includeAttachments,
+                     allowLocalCommands: false, capsuleDispatch: dispatch)
+            case .completed:
+                guard let capsule = task.capsule,
+                      let dispatch = capsuleDispatch(profileID: task.executor.id.uuidString,
+                        context: ["id": capsule.id, "revision": capsule.revision, "stage": "followup"], mode: .work) else { return }
+                // A follow-up is ordinary executor work; keep the completed
+                // capsule's evidence separate from this additional request.
+                send(prompt, preservingDraftOnFailure: true, includeAttachments: includeAttachments,
+                     allowLocalCommands: false, capsuleDispatch: dispatch)
+            }
+            return
+        }
+        guard let planner = duo.saved.planner, let executor = duo.saved.executor else {
+            showToast("Choose Plan with and Build with before sending")
+            return
+        }
+        // Validate both exact routes before consuming the user's request.
+        guard capsuleDispatch(profileID: planner.id.uuidString, context: [:], mode: .plan) != nil,
+              capsuleDispatch(profileID: executor.id.uuidString, context: [:], mode: .work) != nil else { return }
+        var recipe = TaskCapsuleRecipe()
+        recipe.plannerProfileID = planner.id.uuidString
+        recipe.executorProfileID = executor.id.uuidString
+        let request = TaskCapsulePlanningRequest(title: "", request: prompt,
+            workspaceRoot: TaskCapsuleWorkspace.canonicalPath(workspacePath), recipe: recipe,
+            originSessionID: currentSessionID)
+        duo.put(DuoTask(sessionID: currentSessionID, workspaceRoot: request.workspaceRoot,
+                        planner: planner, executor: executor, request: request))
+        startCapsulePlanning(request)
+        if draftText.trimmingCharacters(in: .whitespacesAndNewlines) == prompt { draftText = "" }
+    }
+
+    func acceptDuo(resume: Bool = false) {
+        guard var task = duoTask, let capsule = task.capsule,
+              task.phase == .ready || (resume && task.phase == .paused),
+              !isBusy, !hasPendingPermission, isAgentOnline else { return }
+        guard goals.goal(for: currentSessionID)?.status != .active else { return }
+        taskCapsules.error = nil
+        guard capsuleDispatch(profileID: task.executor.id.uuidString, context: [:], mode: .work) != nil else { return }
+        let attempt = resume ? capsule.resumableAttempt : nil
+        if let attempt, !attempt.canResume { openDuoRecovery(); return }
+        task.phase = .executing
+        task.error = nil
+        task.activeRunID = nil
+        duo.put(task) // Persist before dispatch; repeated clicks now do nothing.
+        startCapsuleStage(capsule, stage: "execute", resumeAttemptID: attempt?.id,
+                          handoffID: attempt == nil ? task.handoffID : nil)
+    }
+
+    func reviseDuo(feedback: String? = nil) {
+        guard var task = duoTask, let capsule = task.capsule,
+              !isBusy, !hasPendingPermission, isAgentOnline else { return }
+        guard capsuleDispatch(profileID: task.planner.id.uuidString, context: [:], mode: .plan) != nil else { return }
+        let previous = (try? JSONEncoder().encode(capsule.plan)).flatMap { String(data: $0, encoding: .utf8) } ?? ""
+        task.request.capsuleID = capsule.id
+        task.request.expectedRevision = capsule.revision
+        task.request.originRunID = nil
+        task.request.revisionOnly = task.phase == .ready
+        task.request.blocker = "\(feedback ?? "Ask which changes the user wants before revising the plan.")\n\nSaved plan:\n\(previous)"
+        task.phase = .planning
+        task.submittedPlan = nil
+        task.activeRunID = nil
+        task.error = nil
+        duo.put(task)
+        if feedback != nil { startCapsulePlanning(task.request) }
+    }
+
+    func saveDuoPlanAgain() async {
+        guard let task = duoTask, task.phase == .saving, let plan = task.submittedPlan else { return }
+        _ = await taskCapsules.savePlan(plan, request: task.request)
+    }
+
+    func refreshDuo() async {
+        guard let task = duoTask, let capsule = task.capsule, !isBusy, isAgentOnline else { return }
+        do {
+            let response = try await backend.get("/api/capsules/\(capsule.id)",
+                query: [URLQueryItem(name: "workspace_root", value: task.workspaceRoot)], as: TaskCapsuleResponse.self)
+            guard var current = duo.saved.tasks[task.sessionID], current.handoffID == task.handoffID,
+                  current.capsule?.revision == response.capsule.revision else { return }
+            current.capsule = response.capsule
+            if current.phase == .paused || current.phase == .executing {
+                if response.capsule.attempts.first?.state == "completed" { current.phase = .completed }
+                else { current.phase = .paused }
+            }
+            duo.put(current)
+        } catch { /* The saved plan remains available; dispatch revalidates it. */ }
+    }
+
+    func openDuoRecovery() {
+        guard let capsule = duoTask?.capsule else { return }
+        taskCapsules.open(selecting: capsule.id)
+    }
+
+    func newDuoPlan() {
+        guard !isBusy, !hasPendingPermission else { return }
+        taskCapsules.cancelPlanning(sessionID: currentSessionID)
+        duo.remove(sessionID: currentSessionID)
+        planApprovalPending = false
+    }
+}

--- a/Locus/EventAutomationsView.swift
+++ b/Locus/EventAutomationsView.swift
@@ -1262,7 +1262,7 @@ private struct EventTriggerEditorView: View {
             }
         }
         Picker("Work mode", selection: $draft.mode) {
-            ForEach(WorkMode.allCases) { Text($0.title).tag($0) }
+            ForEach(WorkMode.automationCases) { Text($0.title).tag($0) }
         }.onChange(of: draft.mode) { _, mode in
             if let index = draft.workflow.steps.firstIndex(where: { $0.type == .agent }) { draft.workflow.steps[index].mode = mode }
         }

--- a/Locus/Models/AgentModels.swift
+++ b/Locus/Models/AgentModels.swift
@@ -47,6 +47,7 @@ struct TurnCompletion: Codable, Hashable {
             case .ask: "Chat finished"
             case .work: "Work finished"
             case .plan: "Plan finished"
+            case .duo: "Duo finished"
             case .grill: "Grill finished"
             case nil: "Finished"
             }

--- a/Locus/Models/ScheduleModels.swift
+++ b/Locus/Models/ScheduleModels.swift
@@ -5,7 +5,11 @@ enum WorkMode: String, CaseIterable, Codable, Identifiable {
     case ask
     case work
     case plan
+    case duo
     case grill
+
+    /// Duo needs an interactive acceptance and a task-owned model pair.
+    static var automationCases: [WorkMode] { allCases.filter { $0 != .duo } }
 
     var id: String { rawValue }
 
@@ -32,6 +36,7 @@ enum WorkMode: String, CaseIterable, Codable, Identifiable {
         case .ask: "Ask"
         case .work: "Work"
         case .plan: "Plan"
+        case .duo: "Duo"
         case .grill: "Grill"
         }
     }
@@ -41,6 +46,7 @@ enum WorkMode: String, CaseIterable, Codable, Identifiable {
         case .ask: "Answers without workspace access"
         case .work: "Chooses the right approach for the request"
         case .plan: "Maps the work before editing"
+        case .duo: "Plan with one model, build with another"
         case .grill: "Stress-tests an idea one question at a time"
         }
     }
@@ -51,6 +57,8 @@ enum WorkMode: String, CaseIterable, Codable, Identifiable {
             "Answer conversationally using only the conversation and files or images the user explicitly attached to this message. Do not inspect attachment paths or browse, read, search, or modify any other workspace files. Do not call tools, skills, or external integrations."
         case .work:
             "Solve the request using the workspace and tools when useful. Choose whether to answer, inspect, plan, or implement from the request itself. Follow the current permission policy for every action."
+        case .duo:
+            WorkMode.plan.instruction + " Prepare a handoff for the user's selected implementation model. Execution starts only after the user accepts the saved plan."
         case .plan:
             "Inspect files if useful, but do not modify anything. Ask clarifying questions when needed by calling ask_question with your options and recommended answer. When the plan is final and decision-complete, call submit_plan exactly once with its title, summary, ordered steps, and test scenarios; do not call submit_plan for a question or partial plan."
         case .grill:

--- a/Locus/TaskCapsuleModel.swift
+++ b/Locus/TaskCapsuleModel.swift
@@ -35,6 +35,8 @@ final class TaskCapsuleModel: ObservableObject {
     private var openConversationHandler: (String) -> Void = { _ in }
     @Published private var pendingPlanning: [String: TaskCapsulePlanningRequest] = [:]
     private var submittedPlans: [String: PlanDocument] = [:]
+    var didSavePlan: (TaskCapsule, TaskCapsulePlanningRequest) -> Void = { _, _ in }
+    var didFailToSavePlan: (TaskCapsulePlanningRequest) -> Void = { _ in }
     private var refreshGeneration = UUID()
     private var editingRevision: Int?
     private var currentWorkspacePath: String { TaskCapsuleWorkspace.canonicalPath(workspacePathProvider()) }
@@ -304,6 +306,7 @@ final class TaskCapsuleModel: ObservableObject {
     func planningStarted(_ request: TaskCapsulePlanningRequest, sessionID: String) {
         var normalized = request
         normalized.workspaceRoot = TaskCapsuleWorkspace.canonicalPath(request.workspaceRoot)
+        normalized.originSessionID = sessionID
         pendingPlanning[sessionID] = normalized
         submittedPlans[sessionID] = nil
         activeStageSessions[sessionID] = request.capsuleID == nil ? "Planning" : "Planner help"
@@ -431,8 +434,10 @@ final class TaskCapsuleModel: ObservableObject {
                 status = "Plan saved. Ready to run with \(profileLabel(id: response.capsule.recipe.executorProfileID))."
                 error = nil
             }
+            didSavePlan(response.capsule, request)
             return response.capsule
         } catch {
+            didFailToSavePlan(request)
             if workspace == currentWorkspacePath {
                 self.error = "Could not save the capsule: \(error.localizedDescription). Your plan remains in the conversation."
             }

--- a/Locus/TaskCapsuleTypes.swift
+++ b/Locus/TaskCapsuleTypes.swift
@@ -228,7 +228,7 @@ struct TaskCapsuleRun: Codable, Hashable, Identifiable {
     }
 }
 
-struct TaskCapsulePlanningRequest {
+struct TaskCapsulePlanningRequest: Codable {
     var title: String
     var request: String
     var workspaceRoot: String
@@ -238,6 +238,7 @@ struct TaskCapsulePlanningRequest {
     var blocker: String?
     var originRunID: String?
     var originSessionID: String?
+    var revisionOnly: Bool? = nil
 }
 
 struct TaskCapsulesResponse: Decodable { var capsules: [TaskCapsule] }

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -1972,7 +1972,7 @@ struct ScheduleEditorView: View {
                     .foregroundStyle(LocusTheme.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
                 Picker("Mode", selection: modeBinding) {
-                    ForEach(WorkMode.allCases) { mode in Text(mode.title).tag(mode) }
+                    ForEach(WorkMode.automationCases) { mode in Text(mode.title).tag(mode) }
                 }
                 .accessibilityIdentifier("scheduleEditor.mode")
                 Picker("Runner", selection: $draft.runner) {

--- a/LocusTests/DuoModeTests.swift
+++ b/LocusTests/DuoModeTests.swift
@@ -1,0 +1,215 @@
+import XCTest
+import SwiftUI
+@testable import Locus
+
+@MainActor
+final class DuoModeTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suite: String!
+
+    override func setUp() async throws {
+        suite = "DuoModeTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suite)!
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suite)
+    }
+
+    private func task() -> DuoTask {
+        let planner = AgentProfile(name: "Planner", route: .providerAccount(UUID()), model: "strong", role: .planner)
+        let executor = AgentProfile(name: "Builder", model: "small", role: .implementer, accessCeiling: .workspaceWrite)
+        var recipe = TaskCapsuleRecipe()
+        recipe.plannerProfileID = planner.id.uuidString
+        recipe.executorProfileID = executor.id.uuidString
+        let request = TaskCapsulePlanningRequest(title: "Change", request: "Make the change", workspaceRoot: "/tmp",
+            recipe: recipe, originRunID: "plan-run", originSessionID: "task-one")
+        return DuoTask(sessionID: "task-one", workspaceRoot: TaskCapsuleWorkspace.canonicalPath("/tmp"),
+            planner: planner, executor: executor, request: request)
+    }
+
+    private func capsule(_ task: DuoTask) -> TaskCapsule {
+        TaskCapsule(title: "Change", request: task.request.request, workspaceRoot: task.workspaceRoot,
+                    plan: PlanDocument(title: "Change", steps: ["Implement", "Verify"]), recipe: task.request.recipe)
+    }
+
+    func testReadyPlanAndExactPairSurviveRestartAndDefaultChanges() throws {
+        let model = DuoModel(defaults: defaults)
+        let original = task()
+        model.put(original)
+        model.planSaved(capsule(original), request: original.request)
+        let handoff = try XCTUnwrap(model.saved.tasks[original.sessionID]?.handoffID)
+        model.setChoice(AgentProfile(name: "Other", model: "other"), planner: false)
+        let restored = DuoModel(defaults: defaults)
+        let value = try XCTUnwrap(restored.task(sessionID: original.sessionID, workspace: "/tmp"))
+        XCTAssertEqual(value.phase, .ready)
+        XCTAssertEqual(value.executor, original.executor)
+        XCTAssertEqual(value.planner, original.planner)
+        XCTAssertEqual(value.handoffID, handoff)
+        XCTAssertNil(restored.task(sessionID: original.sessionID, workspace: "/different"))
+        XCTAssertEqual(restored.saved.profiles.count, 3)
+    }
+
+    func testInterruptedBuildRestoresPausedWithoutChangingAcceptedHandoff() throws {
+        let model = DuoModel(defaults: defaults)
+        var original = task()
+        original.capsule = capsule(original)
+        original.phase = .executing
+        model.put(original)
+        let restored = try XCTUnwrap(DuoModel(defaults: defaults).saved.tasks[original.sessionID])
+        XCTAssertEqual(restored.phase, .paused)
+        XCTAssertEqual(restored.handoffID, original.handoffID)
+    }
+
+    func testOnlySuccessfulPlanTurnBecomesSaveableAndStaleRunCannotOverwriteIt() throws {
+        let model = DuoModel(defaults: defaults)
+        var original = task()
+        original.activeRunID = "plan-run"
+        model.put(original)
+        let plan: [String: Any] = ["id": "p", "title": "Plan", "steps": ["Implement"]]
+        model.handleEvent(["type": "plan_ready", "run_id": "old-run", "plan": plan], sessionID: original.sessionID)
+        XCTAssertNil(model.saved.tasks[original.sessionID]?.submittedPlan)
+        model.handleEvent(["type": "plan_ready", "run_id": "plan-run", "plan": plan], sessionID: original.sessionID)
+        model.handleEvent(["type": "turn_done", "run_id": "plan-run", "reason": "interrupted"], sessionID: original.sessionID)
+        XCTAssertEqual(model.saved.tasks[original.sessionID]?.phase, .planning)
+        model.handleEvent(["type": "turn_done", "run_id": "plan-run", "reason": "complete"], sessionID: original.sessionID)
+        XCTAssertEqual(model.saved.tasks[original.sessionID]?.phase, .saving)
+        let restored = DuoModel(defaults: defaults)
+        XCTAssertEqual(restored.saved.tasks[original.sessionID]?.submittedPlan?.title, "Plan")
+    }
+
+    func testLateSaveCannotReplaceAnotherPlanningRun() {
+        let model = DuoModel(defaults: defaults)
+        let original = task()
+        var newer = original
+        newer.request.originRunID = "new-run"
+        model.put(newer)
+        model.planSaved(capsule(original), request: original.request)
+        XCTAssertNil(model.saved.tasks[original.sessionID]?.capsule)
+        XCTAssertEqual(model.saved.tasks[original.sessionID]?.phase, .planning)
+    }
+
+    func testDuoIsInteractiveAndReadOnlyUntilItsExplicitStageDispatch() throws {
+        XCTAssertTrue(WorkMode.allCases.contains(.duo))
+        XCTAssertFalse(WorkMode.automationCases.contains(.duo))
+        XCTAssertTrue(WorkMode.duo.instruction.contains("do not modify"))
+        XCTAssertEqual(try JSONDecoder().decode(WorkMode.self, from: Data("\"duo\"".utf8)), .duo)
+    }
+
+    func testComposerSubmissionDispatchesPlannerAndKeepsDuoSelected() {
+        let state = DuoModel(defaults: defaults)
+        state.setChoice(AgentProfile(name: "Planner", model: "strong", role: .planner), planner: true)
+        state.setChoice(AgentProfile(name: "Builder", model: "small", role: .implementer, accessCeiling: .workspaceWrite), planner: false)
+        let app = AppModel(startImmediately: false, duoOverride: state)
+        app.installTranscriptSession("task-one", blocks: [])
+        app.agentRuntimePhase = .online
+        app.selectedMode = .duo
+        let ordinaryModel = app.selectedModel
+        app.send("Implement the feature")
+        XCTAssertEqual(app.selectedMode, .duo)
+        XCTAssertEqual(app.turnDispatchedMode, .plan)
+        XCTAssertTrue(app.turnDispatchedInPlanMode)
+        XCTAssertEqual(app.duoTask?.planner.model, "strong")
+        XCTAssertEqual(app.duoTask?.executor.model, "small")
+        XCTAssertEqual(app.selectedModel, ordinaryModel)
+        XCTAssertNotNil(app.taskCapsules.pendingPlanningRequest(for: "task-one"))
+    }
+
+    func testAcceptDispatchesBuilderOnceAndReviseWaitsForFeedback() throws {
+        let state = DuoModel(defaults: defaults)
+        let app = AppModel(startImmediately: false, duoOverride: state)
+        app.installTranscriptSession("task-one", blocks: [])
+        app.agentRuntimePhase = .online
+        app.selectedMode = .duo
+        var original = task()
+        original.planner.route = .localOllama
+        original.workspaceRoot = TaskCapsuleWorkspace.canonicalPath(app.workspacePath)
+        original.request.workspaceRoot = original.workspaceRoot
+        state.put(original)
+        state.planSaved(capsule(original), request: original.request)
+        app.reviseDuo()
+        XCTAssertEqual(app.duoTask?.phase, .planning)
+        XCTAssertFalse(app.isBusy, "Revise opens the conversation without spending a planner call")
+        XCTAssertNil(app.taskCapsules.pendingPlanningRequest(for: "task-one"))
+        let revisionDispatch = try XCTUnwrap(app.duoTask.flatMap { app.capsulePlanningDispatch($0.request) })
+        XCTAssertEqual(revisionDispatch.context["stage"] as? String, "plan")
+        XCTAssertNil(revisionDispatch.context["continuation_of_run_id"])
+        original.request.originRunID = nil
+        state.put(original)
+        state.planSaved(capsule(original), request: original.request)
+        let handoff = try XCTUnwrap(app.duoTask?.handoffID)
+        app.acceptDuo()
+        XCTAssertEqual(app.duoTask?.phase, .executing)
+        XCTAssertEqual(app.turnDispatchedMode, .work)
+        XCTAssertEqual(app.selectedMode, .duo)
+        app.acceptDuo()
+        XCTAssertEqual(app.duoTask?.handoffID, handoff)
+        XCTAssertTrue(app.queuedMessages.isEmpty)
+    }
+
+    func testDuoPanelRendersReadyAndPausedAtNarrowWidth() async throws {
+        let state = DuoModel(defaults: defaults)
+        let app = AppModel(startImmediately: false, duoOverride: state)
+        app.installTranscriptSession("task-one", blocks: [])
+        var value = task()
+        value.workspaceRoot = TaskCapsuleWorkspace.canonicalPath(app.workspacePath)
+        value.request.workspaceRoot = value.workspaceRoot
+        value.capsule = capsule(value)
+        value.capsule?.plan.summary = "Use the existing settings controls and preserve the selected account."
+        let output = FileManager.default.temporaryDirectory.appendingPathComponent("locus-duo-renders", isDirectory: true)
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        for phase in [DuoPhase.ready, .paused] {
+            value.phase = phase
+            state.put(value)
+            let view = DuoComposerView(duo: state, capsules: app.taskCapsules)
+                .environmentObject(app).padding(12).frame(width: 420, height: 300, alignment: .topLeading)
+                .preferredColorScheme(.dark)
+            let host = NSHostingView(rootView: view)
+            host.sizingOptions = []
+            let size = NSSize(width: 420, height: 300)
+            let window = NSWindow(contentRect: NSRect(origin: .zero, size: size), styleMask: [.titled], backing: .buffered, defer: false)
+            window.isReleasedWhenClosed = false
+            window.contentView = host
+            host.frame = NSRect(origin: .zero, size: size)
+            window.center()
+            window.makeKeyAndOrderFront(nil)
+            for _ in 0..<4 {
+                host.layoutSubtreeIfNeeded()
+                try await Task.sleep(for: .milliseconds(30))
+            }
+            host.display()
+            let bitmap = try XCTUnwrap(host.bitmapImageRepForCachingDisplay(in: host.bounds))
+            host.cacheDisplay(in: host.bounds, to: bitmap)
+            let png = try XCTUnwrap(bitmap.representation(using: .png, properties: [:]))
+            try png.write(to: output.appendingPathComponent("\(phase.rawValue).png"))
+            let attachment = XCTAttachment(data: png, uniformTypeIdentifier: "public.png")
+            attachment.name = "Duo \(phase.rawValue) at 420px"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+            XCTAssertEqual(host.bounds.size, size)
+            XCTAssertGreaterThan(png.count, 2000)
+            window.orderOut(nil)
+            window.contentView = nil
+            window.close()
+        }
+        print("Duo renders: \(output.path)")
+    }
+
+    func testWaitingDuoDecisionPreservesQueuedMessages() {
+        let state = DuoModel(defaults: defaults)
+        let app = AppModel(startImmediately: false, duoOverride: state)
+        app.installTranscriptSession("task-one", blocks: [])
+        app.agentRuntimePhase = .online
+        app.selectedMode = .duo
+        var value = task()
+        value.workspaceRoot = TaskCapsuleWorkspace.canonicalPath(app.workspacePath)
+        for phase in [DuoPhase.saving, .ready, .paused] {
+            value.phase = phase
+            state.put(value)
+            app.queuedMessages = ["Preserve this follow-up"]
+            app.drainQueuedMessages()
+            XCTAssertEqual(app.queuedMessages, ["Preserve this follow-up"])
+            XCTAssertFalse(app.isBusy)
+        }
+    }
+}

--- a/agent/ollama_code/capsule_execution.py
+++ b/agent/ollama_code/capsule_execution.py
@@ -70,6 +70,8 @@ def execution_manifest(capsule: dict, profiles: list[dict], run_id: str) -> dict
         # Serialize writes even when the author described independent steps.
         dependencies = list(dict.fromkeys([*step.get("dependencies", []), *([previous] if previous else [])]))
         goal = json.dumps({
+            "request": capsule["request"],
+            "summary": plan.get("summary", ""),
             "step": step,
             "constraints": plan.get("constraints", []),
             "decisions": plan.get("decisions", []),
@@ -136,7 +138,7 @@ def run_capsule_request(svc: Any, text: str, context: dict, attachments: Any,
         store = CapsuleStore(svc.core.workspace_root or svc.core.cwd)
         if svc.core.identity_mode:
             raise ValueError("Open a regular task to work with capsules.")
-        if stage not in {"plan", "execute", "review", "escalate"}:
+        if stage not in {"plan", "execute", "review", "escalate", "followup"}:
             raise ValueError("Unknown capsule stage.")
         if context.get("id"):
             capsule = store.get(str(context["id"]))
@@ -158,19 +160,31 @@ def run_capsule_request(svc: Any, text: str, context: dict, attachments: Any,
                 paths = ", ".join(c["path"] for c in validation["changes"][:5])
                 raise ValueError(f"The plan's source files changed ({paths}). Ask the planner to update it first.")
             manifest = execution_manifest(capsule, context.get("profiles") or [], run_id)
-            from .capsule_progress import CapsuleRuntime
-            progress = CapsuleRuntime(svc, capsule, run_id, context.get("resume_attempt_id"))
-            progress.checks_only = context.get("checks_only") is True
-            svc.core.capsule_runtime = progress
         else:
             limit = context.get("call_limit", 12)
             if capsule:
                 limit = capsule["recipe"]["planning_call_limit"]
+            if stage == "followup":
+                from .capsule_progress import CapsuleProgressStore
+                attempts = CapsuleProgressStore(svc.run_store).list(capsule["id"])
+                if not attempts or attempts[0]["state"] != "completed":
+                    raise ValueError("Finish or resume the saved build before sending an executor follow-up.")
+                limit = capsule["recipe"]["execution_call_limit"]
+                text = ("Follow up on the completed task using the approved decisions below. "
+                        "Inspect current files and verify any new changes. If the request requires a material "
+                        "redesign, explain the blocker and ask the user to request a revised Duo plan.\n\n"
+                        + json.dumps({"request": capsule["request"], "plan": capsule["plan"]}, ensure_ascii=False)
+                        + "\n\nUser follow-up:\n" + text)
             if type(limit) is not int or not 1 <= limit <= 100:
                 raise ValueError("The capsule call limit must be between 1 and 100.")
         if capsule:
-            store.record_run(capsule["id"], run_id, stage, "running", expected_revision=capsule["revision"], continuation_of_run_id=continuation, reserve=True)
+            store.record_run(capsule["id"], run_id, stage, "running", expected_revision=capsule["revision"], continuation_of_run_id=continuation, reserve=True, handoff_id=context.get("handoff_id"))
             reserved = True
+        if stage == "execute":
+            from .capsule_progress import CapsuleRuntime
+            progress = CapsuleRuntime(svc, capsule, run_id, context.get("resume_attempt_id"))
+            progress.checks_only = context.get("checks_only") is True
+            svc.core.capsule_runtime = progress
         svc.emit({"type": "capsule_stage", "capsule_id": capsule["id"] if capsule else None,
                   "stage": stage, "run_id": run_id, "state": "running"})
         if stage == "execute":
@@ -178,7 +192,7 @@ def run_capsule_request(svc: Any, text: str, context: dict, attachments: Any,
         else:
             # Plan mode enforces read-only work for authors and reviewers. The
             # exact selected account is already installed on the isolated worker.
-            run_user(svc, text, False, attachments, agent_config, "plan", run_id,
+            run_user(svc, text, False, attachments, agent_config, "work" if stage == "followup" else "plan", run_id,
                      False, None, limit)
         completed = True
     except (CapsuleError, ValueError) as exc:

--- a/agent/ollama_code/capsules.py
+++ b/agent/ollama_code/capsules.py
@@ -362,7 +362,7 @@ class CapsuleStore:
                 changes.append({"path": previous["path"], "reason": "unsafe", "detail": str(exc)})
         return {"valid": not changes, "capsule_id": capsule_id, "revision": capsule["revision"], "changes": changes, "checked_files": len(capsule["source_fingerprints"])}
 
-    def record_run(self, capsule_id: str, run_id: str, stage: str, state: str, expected_revision: int | None = None, *, continuation_of_run_id: str | None = None, reserve: bool = False, attempt_id: str | None = None) -> dict[str, Any]:
+    def record_run(self, capsule_id: str, run_id: str, stage: str, state: str, expected_revision: int | None = None, *, continuation_of_run_id: str | None = None, reserve: bool = False, attempt_id: str | None = None, handoff_id: str | None = None) -> dict[str, Any]:
         run_id = _identifier(run_id, "run_id")
         stage = _identifier(stage, "stage")
         state = _identifier(state, "state")
@@ -370,6 +370,10 @@ class CapsuleStore:
             _integer(expected_revision, "expected_revision", high=2**31 - 1)
         if attempt_id is not None:
             attempt_id = _identifier(attempt_id, "attempt_id")
+        if handoff_id is not None:
+            handoff_id = _identifier(handoff_id, "handoff_id")
+            if stage != "execute":
+                raise CapsuleError("only execution can reserve a plan handoff")
         if continuation_of_run_id is not None:
             continuation_of_run_id = _identifier(continuation_of_run_id, "continuation_of_run_id")
             if stage != "escalate" or continuation_of_run_id == run_id:
@@ -380,6 +384,8 @@ class CapsuleStore:
             if expected_revision is not None and capsule["revision"] != expected_revision:
                 raise CapsuleError("capsule changed before execution was linked", 409)
             previous = next((item for item in capsule["runs"] if item["run_id"] == run_id), None)
+            if reserve and handoff_id and any(item.get("handoff_id") == handoff_id for item in capsule["runs"]):
+                raise CapsuleError("This accepted plan was already started. Refresh and resume its saved attempt.", 409)
             if previous and reserve:
                 raise CapsuleError("this capsule run was already started", 409)
             if previous and previous["stage"] != stage:
@@ -402,11 +408,13 @@ class CapsuleStore:
             link = {"run_id": run_id, "stage": stage, "state": state, "revision": previous["revision"] if previous else capsule["revision"], "updated_at": _now()}
             if attempt_id is not None:
                 link["attempt_id"] = attempt_id
+            if handoff_id is not None:
+                link["handoff_id"] = handoff_id
             if parent is not None:
                 link["continuation_of_run_id"] = parent["run_id"]
                 link["escalation_root_run_id"] = parent.get("escalation_root_run_id", parent["run_id"])
             elif previous:
-                for field in ("continuation_of_run_id", "escalation_root_run_id", "attempt_id"):
+                for field in ("continuation_of_run_id", "escalation_root_run_id", "attempt_id", "handoff_id"):
                     if field in previous:
                         link[field] = previous[field]
             connection.execute("INSERT INTO capsule_runs VALUES(?,?,?) ON CONFLICT(capsule_id,run_id) DO UPDATE SET payload=excluded.payload", (capsule_id, run_id, json.dumps(link)))

--- a/agent/tests/test_capsule_execution.py
+++ b/agent/tests/test_capsule_execution.py
@@ -533,3 +533,43 @@ def test_generic_team_resume_keeps_existing_checkpoint_path(monkeypatch, tmp_pat
     response = asyncio.run(runs_api._resume_orchestration(service, _no_model, record["id"], {"manifest": {"team": {"id": "team-one"}}}, action="resume"))
     assert response["state"] == "queued"
     assert starts[0][1][-1]["_resume"] == record["checkpoint"]["state"]
+
+
+def test_duo_followup_uses_work_mode_and_execution_allowance(capsule_setup, monkeypatch):
+    from ollama_code.capsule_progress import CapsuleProgressStore
+    workspace, store, capsule, profiles = capsule_setup
+    service, events = _service(workspace)
+    monkeypatch.setattr(CapsuleProgressStore, "list", lambda self, capsule_id: [{"state": "completed"}])
+    calls = []
+    run_capsule_request(service, "Polish the result", _context(capsule, profiles, "followup"), None, None,
+                        "followup-one", run_user=lambda *args: calls.append(args), run_team=_no_model)
+    assert len(calls) == 1
+    assert calls[0][5] == "work"
+    assert calls[0][-1] == capsule["recipe"]["execution_call_limit"]
+    assert "Polish the result" in calls[0][1]
+    assert "Preserve the public API" in calls[0][1]
+    assert not [event for event in events if event["type"] == "error"]
+    assert store.get(capsule["id"])["runs"][-1]["stage"] == "followup"
+
+
+def test_duo_followup_cannot_bypass_unfinished_build(capsule_setup, monkeypatch):
+    from ollama_code.capsule_progress import CapsuleProgressStore
+    workspace, store, capsule, profiles = capsule_setup
+    service, events = _service(workspace)
+    monkeypatch.setattr(CapsuleProgressStore, "list", lambda self, capsule_id: [{"state": "paused"}])
+    run_capsule_request(service, "Continue", _context(capsule, profiles, "followup"), None, None,
+                        "followup-too-early", run_user=_no_model, run_team=_no_model)
+    assert any("resume the saved build" in event.get("message", "") for event in events)
+    assert store.get(capsule["id"])["runs"] == []
+
+
+def test_duplicate_duo_handoff_does_not_create_another_attempt(capsule_setup):
+    from ollama_code.capsule_progress import CapsuleProgressStore
+    workspace, store, capsule, profiles = capsule_setup
+    service, events = _service(workspace)
+    store.record_run(capsule["id"], "first-run", "execute", "completed", expected_revision=1,
+                     reserve=True, handoff_id="same-acceptance")
+    context = {**_context(capsule, profiles), "handoff_id": "same-acceptance"}
+    run_capsule_request(service, "Build", context, None, None, "duplicate-run", run_user=_no_model, run_team=_no_model)
+    assert any("already started" in event.get("message", "") for event in events)
+    assert CapsuleProgressStore(service.run_store).list(capsule["id"]) == []

--- a/agent/tests/test_capsules.py
+++ b/agent/tests/test_capsules.py
@@ -307,3 +307,41 @@ def test_run_conversation_link_requires_available_run_in_capsule_workspace(works
         assert "session_id" not in presented_run()
     finally:
         client.close()
+
+
+def test_duo_acceptance_reserves_one_run_even_with_different_run_ids(workspace, payload):
+    store = CapsuleStore(str(workspace))
+    capsule = store.create(payload)
+
+    def reserve(index):
+        try:
+            return store.record_run(capsule["id"], f"duo-run-{index}", "execute", "running",
+                                    expected_revision=1, reserve=True, handoff_id="accepted-plan-once")
+        except CapsuleError as error:
+            assert error.status_code == 409
+            return None
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(reserve, range(4)))
+    winners = [result for result in results if result]
+    assert len(winners) == 1
+    winner = winners[0]
+    store.record_run(capsule["id"], winner["run_id"], "execute", "completed")
+    reopened = CapsuleStore(str(workspace))
+    with pytest.raises(CapsuleError, match="already started"):
+        reopened.record_run(capsule["id"], "after-restart", "execute", "running",
+                            expected_revision=1, reserve=True, handoff_id="accepted-plan-once")
+    assert len(reopened.get(capsule["id"])["runs"]) == 1
+    assert reopened.get(capsule["id"])["runs"][0]["handoff_id"] == "accepted-plan-once"
+
+
+def test_duo_handoff_rejects_stale_revision_and_non_execution_stage(workspace, payload):
+    store = CapsuleStore(str(workspace))
+    capsule = store.create(payload)
+    store.update(capsule["id"], {"title": "Revised"}, 1)
+    with pytest.raises(CapsuleError, match="changed"):
+        store.record_run(capsule["id"], "stale", "execute", "running", expected_revision=1,
+                         reserve=True, handoff_id="accept-old")
+    with pytest.raises(CapsuleError, match="only execution"):
+        store.record_run(capsule["id"], "plan", "plan", "running", reserve=True, handoff_id="accept-old")
+    assert store.get(capsule["id"])["runs"] == []


### PR DESCRIPTION
Duo adds an inline planner/builder pair to the composer. The planner prepares a read-only plan; after the user chooses **Accept & build**, the selected builder implements it and handles follow-ups. **Revise**, **Resume**, and **Ask planner for help** keep the workflow in the same task.

The implementation reuses Task Capsules for saved plans, source validation, verification, and recovery. It persists the exact model/account pair and reserves each accepted handoff once, including concurrent requests and restarts. Duo stays out of automation and specialist mode menus because it requires interactive acceptance.

Validation:

- 106 capsule backend tests pass, including duplicate acceptance, restart reservation, and follow-up gating.
- Python lint, design-system audit, protocol manifest, and generated-project consistency checks pass.
- 44 focused native tests pass against this standalone branch: 9 Duo, 24 capsule model, and 11 capsule routing tests.
- The broader local AppModel run was stopped when macOS FSEvents stalled in the existing `testSessionInfoWithMissingFieldsStillDecodes` test. The focused suite above then completed successfully. Full GitHub CI remains in progress.
- Provider calls are stubbed; no live paid model run is claimed.

User guidance and suggested follow-ups are in `Docs/DuoMode.md`.
