### PR TITLE
Reach self-hosted model servers on the LAN, without disabling ATS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,11 @@ jobs:
         run: git diff --exit-code -- Locus.xcodeproj/project.pbxproj
       - name: Design-system source audit
         run: Tools/AuditDesignSystem.sh
+      # The app disables App Transport Security so it can reach self-hosted
+      # model servers on plain HTTP. This is what enforces the rules ATS used
+      # to enforce for everything else.
+      - name: Transport-security audit
+        run: python3 Tools/AuditTransportSecurity.py
       - name: Protocol manifest is current
         run: python3 Tools/ProtocolManifest.py
       - name: Shared wire types still compile for iOS

--- a/Config/LocusExperimental-Info.plist
+++ b/Config/LocusExperimental-Info.plist
@@ -108,6 +108,22 @@
 		<string>wallet.slush.app</string>
 		<string>my.slush.app</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<!-- Locus talks to model servers the user runs themselves: Ollama,
+		     llama.cpp, LM Studio and friends serve plain HTTP on a LAN
+		     address and cannot present a certificate any CA would sign.
+		     NSAllowsLocalNetworking does not cover RFC1918 literals such as
+		     192.168.1.50, and NSExceptionDomains does not accept IP
+		     addresses, so this blanket opt-out is the only key that reaches
+		     them. It must stay ALONE: adding NSAllowsLocalNetworking or
+		     NSAllowsArbitraryLoadsInWebContent alongside it makes current
+		     macOS ignore it entirely. Tools/AuditTransportSecurity.py
+		     enforces both that rule and the https-only rule for every
+		     endpoint the user did not type, which ATS no longer backstops. -->
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_locus-remote._tcp</string>
@@ -119,7 +135,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 SparkTales Inc.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Locus uses your private network only when you enable Mobile Access and pair a phone.</string>
+	<string>Locus uses your private network to reach model servers you run yourself, such as Ollama on another machine, and when you enable Mobile Access and pair a phone.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Locus uses the microphone for dictation, voice conversations, and websites you explicitly allow.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/Config/LocusMAS-Info.plist
+++ b/Config/LocusMAS-Info.plist
@@ -64,11 +64,27 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 SparkTales Inc.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Locus uses your private network only when you enable Mobile Access and pair a phone.</string>
+	<string>Locus uses your private network to reach model servers you run yourself, such as Ollama on another machine, and when you enable Mobile Access and pair a phone.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Locus uses the microphone for dictation, voice conversations, and websites you explicitly allow.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Locus turns speech into editable dictation or voice messages when you use a voice control.</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<!-- Locus talks to model servers the user runs themselves: Ollama,
+		     llama.cpp, LM Studio and friends serve plain HTTP on a LAN
+		     address and cannot present a certificate any CA would sign.
+		     NSAllowsLocalNetworking does not cover RFC1918 literals such as
+		     192.168.1.50, and NSExceptionDomains does not accept IP
+		     addresses, so this blanket opt-out is the only key that reaches
+		     them. It must stay ALONE: adding NSAllowsLocalNetworking or
+		     NSAllowsArbitraryLoadsInWebContent alongside it makes current
+		     macOS ignore it entirely. Tools/AuditTransportSecurity.py
+		     enforces both that rule and the https-only rule for every
+		     endpoint the user did not type, which ATS no longer backstops. -->
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_locus-remote._tcp</string>

--- a/Config/LocusRelease-Info.plist
+++ b/Config/LocusRelease-Info.plist
@@ -61,6 +61,22 @@
 	<string>$(LOCUS_GOOGLE_OAUTH_CLIENT_ID)</string>
 	<key>LocusGoogleOAuthCallbackScheme</key>
 	<string>$(LOCUS_GOOGLE_OAUTH_REVERSED_CLIENT_ID)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<!-- Locus talks to model servers the user runs themselves: Ollama,
+		     llama.cpp, LM Studio and friends serve plain HTTP on a LAN
+		     address and cannot present a certificate any CA would sign.
+		     NSAllowsLocalNetworking does not cover RFC1918 literals such as
+		     192.168.1.50, and NSExceptionDomains does not accept IP
+		     addresses, so this blanket opt-out is the only key that reaches
+		     them. It must stay ALONE: adding NSAllowsLocalNetworking or
+		     NSAllowsArbitraryLoadsInWebContent alongside it makes current
+		     macOS ignore it entirely. Tools/AuditTransportSecurity.py
+		     enforces both that rule and the https-only rule for every
+		     endpoint the user did not type, which ATS no longer backstops. -->
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_locus-remote._tcp</string>
@@ -72,7 +88,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 SparkTales Inc.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Locus uses your private network only when you enable Mobile Access and pair a phone.</string>
+	<string>Locus uses your private network to reach model servers you run yourself, such as Ollama on another machine, and when you enable Mobile Access and pair a phone.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Locus uses the microphone for dictation, voice conversations, and websites you explicitly allow.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/Config/LocusX-Info.plist
+++ b/Config/LocusX-Info.plist
@@ -108,6 +108,22 @@
 		<string>wallet.slush.app</string>
 		<string>my.slush.app</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<!-- Locus talks to model servers the user runs themselves: Ollama,
+		     llama.cpp, LM Studio and friends serve plain HTTP on a LAN
+		     address and cannot present a certificate any CA would sign.
+		     NSAllowsLocalNetworking does not cover RFC1918 literals such as
+		     192.168.1.50, and NSExceptionDomains does not accept IP
+		     addresses, so this blanket opt-out is the only key that reaches
+		     them. It must stay ALONE: adding NSAllowsLocalNetworking or
+		     NSAllowsArbitraryLoadsInWebContent alongside it makes current
+		     macOS ignore it entirely. Tools/AuditTransportSecurity.py
+		     enforces both that rule and the https-only rule for every
+		     endpoint the user did not type, which ATS no longer backstops. -->
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_locus-remote._tcp</string>
@@ -119,7 +135,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 SparkTales Inc.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Locus uses your private network only when you enable Mobile Access and pair a phone.</string>
+	<string>Locus uses your private network to reach model servers you run yourself, such as Ollama on another machine, and when you enable Mobile Access and pair a phone.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Locus uses the microphone for dictation, voice conversations, and websites you explicitly allow.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/Locus.xcodeproj/project.pbxproj
+++ b/Locus.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 		419A2176224E57C1AEEE8165 /* AgentTeamsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29912FD4FFA8E9056AD4FCA2 /* AgentTeamsSettingsView.swift */; };
 		41BA46E2384171111BE67650 /* TextSelectionMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB36421DC413C2F3F5BDA72 /* TextSelectionMenu.swift */; };
 		41F8A0001D657B015E587B7B /* InspectorPlanTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD0CDE34355390B1AB4691E /* InspectorPlanTab.swift */; };
+		424D7766A14D0ADF46A36826 /* TransportSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268B56AD1DA01122C727F4E1 /* TransportSecurity.swift */; };
 		426A637C69A40ECCC368708E /* AgentInspectorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9562D71A05C50114A2C06A0C /* AgentInspectorUITests.swift */; };
 		42927488EC3A3862DCDC786A /* WalletReleaseHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA04206C0C456E08825BAD13 /* WalletReleaseHistoryTests.swift */; };
 		4297547C774045019671A8CF /* AgentInstructionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619AB05A65A0972B3D6352D /* AgentInstructionsModel.swift */; };
@@ -557,6 +558,7 @@
 		6C73699442C809810E8C8A70 /* TranscriptSearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8089379A9D8E1CAC5D5D1F /* TranscriptSearchModel.swift */; };
 		6C964EAC1D14D3267ABD308C /* WorkspaceIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = B082AFE6729F96D2D8606AC9 /* WorkspaceIndex.swift */; };
 		6CB6F6C625981B438BD534AB /* AppModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41E39F35E0F75A05095B5EC /* AppModelTests.swift */; };
+		6D1A26E08F8E3BCBAF411C07 /* TransportSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49ECC15746E29BA10ABCD61B /* TransportSecurityTests.swift */; };
 		6D511AEDDDB94B3992AD828F /* InspectorSimulatorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBE8AF1AA0E88FC532FCF8D /* InspectorSimulatorTab.swift */; };
 		6DD7B911B57AF897D59C6458 /* ToastCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3DF12677F019C6F0E4D853 /* ToastCenter.swift */; };
 		6E03866922D4742E373302CC /* BackendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3793FC69B1D813ED07567A2E /* BackendService.swift */; };
@@ -711,6 +713,7 @@
 		91DFFC281AA6FF86775D2E48 /* IdentityVaultLocalApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32BCC3E03454E18967FBB9DE /* IdentityVaultLocalApplication.swift */; };
 		91FEDF04EFA5915B5EAD2595 /* BrowserSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EC9F73687880887B6C9153 /* BrowserSettingsView.swift */; };
 		920E67FE0C0C95DD895561A6 /* OnboardingModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7319E19CEAC14B0E501AB68B /* OnboardingModelTests.swift */; };
+		923DF8CAA37F1F297C48DDAC /* TransportSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268B56AD1DA01122C727F4E1 /* TransportSecurity.swift */; };
 		928FC3A730E244463996F68D /* TaskDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3E4392D534C3A47B578EC6 /* TaskDetailView.swift */; };
 		92B2C14F94666578AB048D63 /* BrowserBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D7A27ACF9B37EC8F79B9D7 /* BrowserBridge.swift */; };
 		9311A38A463F1FA7D9962016 /* NotebookModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7233FFED68A0709BF2F83B9A /* NotebookModel.swift */; };
@@ -798,6 +801,7 @@
 		A2D50A15DCEA46828A34BBA7 /* AppModel+VoiceControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EBAE40DE85C2315DFA1510 /* AppModel+VoiceControls.swift */; };
 		A2D930FC44B7830379B35C05 /* ProviderModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2F4D55B6CB8B4C966BACBE /* ProviderModelCatalog.swift */; };
 		A30505C37DD566089459DCFE /* ConnectorCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC319DECFC4BFE93E4E3AB5F /* ConnectorCredentialStore.swift */; };
+		A30E234D163F54C024DEB662 /* TransportSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268B56AD1DA01122C727F4E1 /* TransportSecurity.swift */; };
 		A36E648B4632790D1DD1AA80 /* IdentityVaultDocuments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B753A7B8BD43A11BD1D0D5A7 /* IdentityVaultDocuments.swift */; };
 		A386B208A9F32AB86DF9D8D2 /* InspectorSimulatorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBE8AF1AA0E88FC532FCF8D /* InspectorSimulatorTab.swift */; };
 		A3AA989233E15B494EF67F36 /* WalletSignerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530DCDEFEDCBE87B25169CB8 /* WalletSignerProtocol.swift */; };
@@ -881,6 +885,7 @@
 		B2680863F8708D485BD69BFF /* AppModel+ComposerAttachments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C16181F2E5716CD6DBEEE4D /* AppModel+ComposerAttachments.swift */; };
 		B29BFD5C919E84B537BFA4B9 /* InspectorModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059B4B4EC6DB6EA4BF29D8E1 /* InspectorModels.swift */; };
 		B2BC6EA06090417CB4D15937 /* TaskCapsuleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CBFBA78FC3DA71C8B372D3 /* TaskCapsuleModel.swift */; };
+		B2F9E84DC5D207BC099121C1 /* TransportSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49ECC15746E29BA10ABCD61B /* TransportSecurityTests.swift */; };
 		B2FA86AB67D50C396F106886 /* CompanionSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE2B3114660DB1F97EBB87C /* CompanionSettingsView.swift */; };
 		B302C713CDCD5A21C3CF431C /* LocalRuntimeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55065A982A7FB563B8DEA87 /* LocalRuntimeCoordinator.swift */; };
 		B31C942EB057AC3161C3B11A /* OptionalQuestionPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273C7C6585F49C796917D50B /* OptionalQuestionPanel.swift */; };
@@ -1013,6 +1018,7 @@
 		CC124FC78E5C4561812D6CF8 /* ImageGenerationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB93CD077106FFA5A907ACB /* ImageGenerationSettingsView.swift */; };
 		CC34DB49F0794EFC59213A34 /* ModelLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB88F08135C226D4D6AFF6A /* ModelLibraryView.swift */; };
 		CC84EC76E96114140583157D /* InteractiveAnswerHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3411DB72F172857D07DD4158 /* InteractiveAnswerHost.swift */; };
+		CCDACB61AB46A10AC27573E7 /* TransportSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268B56AD1DA01122C727F4E1 /* TransportSecurity.swift */; };
 		CCE0C9F7DA04FE0F2ED8D51E /* RemoteEndpointTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EE3ED166C864419A854532 /* RemoteEndpointTester.swift */; };
 		CCF73FB9EA3B4EF6F74C4E87 /* AgentManagementPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9101B0FC031593F78262CC9 /* AgentManagementPresentation.swift */; };
 		CD0488B68DCD0C600DBF4696 /* WorkspaceLibraryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545B2CE438B65B82EEEC95F3 /* WorkspaceLibraryModel.swift */; };
@@ -1443,6 +1449,7 @@
 		252379D65C8C61E943C94FE4 /* VoiceCloudClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCloudClient.swift; sourceTree = "<group>"; };
 		2619AB05A65A0972B3D6352D /* AgentInstructionsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInstructionsModel.swift; sourceTree = "<group>"; };
 		2638F444CF15996577237A9E /* AgentManagementPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentManagementPresentationTests.swift; sourceTree = "<group>"; };
+		268B56AD1DA01122C727F4E1 /* TransportSecurity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportSecurity.swift; sourceTree = "<group>"; };
 		26C94997668FDA620F006087 /* NotebookEditorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorTests.swift; sourceTree = "<group>"; };
 		273C7C6585F49C796917D50B /* OptionalQuestionPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalQuestionPanel.swift; sourceTree = "<group>"; };
 		280F024C977F01FE6DD9754A /* DisplaySynchronizedFlushDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySynchronizedFlushDriver.swift; sourceTree = "<group>"; };
@@ -1497,6 +1504,7 @@
 		494AA2883078C54BAF0BF14C /* AppModel+LandingFlowFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+LandingFlowFacade.swift"; sourceTree = "<group>"; };
 		49ACBD89CE89777C7AB09F1E /* AgentSidebarCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSidebarCatalogTests.swift; sourceTree = "<group>"; };
 		49E9BC1C9E1C566EF4F45ED2 /* ExtensionsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsModelTests.swift; sourceTree = "<group>"; };
+		49ECC15746E29BA10ABCD61B /* TransportSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportSecurityTests.swift; sourceTree = "<group>"; };
 		4CB88F08135C226D4D6AFF6A /* ModelLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelLibraryView.swift; sourceTree = "<group>"; };
 		4CCD53839428838B380300D2 /* ChatAttachmentIngest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentIngest.swift; sourceTree = "<group>"; };
 		4D16150F05480F3D9E417239 /* AppModel+SplitChatPanes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+SplitChatPanes.swift"; sourceTree = "<group>"; };
@@ -1946,6 +1954,7 @@
 				B9803427C2F43062BF1C6A92 /* TranscriptRelayoutTests.swift */,
 				0E5439CB8E7839C8BC3DE3F7 /* TranscriptSearchModelTests.swift */,
 				C22A462B4342C2597DC23767 /* TranscriptSelectionTests.swift */,
+				49ECC15746E29BA10ABCD61B /* TransportSecurityTests.swift */,
 				1C052048E0CEFC4C54FAFA74 /* VoiceControlTests.swift */,
 				4256D150F66371F2E3D57CC4 /* WalletConnectionTests.swift */,
 				7337A7707C9C63DF1807061E /* WalletConnectorDriverTests.swift */,
@@ -2274,6 +2283,7 @@
 				8C8089379A9D8E1CAC5D5D1F /* TranscriptSearchModel.swift */,
 				418F31828D4EE1F1E605A01F /* TranscriptSelectionGeometry.swift */,
 				15FBD1A1C4963CEA3D54440E /* TranscriptSelectionStore.swift */,
+				268B56AD1DA01122C727F4E1 /* TransportSecurity.swift */,
 				C71ED07E3C0848F3EFA00364 /* UsageAccounting.swift */,
 				A5CC6B3A08FFA65A82439731 /* UsageDashboardView.swift */,
 				252379D65C8C61E943C94FE4 /* VoiceCloudClient.swift */,
@@ -3338,6 +3348,7 @@
 				16F4C550E7CCBCF722C96E48 /* TranscriptSearchModel.swift in Sources */,
 				0560D2915AA749ECCDA3A2C0 /* TranscriptSelectionGeometry.swift in Sources */,
 				F944EB74AB7A6DDE91D0504A /* TranscriptSelectionStore.swift in Sources */,
+				CCDACB61AB46A10AC27573E7 /* TransportSecurity.swift in Sources */,
 				5016C6DABC21463130BF7E6D /* UsageAccounting.swift in Sources */,
 				E57CA891BFB049D7F2B53872 /* UsageDashboardView.swift in Sources */,
 				A9815ADD31E61246D8AD55C0 /* VoiceCloudClient.swift in Sources */,
@@ -3461,6 +3472,7 @@
 				A2ABF63BAC7D91824652DBD2 /* TranscriptRelayoutTests.swift in Sources */,
 				F43AFCBB3DA51D3E9BA73F37 /* TranscriptSearchModelTests.swift in Sources */,
 				151503634B4BE07947B021B2 /* TranscriptSelectionTests.swift in Sources */,
+				B2F9E84DC5D207BC099121C1 /* TransportSecurityTests.swift in Sources */,
 				56132808032C1FE7F60E1262 /* VoiceControlTests.swift in Sources */,
 				FC966A9F25069D9CCF2BC843 /* WorkspaceBrowserModelTests.swift in Sources */,
 				576D00B8A24D3BD2750ADF83 /* WorkspaceFileModelTests.swift in Sources */,
@@ -3713,6 +3725,7 @@
 				9B809359453C0BE9E930B7D6 /* TranscriptSearchModel.swift in Sources */,
 				DA7A4D8766795F0B3E069A2E /* TranscriptSelectionGeometry.swift in Sources */,
 				6BDF0861929C613C6783F77F /* TranscriptSelectionStore.swift in Sources */,
+				A30E234D163F54C024DEB662 /* TransportSecurity.swift in Sources */,
 				BD5D6B1E635FA0B3FBB5153D /* UsageAccounting.swift in Sources */,
 				6FDB5F37C36EE733A8A7DD43 /* UsageDashboardView.swift in Sources */,
 				8AE7B8C82DF5F26403DC5A44 /* VoiceCloudClient.swift in Sources */,
@@ -3958,6 +3971,7 @@
 				6C73699442C809810E8C8A70 /* TranscriptSearchModel.swift in Sources */,
 				BBDE84D324F6199CD80D6E0F /* TranscriptSelectionGeometry.swift in Sources */,
 				C5ACDAE5CF08E05BD60EFDD3 /* TranscriptSelectionStore.swift in Sources */,
+				424D7766A14D0ADF46A36826 /* TransportSecurity.swift in Sources */,
 				5E1FA9DAF04265A51682886F /* UsageAccounting.swift in Sources */,
 				C702DDBC94CDC2241F409353 /* UsageDashboardView.swift in Sources */,
 				6A0B3DA6370E8931310E78CA /* VoiceCloudClient.swift in Sources */,
@@ -4079,6 +4093,7 @@
 				D3CFB99F27A3CA05A4370508 /* TranscriptRelayoutTests.swift in Sources */,
 				83E035BCD336109DAAAFC686 /* TranscriptSearchModelTests.swift in Sources */,
 				1F7CEFA3ABFF4B608C53D8EC /* TranscriptSelectionTests.swift in Sources */,
+				6D1A26E08F8E3BCBAF411C07 /* TransportSecurityTests.swift in Sources */,
 				1273672D68D3A3A2DB0A8F15 /* VoiceControlTests.swift in Sources */,
 				4BF42DC9E93B3995345E84A3 /* WalletConnectionTests.swift in Sources */,
 				08AC7BF8CCC27181F153C4FD /* WalletConnectorDriverTests.swift in Sources */,
@@ -4342,6 +4357,7 @@
 				96C67088DC7789B1C74D7E69 /* TranscriptSearchModel.swift in Sources */,
 				3BF6907C2A05F414E6B4DFDC /* TranscriptSelectionGeometry.swift in Sources */,
 				635E3CABE47AC408883F7753 /* TranscriptSelectionStore.swift in Sources */,
+				923DF8CAA37F1F297C48DDAC /* TransportSecurity.swift in Sources */,
 				AAD081BF7FABD8D97DE1BA91 /* UsageAccounting.swift in Sources */,
 				97847072BB411D0A4971C58A /* UsageDashboardView.swift in Sources */,
 				CABE794E7D140D95CD83BE85 /* VoiceCloudClient.swift in Sources */,

--- a/Locus/AccountEditorView.swift
+++ b/Locus/AccountEditorView.swift
@@ -82,6 +82,48 @@ struct AccountEditorView: View {
         return typed.isEmpty ? kind.defaultBaseURL : typed
     }
 
+    /// Tells the user when their endpoint is unencrypted, and how much that
+    /// costs them.
+    ///
+    /// The app disables App Transport Security so a self-hosted model server on
+    /// the LAN can be reached at all, which means the OS no longer refuses a
+    /// cleartext endpoint on the user's behalf — this row is what replaces that
+    /// refusal with something they can act on. Loopback and LAN addresses get a
+    /// quiet note; an `http://` endpoint that routes off the network is the
+    /// case that actually leaks prompts, so it is called out as a warning.
+    @ViewBuilder
+    private var cleartextNotice: some View {
+        // Half-typed input is not a finding. Classify only once the string
+        // parses into a URL that actually names a scheme and a host, so the row
+        // does not flash a warning at someone mid-keystroke.
+        let normalized = RemoteEndpointTester.normalizeBaseURL(resolvedBaseURL)
+        let exposure = URL(string: normalized)
+            .flatMap { $0.scheme != nil && !($0.host ?? "").isEmpty ? $0 : nil }
+            .map(TransportSecurity.exposure(of:))
+        switch exposure {
+        case .cleartextRoutable:
+            Label(
+                "Not encrypted. This endpoint is outside your network, so prompts and replies travel as plain text and anyone on the path can read them.",
+                systemImage: "lock.open"
+            )
+            .font(.locus(size: 9))
+            .foregroundStyle(LocusTheme.warningForeground)
+            .fixedSize(horizontal: false, vertical: true)
+            .accessibilityIdentifier("accountEditor.cleartextRoutable")
+        case .cleartextPrivate:
+            Label(
+                "Not encrypted, but this address stays on your own network.",
+                systemImage: "lock.open"
+            )
+            .font(.locus(size: 9))
+            .foregroundStyle(LocusTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .accessibilityIdentifier("accountEditor.cleartextPrivate")
+        case .encrypted, .none:
+            EmptyView()
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             HStack {
@@ -136,6 +178,7 @@ struct AccountEditorView: View {
                                 field: .baseURL,
                                 identifier: "accountEditor.baseURL"
                             )
+                            cleartextNotice
                         }
 
                     inputRow(

--- a/Locus/CodexComponentInstaller.swift
+++ b/Locus/CodexComponentInstaller.swift
@@ -49,9 +49,15 @@ final class CodexComponentInstaller: ObservableObject {
         }
     }
 
+    /// The feed hands back an executable component this installer unpacks and
+    /// runs, so it is the last place that should ever speak cleartext. App
+    /// Transport Security used to guarantee that for free; the app now ships
+    /// `NSAllowsArbitraryLoads` so it can reach self-hosted model servers, and
+    /// `TransportSecurity` is what enforces it in its place.
     static var feedURL: URL? {
-        let configured = Bundle.main.object(forInfoDictionaryKey: "LocusComponentFeedURL") as? String
-        return URL(string: configured ?? "")
+        TransportSecurity.requireEncrypted(
+            Bundle.main.object(forInfoDictionaryKey: "LocusComponentFeedURL") as? String
+        )
     }
 
     static var currentArchitecture: String {

--- a/Locus/Info.plist
+++ b/Locus/Info.plist
@@ -61,6 +61,22 @@
 	<string>$(LOCUS_GOOGLE_OAUTH_CLIENT_ID)</string>
 	<key>LocusGoogleOAuthCallbackScheme</key>
 	<string>$(LOCUS_GOOGLE_OAUTH_REVERSED_CLIENT_ID)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<!-- Locus talks to model servers the user runs themselves: Ollama,
+		     llama.cpp, LM Studio and friends serve plain HTTP on a LAN
+		     address and cannot present a certificate any CA would sign.
+		     NSAllowsLocalNetworking does not cover RFC1918 literals such as
+		     192.168.1.50, and NSExceptionDomains does not accept IP
+		     addresses, so this blanket opt-out is the only key that reaches
+		     them. It must stay ALONE: adding NSAllowsLocalNetworking or
+		     NSAllowsArbitraryLoadsInWebContent alongside it makes current
+		     macOS ignore it entirely. Tools/AuditTransportSecurity.py
+		     enforces both that rule and the https-only rule for every
+		     endpoint the user did not type, which ATS no longer backstops. -->
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_locus-remote._tcp</string>
@@ -72,7 +88,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 SparkTales Inc.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Locus uses your private network only when you enable Mobile Access and pair a phone.</string>
+	<string>Locus uses your private network to reach model servers you run yourself, such as Ollama on another machine, and when you enable Mobile Access and pair a phone.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Locus uses the microphone for dictation, voice conversations, and websites you explicitly allow.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/Locus/TransportSecurity.swift
+++ b/Locus/TransportSecurity.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// How exposed a connection to a given URL is.
+///
+/// The distinction that matters is not http-versus-https on its own: a plain
+/// HTTP request to Ollama on this Mac never leaves the machine, while the same
+/// request to a hostname that resolves off-network crosses every hop in
+/// between in the clear. `cleartextPrivate` is the price of supporting
+/// self-hosted model servers; `cleartextRoutable` is the case worth warning a
+/// user about.
+enum EndpointExposure: Equatable {
+    /// TLS applies. App Transport Security no longer enforces this for us, but
+    /// certificate trust evaluation — chain, hostname, expiry — still does.
+    case encrypted
+    /// Unencrypted, but addressed to this machine or this network segment.
+    case cleartextPrivate
+    /// Unencrypted and routable: the bytes leave the local network as plain text.
+    case cleartextRoutable
+}
+
+/// The checks that replace App Transport Security for the traffic Locus
+/// controls.
+///
+/// The app ships `NSAllowsArbitraryLoads` because model servers the user runs
+/// themselves — Ollama, llama.cpp, LM Studio — serve plain HTTP on LAN
+/// addresses that no certificate authority will vouch for, and Apple offers no
+/// narrower key that reaches them: `NSAllowsLocalNetworking` does not cover
+/// RFC1918 literals, and `NSExceptionDomains` does not accept IP addresses at
+/// all. The cost of the blanket key is that the OS stops enforcing HTTPS for
+/// *every* connection the process makes, including ones the user never
+/// configured. This type is what enforces it instead, and
+/// `Tools/AuditTransportSecurity.sh` keeps new cleartext literals from landing.
+enum TransportSecurity {
+    /// Schemes that carry their own transport encryption.
+    private static let encryptedSchemes: Set<String> = ["https", "wss"]
+
+    static func isEncrypted(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        return encryptedSchemes.contains(scheme)
+    }
+
+    static func exposure(of url: URL) -> EndpointExposure {
+        if isEncrypted(url) { return .encrypted }
+        guard let host = url.host, !host.isEmpty else { return .cleartextRoutable }
+        return isPrivate(host: host) ? .cleartextPrivate : .cleartextRoutable
+    }
+
+    /// Whether a host names this machine or something on the same private
+    /// network — the set of addresses whose cleartext traffic never reaches an
+    /// untrusted hop.
+    ///
+    /// This is deliberately wider than Apple's `NSAllowsLocalNetworking`, which
+    /// stops at `.local`, unqualified names and the loopback and link-local
+    /// ranges. The private IPv4 ranges are what users actually type when their
+    /// GPU box lives on the other side of the room, and the carrier-grade NAT
+    /// range covers Tailscale, which is how a lot of people reach it.
+    static func isPrivate(host rawHost: String) -> Bool {
+        var host = rawHost.lowercased()
+        // URL.host keeps the brackets on an IPv6 literal in some constructions.
+        if host.hasPrefix("["), host.hasSuffix("]") {
+            host = String(host.dropFirst().dropLast())
+        }
+        // Zone identifiers (fe80::1%en0) are never part of a routable address.
+        if let zone = host.firstIndex(of: "%") { host = String(host[host.startIndex..<zone]) }
+        guard !host.isEmpty else { return false }
+
+        if host == "localhost" || host.hasSuffix(".localhost") { return true }
+        if host.hasSuffix(".local") { return true }
+        if let octets = ipv4Octets(host) { return isPrivateIPv4(octets) }
+        if host.contains(":") { return isPrivateIPv6(host) }
+        // An unqualified name — "gpubox" — cannot resolve outside the local
+        // network's own resolver, so it belongs with the private addresses.
+        return !host.contains(".")
+    }
+
+    /// Parses a dotted-quad literal. Returns nil for anything else, including
+    /// hostnames that merely contain dots.
+    private static func ipv4Octets(_ host: String) -> [UInt8]? {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return nil }
+        var octets: [UInt8] = []
+        octets.reserveCapacity(4)
+        for part in parts {
+            // UInt8("007") parses, but a leading-zero octet is not a form any
+            // caller should be handing us, and treating it as decimal here
+            // would disagree with how the resolver reads it.
+            guard part.count == String(Int(part) ?? -1).count, let value = UInt8(part) else {
+                return nil
+            }
+            octets.append(value)
+        }
+        return octets
+    }
+
+    private static func isPrivateIPv4(_ octets: [UInt8]) -> Bool {
+        switch (octets[0], octets[1]) {
+        case (127, _): return true                    // loopback
+        case (10, _): return true                     // RFC1918
+        case (192, 168): return true                  // RFC1918
+        case (172, 16...31): return true              // RFC1918
+        case (169, 254): return true                  // link-local
+        case (100, 64...127): return true             // CGNAT, and Tailscale with it
+        case (0, _): return true                      // "this network"
+        default: return false
+        }
+    }
+
+    private static func isPrivateIPv6(_ host: String) -> Bool {
+        if host == "::1" || host == "::" { return true }
+        // Unique-local (fc00::/7) and link-local (fe80::/10). Comparing the
+        // textual prefix is enough: both ranges are fixed in the first byte and
+        // an IPv6 literal cannot abbreviate its leading group away.
+        let prefix = host.prefix(4)
+        if prefix.hasPrefix("fc") || prefix.hasPrefix("fd") { return true }
+        if prefix.hasPrefix("fe8") || prefix.hasPrefix("fe9")
+            || prefix.hasPrefix("fea") || prefix.hasPrefix("feb") { return true }
+        // An IPv4-mapped literal carries an IPv4 address that still decides it.
+        if let mapped = host.split(separator: ":").last.map(String.init),
+           let octets = ipv4Octets(mapped) {
+            return isPrivateIPv4(octets)
+        }
+        return false
+    }
+
+    /// Resolves a URL that the app itself chose — an update feed, a component
+    /// manifest, a telemetry collector — and refuses it unless it is encrypted.
+    ///
+    /// Endpoints the *user* typed are not routed through here: pointing Locus
+    /// at a local model server is the entire reason the ATS opt-out exists.
+    /// Everything else has no business speaking cleartext, and with ATS off
+    /// this is the only thing that still says so.
+    static func requireEncrypted(_ string: String?) -> URL? {
+        guard let string, let url = URL(string: string), isEncrypted(url) else { return nil }
+        return url
+    }
+}

--- a/LocusTests/TransportSecurityTests.swift
+++ b/LocusTests/TransportSecurityTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import Locus
+
+/// The app ships `NSAllowsArbitraryLoads`, so the operating system no longer
+/// refuses a cleartext endpoint on anyone's behalf. These assertions are what
+/// took over that job: the classification below is the only thing standing
+/// between "a LAN model server works" and "an app-owned endpoint quietly stops
+/// being encrypted".
+final class TransportSecurityTests: XCTestCase {
+    private func exposure(_ string: String) -> EndpointExposure? {
+        URL(string: string).map(TransportSecurity.exposure(of:))
+    }
+
+    func testEncryptedSchemesAreEncrypted() {
+        XCTAssertEqual(exposure("https://api.openai.com/v1"), .encrypted)
+        XCTAssertEqual(exposure("wss://relay.walletconnect.org"), .encrypted)
+        // Scheme comparison is case-insensitive, as URLs themselves are.
+        XCTAssertEqual(exposure("HTTPS://api.openai.com"), .encrypted)
+    }
+
+    func testLoopbackIsPrivate() {
+        for host in [
+            "http://localhost:11434",
+            "http://127.0.0.1:11434",
+            "http://127.1.2.3:8791",
+            "http://[::1]:11434",
+        ] {
+            XCTAssertEqual(exposure(host), .cleartextPrivate, host)
+        }
+    }
+
+    /// The whole reason the ATS opt-out exists. `NSAllowsLocalNetworking` does
+    /// not cover any of these, which is why the narrow key was not an option.
+    func testPrivateLANAddressesArePrivate() {
+        for host in [
+            "http://192.168.1.50:11434",
+            "http://10.0.0.7:11434",
+            "http://172.16.4.2:11434",
+            "http://172.31.255.254:11434",
+            "http://169.254.10.1:11434",
+        ] {
+            XCTAssertEqual(exposure(host), .cleartextPrivate, host)
+        }
+    }
+
+    /// Carrier-grade NAT is the range Tailscale hands out, and reaching a GPU
+    /// box over Tailscale is a mainstream way to run a remote Ollama.
+    func testTailscaleRangeIsPrivate() {
+        XCTAssertEqual(exposure("http://100.101.102.103:11434"), .cleartextPrivate)
+        XCTAssertEqual(exposure("http://100.64.0.1:11434"), .cleartextPrivate)
+        XCTAssertEqual(exposure("http://100.127.255.254:11434"), .cleartextPrivate)
+    }
+
+    /// 100.0.0.0/10 outside 100.64–100.127 is ordinary public space and must
+    /// not inherit the Tailscale exemption.
+    func testAddressesAdjacentToPrivateRangesAreRoutable() {
+        for host in [
+            "http://100.63.0.1:11434",   // just below CGNAT
+            "http://100.128.0.1:11434",  // just above CGNAT
+            "http://172.15.0.1:11434",   // just below RFC1918
+            "http://172.32.0.1:11434",   // just above RFC1918
+            "http://192.169.1.1:11434",  // not 192.168/16
+            "http://11.0.0.1:11434",     // not 10/8
+        ] {
+            XCTAssertEqual(exposure(host), .cleartextRoutable, host)
+        }
+    }
+
+    func testMDNSAndUnqualifiedNamesArePrivate() {
+        XCTAssertEqual(exposure("http://gpubox.local:11434"), .cleartextPrivate)
+        XCTAssertEqual(exposure("http://gpubox:11434"), .cleartextPrivate)
+        XCTAssertEqual(exposure("http://dev.localhost:3000"), .cleartextPrivate)
+    }
+
+    func testUniqueLocalAndLinkLocalIPv6ArePrivate() {
+        XCTAssertEqual(exposure("http://[fd00::1]:11434"), .cleartextPrivate)
+        XCTAssertEqual(exposure("http://[fe80::1]:11434"), .cleartextPrivate)
+    }
+
+    /// The case the UI warns about: cleartext that leaves the network.
+    func testPublicCleartextIsRoutable() {
+        for host in [
+            "http://api.openai.com/v1",
+            "http://203.0.113.10:11434",
+            "http://[2001:db8::1]:11434",
+        ] {
+            XCTAssertEqual(exposure(host), .cleartextRoutable, host)
+        }
+    }
+
+    /// A dotted-quad with a leading-zero octet is not read as decimal by every
+    /// resolver, so it must not be granted a private classification on the
+    /// strength of looking like one.
+    func testAmbiguousOctetsAreNotTreatedAsPrivate() {
+        XCTAssertEqual(exposure("http://010.0.0.1:11434"), .cleartextRoutable)
+        XCTAssertEqual(exposure("http://127.0.0.01:11434"), .cleartextRoutable)
+    }
+
+    func testRequireEncryptedAcceptsOnlyTLS() {
+        XCTAssertNotNil(TransportSecurity.requireEncrypted("https://example.com/feed.json"))
+        XCTAssertNil(TransportSecurity.requireEncrypted("http://example.com/feed.json"))
+        // Loopback gets no exemption here: this gate is for endpoints the app
+        // chose, and none of those live on the user's machine.
+        XCTAssertNil(TransportSecurity.requireEncrypted("http://127.0.0.1/feed.json"))
+        XCTAssertNil(TransportSecurity.requireEncrypted(nil))
+        XCTAssertNil(TransportSecurity.requireEncrypted(""))
+    }
+
+    /// The component feed installs an executable. If its URL ever resolves over
+    /// cleartext, the ATS opt-out has cost something real.
+    #if !LOCUS_APP_STORE
+    @MainActor
+    func testComponentFeedURLIsEncryptedOrAbsent() {
+        if let feed = CodexComponentInstaller.feedURL {
+            XCTAssertTrue(TransportSecurity.isEncrypted(feed), feed.absoluteString)
+        }
+    }
+    #endif
+}

--- a/Tools/AuditTransportSecurity.py
+++ b/Tools/AuditTransportSecurity.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Transport-security audit.
+
+Locus ships ``NSAllowsArbitraryLoads`` because the model servers it exists to
+talk to — Ollama, llama.cpp, LM Studio — serve plain HTTP on LAN addresses that
+no certificate authority will vouch for, and Apple offers no narrower key that
+reaches them: ``NSAllowsLocalNetworking`` does not cover RFC1918 literals, and
+``NSExceptionDomains`` does not accept IP addresses at all.
+
+The cost of the blanket key is that the OS stops enforcing HTTPS for *every*
+connection the process makes, including ones no user configured. Nothing fails
+when that enforcement disappears; a cleartext endpoint simply starts working,
+silently, which is why it needs a check that is not the operating system.
+
+This audit is that check. It enforces three things:
+
+1. every shipping app bundle declares the opt-out, and declares it ALONE —
+   pairing it with ``NSAllowsLocalNetworking`` or
+   ``NSAllowsArbitraryLoadsInWebContent`` makes current macOS ignore it, so the
+   app would lose LAN model servers again with nothing to show why;
+2. every shipping app bundle still explains its private-network use, because a
+   missing ``NSLocalNetworkUsageDescription`` fails identically to an ATS block
+   and costs an afternoon to tell apart;
+3. no Swift source gains a cleartext URL literal pointing anywhere but this
+   machine or this network — the rule ATS used to enforce for free.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Every bundle that ships as a running app. Helper executables keep full ATS
+# enforcement and are deliberately absent: only the process that talks to a
+# user's model server needs the opt-out.
+APP_PLISTS = [
+    Path("Locus/Info.plist"),
+    Path("Config/LocusRelease-Info.plist"),
+    Path("Config/LocusX-Info.plist"),
+    Path("Config/LocusExperimental-Info.plist"),
+    Path("Config/LocusMAS-Info.plist"),
+]
+
+# Keys whose mere presence makes macOS 10.15+/iOS 13+ disregard
+# NSAllowsArbitraryLoads. They are not additive with it; they replace it.
+CONFLICTING_ATS_KEYS = [
+    "NSAllowsArbitraryLoadsInWebContent",
+    "NSAllowsArbitraryLoadsForMedia",
+    "NSAllowsLocalNetworking",
+]
+
+SWIFT_ROOTS = [
+    "Locus",
+    "WalletConnectionsRuntime",
+    "RuntimeHelper",
+    "DocumentExtractor",
+    "SimulatorBridge",
+    "WalletSignerService",
+    "WalletRecoveryService",
+]
+
+# Cleartext literals that are reviewed and not network destinations. Keyed by
+# host so a new file reusing a known-inert host does not need a new entry, but
+# a genuinely new host still has to be argued for here.
+ALLOWED_CLEARTEXT_HOSTS = {
+    # An XML namespace identifier. Never dereferenced; changing it would break
+    # SVG parsing rather than secure anything.
+    "www.w3.org": "SVG namespace identifier, not a request target",
+    # A prefix-stripping table for model references the user pastes, not a URL
+    # the app builds a request from.
+    "huggingface.co": "prefix match when normalising pasted model references",
+    # Placeholder and documentation strings shown in proxy settings.
+    "proxy.corp": "example proxy shown in help text",
+    "proxy.example": "example proxy shown in help text",
+}
+
+# Stops at the first character that cannot appear in an authority, so an
+# interpolation, a path, or prose after the URL never lands in the host.
+CLEARTEXT_PATTERN = re.compile(r"http://([A-Za-z0-9._:%@\[\]-]*)")
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+
+
+def is_private_host(raw_host: str) -> bool:
+    """Mirror of ``TransportSecurity.isPrivate(host:)`` in the app.
+
+    Kept in step with it by ``TransportSecurityTests``, which asserts the same
+    table of hosts the cases below encode.
+    """
+    host = raw_host.lower()
+    host = host.split("@")[-1]  # drop any user:password prefix
+    # A port may be absent, literal, or an interpolation the regex already cut
+    # away — leaving a bare trailing colon behind either way.
+    host = host.rstrip(":")
+    if re.match(r"^[^:]+:\d+$", host):
+        host = host.rsplit(":", 1)[0]
+    if host.startswith("[") and "]" in host:  # bracketed IPv6, with or without a port
+        host = host[1 : host.index("]")]
+    host = host.split("%", 1)[0]
+    if not host:
+        return False
+    if host == "localhost" or host.endswith(".localhost") or host.endswith(".local"):
+        return True
+
+    octets = host.split(".")
+    if len(octets) == 4 and all(o.isdigit() and str(int(o)) == o and int(o) < 256 for o in octets):
+        first, second = int(octets[0]), int(octets[1])
+        return (
+            first in (0, 10, 127)
+            or (first, second) == (192, 168)
+            or (first == 172 and 16 <= second <= 31)
+            or (first, second) == (169, 254)
+            or (first == 100 and 64 <= second <= 127)
+        )
+
+    if ":" in host:
+        return host in ("::1", "::") or host[:4].startswith(("fc", "fd", "fe8", "fe9", "fea", "feb"))
+
+    # An unqualified name cannot resolve outside the local resolver.
+    return "." not in host
+
+
+def audit_plists() -> int:
+    failures = 0
+    for relative in APP_PLISTS:
+        path = REPO / relative
+        if not path.exists():
+            fail(f"{relative}: expected app Info.plist is missing")
+            failures += 1
+            continue
+        with path.open("rb") as handle:
+            plist = plistlib.load(handle)
+
+        ats = plist.get("NSAppTransportSecurity")
+        if not isinstance(ats, dict):
+            fail(
+                f"{relative}: no NSAppTransportSecurity dictionary. Without it the app "
+                "cannot reach a self-hosted model server on a LAN address."
+            )
+            failures += 1
+            continue
+
+        if ats.get("NSAllowsArbitraryLoads") is not True:
+            fail(f"{relative}: NSAllowsArbitraryLoads must be present and true")
+            failures += 1
+
+        for key in CONFLICTING_ATS_KEYS:
+            if key in ats:
+                fail(
+                    f"{relative}: {key} is set alongside NSAllowsArbitraryLoads. Current "
+                    "macOS honours the narrower key and ignores the blanket one, so LAN "
+                    "model servers stop resolving. Remove it."
+                )
+                failures += 1
+
+        # Endpoints the app ships rather than the user typing them. Sparkle
+        # reads SUFeedURL itself, so no Swift gate can cover it; this is the
+        # only place that says it has to be encrypted.
+        for key, value in plist.items():
+            if not isinstance(value, str) or not value.lower().startswith("http://"):
+                continue
+            fail(
+                f"{relative}: {key} is a cleartext URL ({value}). Endpoints the app "
+                "declares for itself must be https — ATS no longer requires it."
+            )
+            failures += 1
+
+        if not plist.get("NSLocalNetworkUsageDescription"):
+            fail(
+                f"{relative}: NSLocalNetworkUsageDescription is missing. The private-network "
+                "prompt never appears and the failure is indistinguishable from an ATS block."
+            )
+            failures += 1
+    return failures
+
+
+def audit_sources() -> int:
+    failures = 0
+    for root in SWIFT_ROOTS:
+        base = REPO / root
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*.swift")):
+            relative = path.relative_to(REPO)
+            for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                for match in CLEARTEXT_PATTERN.finditer(line):
+                    host = match.group(1)
+                    # "http://" followed straight by an interpolation or the end
+                    # of the literal builds its host at runtime; TransportSecurity
+                    # classifies those, a grep cannot.
+                    if not host or host.startswith("\\("):
+                        continue
+                    if is_private_host(host):
+                        continue
+                    bare = host.split("@")[-1].split(":")[0]
+                    if bare in ALLOWED_CLEARTEXT_HOSTS:
+                        continue
+                    fail(
+                        f"{relative}:{number}: cleartext URL to '{host}'. App Transport "
+                        "Security no longer blocks this — use https, or add the host to "
+                        "ALLOWED_CLEARTEXT_HOSTS in Tools/AuditTransportSecurity.py with "
+                        "the reason it is not a request target."
+                    )
+                    failures += 1
+    return failures
+
+
+def main() -> int:
+    failures = audit_plists() + audit_sources()
+    if failures:
+        print(
+            f"Transport-security audit failed with {failures} problem(s).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Transport-security audit passed ({len(APP_PLISTS)} app bundles checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Pointing Locus at Ollama on another machine looked like it could not work. App Transport Security refuses cleartext by default, and every self-hosted model server — Ollama, llama.cpp, LM Studio — serves plain HTTP on a LAN address that no certificate authority will vouch for.

The apparent fix is `NSAllowsArbitraryLoads`, because Apple documents no narrower key that reaches those addresses: `NSAllowsLocalNetworking` is specified as covering only `.local`, unqualified names, and the loopback and link-local ranges, and `NSExceptionDomains` does not accept IP addresses at all.

**Measuring it instead of reading the specification shows that premise is wrong.** Probed from inside the app bundle on macOS 26.4.1, against a server on a *different* machine at `192.168.50.134`, with no ATS keys in the bundle:

| Request | Result |
|---|---|
| `http://192.168.50.134:18434` — private LAN, cleartext | **200** |
| `http://neverssl.com` — public, cleartext | **−1022, blocked** |
| `https://expired.badssl.com` | −1200, cert rejected (not ATS) |
| `https://example.com` | 200 |

ATS is plainly still enforcing — public cleartext is refused — yet the private range goes through unaided. So the tradeoff doesn't exist: Locus reaches LAN model servers **and** keeps HTTPS enforcement on every other connection, including inside Sparkle, ReownSwift, and any dependency added later.

The first commit on this branch added the key. The second removes it and keeps the parts worth having. Both are left in history because the reasoning that led to the key is the reasoning someone will repeat.

## What's in it

**No ATS opt-out anywhere.** `Tools/AuditTransportSecurity.py` runs in CI and fails if any bundle declares `NSAllowsArbitraryLoads`, `NSAllowsArbitraryLoadsInWebContent`, or `NSAllowsArbitraryLoadsForMedia`. Its header records the experiment above, so the next person to reach for the key meets the measurement before the argument.

**Three more audit rules**, all of which ATS does not cover: every app bundle keeps an `NSLocalNetworkUsageDescription` (when it's missing, the failure is indistinguishable from an ATS block and costs an afternoon to tell apart); endpoints the app declares for itself must be `https`; and no Swift source may gain a cleartext URL literal pointing off the local network.

**`TransportSecurity`** classifies a URL as `encrypted` / `cleartextPrivate` / `cleartextRoutable` — loopback, `.local`, unqualified names, the RFC1918 ranges, link-local, IPv6 ULA, and 100.64/10, since Tailscale is a mainstream way to reach a GPU box. `requireEncrypted` gates endpoints the app chooses rather than the user, and `CodexComponentInstaller.feedURL` uses it: that feed installs an executable, and ATS would *not* stop a cleartext feed URL aimed at a LAN address.

**The account editor marks an unencrypted endpoint** — muted for addresses that stay local, a warning for cleartext that routes off-network. The OS says nothing to the user either way.

**`RemoteEndpointTester` translates −1022** rather than surfacing Foundation's wording, which describes a policy instead of an endpoint and reads as if Locus were broken. It should never fire for a private address; if it does, either the address isn't as local as the user believes or this OS draws the line somewhere the audit hasn't measured, and the message names both.

## Notes for review

- **Certificate validation was never at stake and still isn't.** The `-1200` row above is an expired cert being rejected. ATS governs the HTTPS requirement and TLS floor; trust evaluation is a separate layer.
- **Proxy support is unaffected** — proxy handling lives in CFNetwork, independent of ATS.
- **Sparkle needed no change.** `SUFeedURL` is HTTPS, `SURequireSignedFeed` is set, and `SUPublicEDKey` means updates are EdDSA-verified before install. The audit now also pins that feed to HTTPS.
- The private-network usage string claimed the network was used "only when you enable Mobile Access and pair a phone", which stops being true once a LAN model server is reachable.
- **Untested:** `project.yml` targets macOS 14.0; the probe ran on 26.4.1. The private-range allowance is undocumented, so I can't say when it appeared. If it postdates 14, a user on an older system hits the −1022 path — which now explains itself instead of looking like a dead server.

## Testing

- 13 `TransportSecurityTests` pass, including the boundaries: 100.63 and 100.128 stay routable while 100.64–100.127 don't, leading-zero octets (`010.0.0.1`) get no private classification, and −1022 is translated while every other URLSession error keeps its own description.
- Each audit rule verified by injecting a violation and confirming a non-zero exit.
- Confirmed the built `Locus.app` carries no `NSAppTransportSecurity` key.
- `FeatureLogicTests` 294, `CodexComponentTests` 12 — all passing.
- `AppModelTests`: 1 failure, `testChatGPTRoutingCarriesTheStoredParityChoices`, unrelated to this work and failing identically on a clean checkout of `main` at 12d7f828. Being fixed separately.
