### PR TITLE
Isolate the ChatGPT effort routing tests from real workspace profiles

### DIFF
--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -2887,6 +2887,9 @@ final class AppModelTests: XCTestCase {
         model.saveProviderAccount(ProviderAccount(kind: .chatGPT, name: "Work"), apiKey: nil)
         let account = try! XCTUnwrap(model.providerAccounts.first)
         model.settings.activeAccountID = account.id.uuidString
+        // Seeded for the same reason: a real workspace profile carrying an
+        // effort would answer here instead of the account's own default.
+        model.workspaceProfiles = [seededProfile(path: model.workspacePath)]
 
         let body = model.providerRequestBody()
         XCTAssertEqual(body["provider"] as? String, "chatgpt")
@@ -2909,6 +2912,10 @@ final class AppModelTests: XCTestCase {
         account.codexReasoningEffort = "xhigh"
         model.saveProviderAccount(account, apiKey: nil)
         model.settings.activeAccountID = account.id.uuidString
+        // Seeded with no effort of its own: profiles are read from the real
+        // defaults even with persistence off, so a workspace on this machine
+        // that had chosen Auto would override the account and empty the field.
+        model.workspaceProfiles = [seededProfile(path: model.workspacePath)]
 
         let body = model.providerRequestBody()
         XCTAssertEqual(body["native_mode"] as? Bool, false)


### PR DESCRIPTION
## What

`LocusTests/AppModelTests/testChatGPTRoutingCarriesTheStoredParityChoices` failed deterministically on a clean checkout of `main` (verified at 12d7f828 in a fresh worktree):

```
XCTAssertEqual failed: ("Optional("")") is not equal to ("Optional("xhigh")")
```

## Why it failed

Machine state, not a regression. The routing contract is intact.

`AppModel(startImmediately: false)` restores `workspaceProfiles` from the real `UserDefaults` key `Locus.workspaceProfiles` even with persistence off (`AppModel.swift:964`). `resolvedReasoningEffort` treats `nil` and `""` as different answers on purpose: `nil` is a workspace that never chose and defers to the account, `""` is a workspace that chose Auto and must beat an account default — otherwise picking Auto on a ChatGPT account with a stored effort would do nothing.

On the failing machine the most recent stored profile had `reasoningEffort: ""`, and it was also what `initialWorkspacePath` resolved to. So the test's workspace carried a genuine "chose Auto" override, which correctly suppressed the account's `"xhigh"`. Deterministic on that machine, environment-dependent everywhere else.

The neighbouring effort tests already guard against exactly this, with the comment *"profiles are read from the real defaults even with persistence off, so leaving this to the machine's own state would make the test pass or fail depending on which workspaces it has open."* This test just omitted that line.

## Change

Tests only — no production code touched.

- `testChatGPTRoutingCarriesTheStoredParityChoices`: seed a profile with no effort of its own, so the account default is what resolves.
- `testChatGPTRoutingNamesTheAccountsOwnCredentialHome`: same latent exposure in the other direction — it asserts the empty default and was passing only where the stored override happened to be empty. A machine whose workspace had chosen `"high"` would have failed it instead.

## Verification

All five effort-routing tests pass locally:

```
testAnEffortTheChatGPTCatalogDoesNotListIsNotSent           passed
testChatGPTRoutingCarriesTheStoredParityChoices             passed
testChatGPTRoutingNamesTheAccountsOwnCredentialHome         passed
testChoosingAutoOverridesTheAccountsOwnDefaultEffort        passed
testRemoteRouteSendsAnEffortOnlyForModelsThatAcceptOne      passed
** TEST SUCCEEDED **
```