### PR TITLE
Build portable runtime packages and recover failed service updates

### DIFF
--- a/.github/workflows/runtime-packages.yml
+++ b/.github/workflows/runtime-packages.yml
@@ -1,0 +1,83 @@
+name: Runtime package candidates
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/runtime-packages.yml'
+      - 'Tools/*RemoteRuntime*'
+      - 'agent/requirements-runtime.lock'
+      - 'agent/ollama_code/**'
+      - 'agent/tests/test_runtime_release.py'
+      - 'Locus/Resources/ThirdPartyLicenses/**'
+      - 'Locus/Resources/ThirdPartyNotices.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-packages-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  package:
+    name: Build and exercise ${{ matrix.target }}
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x86_64
+            runner: ubuntu-24.04
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+          - target: macos-arm64
+            runner: macos-14
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Prepare the disposable Linux user service manager
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          runtime_uid="$(id -u)"
+          sudo loginctl enable-linger "$(id -un)"
+          sudo systemctl start "user@${runtime_uid}.service"
+          echo "XDG_RUNTIME_DIR=/run/user/${runtime_uid}" >> "$GITHUB_ENV"
+          echo "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${runtime_uid}/bus" >> "$GITHUB_ENV"
+      - name: Build from pinned artifacts and hashed dependencies
+        env:
+          RUNTIME_TARGET: ${{ matrix.target }}
+        run: >-
+          python3 Tools/PrepareRemoteRuntime.py
+          --target "$RUNTIME_TARGET"
+          --require-clean
+          --output "build/runtime-packages/locus-runtime-$RUNTIME_TARGET.tar.gz"
+      - name: Exercise detached work, restart, helper initialization and failed-update recovery
+        env:
+          RUNTIME_TARGET: ${{ matrix.target }}
+        shell: bash
+        run: |
+          runtime_package="build/runtime-packages/locus-runtime-$RUNTIME_TARGET.tar.gz"
+          runtime_sha="$(cat "$runtime_package.sha256")"
+          python3 Tools/SmokeRemoteRuntime.py \
+            --package "$runtime_package" --sha256 "$runtime_sha" \
+            --service-manager --exercise-rollback \
+            --output "build/runtime-packages/$RUNTIME_TARGET.smoke.json"
+      - name: Retain fixture validation evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runtime-evidence-${{ matrix.target }}-${{ github.sha }}
+          path: |
+            build/runtime-packages/*.json
+            build/runtime-packages/*.sha256
+          if-no-files-found: warn
+          retention-days: 30
+      - name: Retain validated candidate package
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runtime-candidate-${{ matrix.target }}-${{ github.sha }}
+          path: build/runtime-packages/*.tar.gz
+          if-no-files-found: error
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Added
+
+- Portable runtime package builds for Linux x86-64/ARM64 and Apple Silicon Macs,
+  with pinned Python and ChatGPT helpers, verified downloads, dependency hashes,
+  bundled license notices, and isolated service validation in CI.
+
+### Fixed
+
+- Runtime updates block new work during installation and restore the previous
+  service and databases if startup fails. Interrupted updates retain recovery
+  records; successful updates keep the previous package and database backups.
+- Packaged ChatGPT helpers start with their correct app-server entry point.
+- Run-history operations close database connections promptly, preventing
+  independent workers from exhausting the background service's file handles.
+
 ## 2.8.0 — 2026-09-09
 
 ### Added

--- a/Docs/runtime/implementation.md
+++ b/Docs/runtime/implementation.md
@@ -81,6 +81,11 @@ remote live-provider/login/reboot tests remain release gates.
 
 ## Build and install a remote package
 
+The next phase adds a complete pinned builder and service recovery gates. See
+[Runtime package release readiness](release-readiness.md) for the current build,
+validation and rollback procedures. The stage logs below describe earlier checks;
+the new report records the additional package and service validation separately.
+
 Run `Tools/PackageRemoteRuntime.py` with `--runtime` pointing to a portable runtime
 layout (`python/bin/python3`, `site-packages`, and `source/ollama_code`), the pinned
 0.147.0 helper and its `codex-code-mode-host` sibling, `--target` (`linux-x86_64`,

--- a/Docs/runtime/release-readiness.md
+++ b/Docs/runtime/release-readiness.md
@@ -1,0 +1,127 @@
+# Runtime package release readiness
+
+This phase follows the four independent-agent stages merged into main. It builds
+complete portable packages, verifies them through actual supervisor and worker
+processes, and makes service updates recoverable. It does not change edition
+availability or enable background execution for ordinary agents.
+
+## Building a candidate
+
+Build on the target OS and architecture from a clean committed checkout:
+
+```sh
+python3 Tools/PrepareRemoteRuntime.py \
+  --target macos-arm64 --require-clean \
+  --output build/runtime-packages/locus-runtime-macos-arm64.tar.gz
+```
+
+Supported targets are `linux-x86_64`, `linux-arm64` and `macos-arm64`. Linux needs
+glibc 2.28 or newer and a working systemd user session. macOS needs version 14 or
+newer, Apple Silicon and an active graphical login. The host needs Python 3.10+
+only for setup; execution uses the bundled Python. Linux lingering is needed for
+continuation after SSH logout. Mac work runs while the user is logged in and the
+machine is awake. The installer reports these requirements without changing them.
+
+`Tools/RemoteRuntimeArtifacts.json` pins Python 3.14.6 from the
+[20260728 standalone release](https://github.com/astral-sh/python-build-standalone/releases/tag/20260728)
+and the CLI and code-mode-host binaries from
+[Codex 0.147.0](https://github.com/openai/codex/releases/tag/rust-v0.147.0).
+Every download and cache reuse is checked against its reviewed SHA-256. The
+builder installs binary wheels from `agent/requirements-runtime.lock`, requires
+their hashes, and bounds wheel compatibility to the supported OS baseline.
+It copies tracked backend source, prunes unused development/Tk/dbm files and
+retains dependency license notices, including the pinned helper's LICENSE and
+NOTICE from its verified source archive. No extra runtime dependencies are added.
+
+The archive contains a file-hash manifest, dependency and artifact provenance,
+source revision and dirty-checkout status. Account homes, controller state and
+project files are separate. Tar metadata and gzip timestamps are deterministic;
+packaging an unchanged prepared layout produces the same checksum regardless of
+its output filename or file timestamps. This does not claim that arbitrary
+dependency installations are byte-identical across different build environments.
+
+The builder produces `.tar.gz`, `.tar.gz.sha256` and `.tar.gz.build.json` files.
+Select the archive and checksum in Settings → Runtimes. SHA-256 verifies the
+selected artifact's integrity; it is not a replacement for trusted distribution or
+the separate signed desktop Service Management helper. The lower-level
+`Tools/PackageRemoteRuntime.py` remains available for an already prepared layout.
+
+## Update transaction and recovery
+
+Pause and drain the runtime before updating. An exclusive installation lock also
+serializes service controls. After checking the uploaded archive, helper version
+and isolated imports, the installer writes a durable journal before stopping the
+old service. Once stopped, it backs up every profile SQLite database using SQLite's
+backup API. Candidate startup runs in maintenance mode: HTTP mutations, worker
+creation, commands and automatic admission are blocked. Read-only authenticated
+health requests still work.
+
+The candidate service must report the expected protocol and package identity
+before `current` advances. Existing installations remain paused until resumed
+explicitly. The previous package and database backups remain available. The
+service command references the immutable version directory directly, so changing
+`current` cannot move an active process onto another package.
+
+On failure, the installer stops the candidate, restores the old unit and package
+references, restores backed-up databases and removes databases created during the
+failed startup. It restarts the prior service if it was running and verifies its
+identity. If recovery fails or the installer is interrupted, the journal remains
+and new work stays blocked. Retrying installation recovers the pending transaction
+before attempting the upload. Do not delete `installation.json` to bypass recovery.
+Credentials are not placed in the journal or restored from project snapshots.
+
+The packaged helper is the full Codex CLI. The service declares its `cli` entry
+point explicitly so the manager invokes `app-server --listen stdio://` even though
+the packaged filename is `codex-app-server`. Existing desktop basename handling
+remains compatible.
+
+Run-history connections now close at each transaction boundary. The actual macOS
+service test exposed file-handle exhaustion because SQLite's default context
+manager commits or rolls back without closing the connection. A process test with
+garbage collection disabled and only 64 file handles verifies repeated history
+queries, and transaction tests preserve commit/rollback behavior. Read-only
+database URLs also encode special characters in profile paths correctly.
+
+## Isolated package validation
+
+The smoke runner uses a fresh random service name, separate profile, separate
+account homes and a temporary project. It never uses the production runtime or
+existing provider credentials. Its model responses come from a local deterministic
+HTTP fixture. It starts the actual packaged ChatGPT helper in two signed-out
+account homes to verify protocol initialization without login or billable calls.
+
+```sh
+python3 Tools/SmokeRemoteRuntime.py \
+  --package build/runtime-packages/locus-runtime-macos-arm64.tar.gz \
+  --sha256 REVIEWED_PACKAGE_SHA256 \
+  --service-manager --exercise-rollback \
+  --output build/runtime-packages/macos-arm64.smoke.json
+```
+
+The scenario verifies authenticated loopback access, a schedule after controller
+detach, verified output and ledger usage, an explicitly requested and approved
+correction check enforced on the next task, service restart without duplicate
+runs or usage, and a deliberately broken update restoring the previous service
+and results. It stops and removes only its own service and workspace in cleanup.
+Omit `--service-manager --exercise-rollback` for a foreground process-only check.
+An unsuccessful cleanup makes the report fail. A forcibly killed smoke runner may
+leave its validation namespace behind; normal exit cleans it even after failure.
+
+The **Runtime package candidates** workflow builds and runs these checks on
+Linux x86-64, Linux ARM64 and macOS 14 ARM64. It retains build/smoke JSON evidence
+and checksums separately, and uploads candidate archives only for passing targets.
+It does not publish a production release or configure a user's SSH host.
+
+## Validation and remaining release gates
+
+Validation results for this branch are recorded below after running the checks.
+Deterministic provider fixtures and signed-out helper initialization do not
+establish real provider billing, refresh or account expiration behavior.
+
+Production release still requires signed direct-download SMAppService
+registration, SSH deployment to disposable owned Linux and Mac hosts, host-key
+change rejection, login/reboot lifecycle, real connector delivery, and bounded
+API/Ollama/independent ChatGPT login, model-call and expiration/recovery checks.
+The isolated user-service check exercises launchd/systemd directly; it does not
+test the desktop SMAppService registration flow. No live SSH host or provider
+account is required for the fixture build pipeline, and none is provisioned by it.

--- a/Docs/runtime/release-readiness.md
+++ b/Docs/runtime/release-readiness.md
@@ -114,9 +114,13 @@ It does not publish a production release or configure a user's SSH host.
 
 ## Validation and remaining release gates
 
-Validation results for this branch are recorded below after running the checks.
-Deterministic provider fixtures and signed-out helper initialization do not
-establish real provider billing, refresh or account expiration behavior.
+Regression coverage includes archive traversal, pinned-download and installed-file
+tampering, authentication before maintenance responses, concurrent installer
+locking, successful and failed updates, interrupted recovery, and database cleanup
+under a 64-file-handle limit. Each package run records its exact SHA-256, platform,
+process/service mode and scenario outcomes in JSON evidence. Deterministic provider
+fixtures and signed-out helper initialization do not establish real provider
+billing, refresh or account expiration behavior.
 
 Production release still requires signed direct-download SMAppService
 registration, SSH deployment to disposable owned Linux and Mac hosts, host-key

--- a/Tools/PackageRemoteRuntime.py
+++ b/Tools/PackageRemoteRuntime.py
@@ -1,55 +1,126 @@
 #!/usr/bin/env python3
-"""Package a portable, dependency-pinned AgentRuntime and pinned ChatGPT helper.
+"""Reproducible remote runtime archives; no credentials or host paths in manifests."""
+from __future__ import annotations
 
-Build on each supported host/architecture using Tools/PrepareAgentRuntime.sh and
-Tools/PrepareCodexAppServer.sh (or the same pinned helper built for Linux). This
-command never downloads unverified executables. Ship its SHA-256 with the release.
-"""
 import argparse
+import gzip
 import hashlib
 import io
 import json
-import tarfile
-import subprocess
+import os
 import platform
+import subprocess
+import tarfile
+import tempfile
 from pathlib import Path
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--runtime', type=Path, required=True)
-parser.add_argument('--codex-helper', type=Path, required=True)
-parser.add_argument('--codex-code-mode-host', type=Path, required=True)
-parser.add_argument('--target', choices=['linux-x86_64', 'linux-arm64', 'macos-arm64'], required=True)
-parser.add_argument('--output', type=Path, required=True)
-args = parser.parse_args()
-system = platform.system()
-architecture = 'arm64' if platform.machine() in {'arm64', 'aarch64'} else 'x86_64'
-actual_target = ('macos-' if system == 'Darwin' else 'linux-' if system == 'Linux' else 'unsupported-') + architecture
-if actual_target != args.target:
-    parser.error('Build and validate this package on its target operating system and architecture.')
-version = subprocess.run([str(args.codex_helper.resolve()), '--version'], capture_output=True, text=True, timeout=20)
-if version.returncode or not version.stdout.strip().endswith(' 0.147.0'):
-    parser.error('The ChatGPT helper must be pinned to version 0.147.0.')
-for required in ['python/bin/python3', 'source/ollama_code/runtime.py']:
-    if not (args.runtime / required).is_file():
-        parser.error('The portable runtime layout is incomplete: ' + required)
-files = {}
-for path in sorted(args.runtime.rglob('*')):
-    if path.is_file() and '__pycache__' not in path.parts and path.suffix != '.pyc':
-        files[path.relative_to(args.runtime).as_posix()] = path
-files['codex-app-server'] = args.codex_helper
-files['codex-code-mode-host'] = args.codex_code_mode_host
-manifest = {'version': 1, 'protocol_version': 1, 'target': args.target, 'codex_version': '0.147.0',
-            'files': {name: hashlib.sha256(path.read_bytes()).hexdigest() for name, path in files.items()}}
-with tarfile.open(args.output, 'w:gz') as archive:
-    for name, path in files.items():
-        data = path.read_bytes()
-        item = tarfile.TarInfo(name)
-        item.mode, item.size = (0o700 if path.stat().st_mode & 0o111 else 0o600), len(data)
-        archive.addfile(item, io.BytesIO(data))
-    data = json.dumps(manifest, sort_keys=True).encode()
-    item = tarfile.TarInfo('manifest.json')
-    item.size, item.mode = len(data), 0o600
-    archive.addfile(item, io.BytesIO(data))
-checksum = hashlib.sha256(args.output.read_bytes()).hexdigest()
-args.output.with_suffix(args.output.suffix + '.sha256').write_text(checksum + '\n')
-print(f'{args.target}: {args.output} (SHA-256 {checksum})')
+TARGETS = ("linux-x86_64", "linux-arm64", "macos-arm64")
+CODEX_VERSION = "0.147.0"
+
+
+def host_target() -> str:
+    system = {"Darwin": "macos", "Linux": "linux"}.get(platform.system(), "unsupported")
+    arch = {"arm64": "arm64", "aarch64": "arm64", "x86_64": "x86_64"}.get(platform.machine(), "unsupported")
+    return f"{system}-{arch}"
+
+
+def digest(path: Path) -> str:
+    with path.open("rb") as stream:
+        value = hashlib.sha256()
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            value.update(chunk)
+        return value.hexdigest()
+
+
+def runtime_files(runtime: Path) -> dict[str, Path]:
+    runtime = runtime.resolve(strict=True)
+    files = {}
+    for path in sorted(runtime.rglob("*")):
+        if "__pycache__" in path.parts or path.suffix == ".pyc" or path.name == ".DS_Store" or path.name.startswith("._"):
+            continue
+        if path.is_symlink():
+            resolved = path.resolve(strict=True)
+            if runtime not in resolved.parents or resolved.is_dir():
+                raise ValueError("Runtime links must reference files inside the prepared runtime")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            raise ValueError("Runtime contains a non-regular file")
+        name = path.relative_to(runtime).as_posix()
+        if name.split("/")[0] not in {"python", "source", "site-packages", "licenses", "provenance.json"}:
+            raise ValueError("Unexpected file in prepared runtime: " + name)
+        files[name] = path
+    for name in ("python/bin/python3", "source/ollama_code/runtime.py"):
+        if name not in files:
+            raise ValueError("The portable runtime layout is incomplete: " + name)
+    return files
+
+
+def check_runtime(runtime: Path, helper: Path) -> None:
+    result = subprocess.run([str(helper.resolve()), "--version"], capture_output=True, text=True, timeout=20, check=False)
+    if result.returncode or result.stdout.strip() != "codex-cli " + CODEX_VERSION:
+        raise ValueError("The ChatGPT helper must be pinned to version " + CODEX_VERSION)
+    with tempfile.TemporaryDirectory(prefix="locus-package-check-") as temporary:
+        environment = {**os.environ, "PYTHONPATH": str(runtime / "source") + os.pathsep + str(runtime / "site-packages"),
+                       "PYTHONNOUSERSITE": "1", "PYTHONDONTWRITEBYTECODE": "1",
+                       "OLLAMA_CODE_HOME": str(Path(temporary) / "profile"), "LOCUS_CODEX_HOME": str(Path(temporary) / "accounts")}
+        result = subprocess.run([str(runtime / "python/bin/python3"), "-s", "-c",
+                                 "import ssl, sqlite3, ollama_code.runtime; import fastapi, uvicorn; print('ready')"],
+                                env=environment, cwd=temporary, capture_output=True, timeout=40, check=False)
+        if result.returncode or result.stdout.strip() != b"ready":
+            raise ValueError("The prepared Python runtime cannot import its dependencies in isolation")
+
+
+def package_runtime(runtime: Path, helper: Path, code_host: Path, target: str, output: Path) -> str:
+    if target not in TARGETS or host_target() != target:
+        raise ValueError("Build and validate this package on its target operating system and architecture")
+    runtime = runtime.resolve(strict=True)
+    output = output.resolve()
+    if output == runtime or runtime in output.parents:
+        raise ValueError("The package output must be outside the prepared runtime")
+    files = runtime_files(runtime)
+    for path in (helper, code_host):
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise ValueError("Both pinned ChatGPT helper executables are required")
+    check_runtime(runtime, helper)
+    files.update({"codex-app-server": helper, "codex-code-mode-host": code_host})
+    hashes = {name: digest(path) for name, path in sorted(files.items())}
+    manifest = {"version": 1, "protocol_version": 1, "target": target, "codex_version": CODEX_VERSION, "files": hashes}
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=".package-", dir=output.parent)
+    try:
+        with os.fdopen(fd, "wb") as raw, gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=0) as compressed, tarfile.open(fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT) as archive:
+            for name, path in sorted(files.items()):
+                item = tarfile.TarInfo(name)
+                item.mode = 0o700 if path.stat().st_mode & 0o111 else 0o600
+                item.size = path.stat().st_size
+                with path.open("rb") as stream:
+                    archive.addfile(item, stream)
+                if digest(path) != hashes[name]:
+                    raise ValueError("A runtime file changed while it was being packaged: " + name)
+            data = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+            item = tarfile.TarInfo("manifest.json")
+            item.size, item.mode = len(data), 0o600
+            archive.addfile(item, io.BytesIO(data))
+        os.replace(temporary, output)
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+    checksum = digest(output)
+    output.with_suffix(output.suffix + ".sha256").write_text(checksum + "\n")
+    return checksum
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runtime", type=Path, required=True)
+    parser.add_argument("--codex-helper", type=Path, required=True)
+    parser.add_argument("--codex-code-mode-host", type=Path, required=True)
+    parser.add_argument("--target", choices=TARGETS, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    checksum = package_runtime(args.runtime, args.codex_helper, args.codex_code_mode_host, args.target, args.output)
+    print(json.dumps({"target": args.target, "package": args.output.name, "sha256": checksum}))
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/PrepareRemoteRuntime.py
+++ b/Tools/PrepareRemoteRuntime.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Build a complete remote package on its target host from reviewed, pinned inputs."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path, PurePosixPath
+
+from PackageRemoteRuntime import TARGETS, digest, host_target, package_runtime
+
+ROOT = Path(__file__).resolve().parents[1]
+PINS = Path(__file__).with_name("RemoteRuntimeArtifacts.json")
+MAX_DOWNLOAD = 512 * 1024 * 1024
+MAX_EXPANDED = 2 * 1024 * 1024 * 1024
+
+
+def wheel_platforms(target: str) -> list[str]:
+    if target == "macos-arm64":
+        return ["macosx_14_0_arm64"]
+    architecture = "aarch64" if target == "linux-arm64" else "x86_64"
+    return [f"manylinux_2_{minor}_{architecture}" for minor in (28, 27, 24, 17)] + ["manylinux2014_" + architecture]
+
+
+def download(component: dict, cache: Path) -> Path:
+    """Every cache reuse is verified; partial downloads never become cache entries."""
+    checksum = component["sha256"]
+    if len(checksum) != 64 or any(c not in "0123456789abcdef" for c in checksum):
+        raise ValueError("Invalid pinned artifact checksum")
+    if not component["url"].startswith("https://github.com/"):
+        raise ValueError("Artifact inputs must use reviewed HTTPS release URLs")
+    cache.mkdir(parents=True, exist_ok=True)
+    destination = cache / (checksum + ".tar.gz")
+    if destination.is_symlink():
+        raise ValueError("Artifact cache entries cannot be symlinks")
+    if destination.is_file() and digest(destination) == checksum:
+        return destination
+    fd, temporary = tempfile.mkstemp(prefix=".download-", dir=cache)
+    try:
+        request = urllib.request.Request(component["url"], headers={"User-Agent": "LocusRuntimeBuilder/1"})
+        with os.fdopen(fd, "wb") as output, urllib.request.urlopen(request, timeout=60) as response:
+            if not response.geturl().startswith("https://"):
+                raise ValueError("Artifact download redirected outside HTTPS")
+            size = 0
+            while chunk := response.read(1024 * 1024):
+                size += len(chunk)
+                if size > MAX_DOWNLOAD:
+                    raise ValueError("Artifact download exceeds the size limit")
+                output.write(chunk)
+        if digest(Path(temporary)) != checksum:
+            raise ValueError("Pinned artifact integrity check failed")
+        if component.get("size") is not None and size != component["size"]:
+            raise ValueError("Pinned artifact size changed")
+        os.replace(temporary, destination)
+        return destination
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+
+
+def extract(archive_path: Path, destination: Path) -> None:
+    """Extract reviewed inputs without allowing archive paths to escape staging."""
+    destination.mkdir(parents=True, exist_ok=True)
+    root = destination.resolve()
+    links, seen, total = [], set(), 0
+    with tarfile.open(archive_path, "r:gz") as archive:
+        for member in archive:
+            name = PurePosixPath(member.name)
+            if name.is_absolute() or ".." in name.parts or str(name) in seen:
+                raise ValueError("Unsafe artifact archive path")
+            seen.add(str(name))
+            path = root / str(name)
+            if member.isdir():
+                path.mkdir(parents=True, exist_ok=True)
+            elif member.issym():
+                links.append((path, member.linkname))
+            elif member.isfile():
+                total += member.size
+                if total > MAX_EXPANDED:
+                    raise ValueError("Artifact archive exceeds the expanded size limit")
+                path.parent.mkdir(parents=True, exist_ok=True)
+                with path.open("xb") as output:
+                    shutil.copyfileobj(archive.extractfile(member), output)
+                path.chmod(0o755 if member.mode & 0o111 else 0o644)
+            else:
+                raise ValueError("Unsupported artifact archive entry")
+    for path, value in links:
+        if Path(value).is_absolute() or root not in (path.parent / value).resolve().parents:
+            raise ValueError("Artifact link escapes staging")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.symlink_to(value)
+    for path, _ in links:
+        if root not in path.resolve(strict=True).parents:
+            raise ValueError("Artifact link escapes staging")
+
+
+def copy_source(repo: Path, output: Path) -> str:
+    """Only tracked agent files belong in a release, including their current edits."""
+    names = subprocess.check_output(["git", "-C", str(repo), "ls-files", "-z", "agent/ollama_code"], text=True).split("\0")
+    source = repo / "agent/ollama_code"
+    for name in filter(None, names):
+        path = repo / name
+        if path.is_symlink() or not path.is_file():
+            raise ValueError("Agent source must contain regular tracked files")
+        target = output / "source/ollama_code" / path.relative_to(source)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(path, target)
+    return subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
+
+
+def prune_python(root: Path) -> None:
+    """Apply the desktop runtime's unused GPL/Tk and development-file exclusions."""
+    for library in (root / "python/lib").glob("python3.*"):
+        for name in ("dbm", "tkinter", "test", "idlelib", "turtledemo", "ensurepip", "site-packages"):
+            shutil.rmtree(library / name, ignore_errors=True)
+        for pattern in ("lib-dynload/_dbm*.so", "lib-dynload/_gdbm*.so", "lib-dynload/_tkinter*.so"):
+            for path in library.glob(pattern):
+                path.unlink()
+    for path in (root / "python/bin").iterdir():
+        if not path.name.startswith("python3"):
+            path.unlink()
+    for directory in (root / "python/include", root / "python/share"):
+        shutil.rmtree(directory, ignore_errors=True)
+    for pattern in ("tcl*", "tk*", "itcl*", "libtcl*", "libtk*", "Tix*", "thread*"):
+        for path in (root / "python/lib").glob(pattern):
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+    shutil.rmtree(root / "site-packages/bin", ignore_errors=True)
+
+
+def prepare(target: str, cache: Path, output: Path, *, require_clean: bool = False) -> dict:
+    if target != host_target():
+        raise ValueError("Build on the selected target operating system and architecture")
+    pins = json.loads(PINS.read_text())
+    dirty = bool(subprocess.check_output(["git", "-C", str(ROOT), "status", "--porcelain"], text=True))
+    if require_clean and dirty:
+        raise ValueError("Release builds require a clean committed checkout")
+    components = {**pins["targets"][target], "codex_source": pins["codex_source"]}
+    archives = {}
+    for name, component in components.items():
+        print("Verifying pinned " + name, flush=True)
+        archives[name] = download(component, cache)
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".runtime-build-", dir=output.parent) as temporary:
+        work = Path(temporary)
+        runtime = work / "runtime"
+        extract(archives["python"], runtime)
+        python = runtime / "python/bin/python3"
+        if not python.is_file():
+            raise ValueError("Unexpected standalone Python layout")
+        lock = ROOT / "agent/requirements-runtime.lock"
+        platforms = [argument for value in wheel_platforms(target) for argument in ("--platform", value)]
+        subprocess.run([str(python), "-s", "-m", "pip", "--isolated", "install", "--disable-pip-version-check", *platforms,
+                        "--require-hashes", "--only-binary=:all:", "--no-compile", "--target", str(runtime / "site-packages"),
+                        "--requirement", str(lock)], check=True, timeout=900)
+        revision = copy_source(ROOT, runtime)
+        helper_paths = {}
+        for name in ("codex", "code_mode_host"):
+            folder = work / name
+            extract(archives[name], folder)
+            binaries = [p for p in folder.rglob("*") if p.is_file() and p.stat().st_mode & 0o111]
+            if len(binaries) != 1:
+                raise ValueError("Unexpected pinned helper archive layout")
+            helper_paths[name] = binaries[0]
+        licenses = runtime / "licenses"
+        shutil.copytree(ROOT / "Locus/Resources/ThirdPartyLicenses", licenses)
+        shutil.copyfile(ROOT / "Locus/Resources/ThirdPartyNotices.md", licenses / "ThirdPartyNotices.md")
+        shutil.copyfile(ROOT / "LICENSE", licenses / "Locus-LICENSE")
+        helper_licenses = licenses / ("openai-codex-" + pins["codex_version"])
+        helper_licenses.mkdir()
+        with tarfile.open(archives["codex_source"], "r:gz") as archive:
+            for name in ("LICENSE", "NOTICE"):
+                matches = [m for m in archive.getmembers() if len(PurePosixPath(m.name).parts) == 2 and PurePosixPath(m.name).name == name and m.isfile()]
+                if len(matches) != 1:
+                    raise ValueError("Pinned helper source is missing its license notices")
+                (helper_licenses / name).write_bytes(archive.extractfile(matches[0]).read())
+        prune_python(runtime)
+        provenance = {"version": 1, "target": target, "source_revision": revision, "source_dirty": dirty,
+                      "dependency_lock_sha256": digest(lock), "artifact_pins_sha256": digest(PINS),
+                      "python_version": pins["python_version"], "codex_version": pins["codex_version"],
+                      "wheel_platforms": wheel_platforms(target),
+                      "minimum_os": "macOS 14" if target == "macos-arm64" else "Linux with glibc 2.28 and systemd",
+                      "components": components, "helper_delivery": "verified-upstream-release"}
+        (runtime / "provenance.json").write_text(json.dumps(provenance, sort_keys=True, indent=2) + "\n")
+        checksum = package_runtime(runtime, helper_paths["codex"], helper_paths["code_mode_host"], target, output)
+    report = {"target": target, "package": output.name, "sha256": checksum, "provenance": provenance}
+    output.with_suffix(output.suffix + ".build.json").write_text(json.dumps(report, indent=2) + "\n")
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", choices=TARGETS, default=host_target())
+    parser.add_argument("--cache", type=Path, default=ROOT / "build/runtime-downloads")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--require-clean", action="store_true")
+    args = parser.parse_args()
+    print(json.dumps(prepare(args.target, args.cache, args.output, require_clean=args.require_clean)))
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/RemoteRuntimeArtifacts.json
+++ b/Tools/RemoteRuntimeArtifacts.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "python_version": "3.14.6",
+  "python_release": "20260728",
+  "codex_version": "0.147.0",
+  "codex_source": {
+    "url": "https://github.com/openai/codex/archive/refs/tags/rust-v0.147.0.tar.gz",
+    "sha256": "355bde4b40d5ba6deea2e469d36f91708315729f3e84c9c69cce6b041a5ba593"
+  },
+  "targets": {
+    "macos-arm64": {
+      "python": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.14.6%2B20260728-aarch64-apple-darwin-install_only_stripped.tar.gz",
+        "sha256": "f4b47659e2da4b97f38cefdf5ad19f0042946099d843cde60de308708e5b1ac5",
+        "size": 26022203
+      },
+      "codex": {
+        "url": "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-aarch64-apple-darwin.tar.gz",
+        "sha256": "75984b81f92a71b0c0f4b3b5cad80e5c57177e4d8c8b4b1e13db703b20dc4358",
+        "size": 87984231
+      },
+      "code_mode_host": {
+        "url": "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-code-mode-host-aarch64-apple-darwin.tar.gz",
+        "sha256": "56cdbf6187bf914108d3b7feeea5a34ffba15e5c162bedce69e062ee92ddfb5e",
+        "size": 17556525
+      }
+    },
+    "linux-arm64": {
+      "python": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.14.6%2B20260728-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+        "sha256": "44f86d58f3bbc1aa6c95ee90f03226e0fdbd22475a98c4410e5a20042b7f40d3",
+        "size": 30211232
+      },
+      "codex": {
+        "url": "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-aarch64-unknown-linux-musl.tar.gz",
+        "sha256": "eb677c80f666b1ab8b4b1d083b66e8d614b1281d960bb6f9fd8ca98f58b38b90",
+        "size": 91607658
+      },
+      "code_mode_host": {
+        "url": "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-code-mode-host-aarch64-unknown-linux-musl.tar.gz",
+        "sha256": "dfd4ff98ea4db30ed078af9c31b6f86e3da4836d0573aa87e225e5a5b54d3c7c",
+        "size": 17260137
+      }
+    },
+    "linux-x86_64": {
+      "python": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.14.6%2B20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+        "sha256": "d6254462d5fe066810a472d286861f6a18f66400008bfa9688e202a5672e88cb",
+        "size": 35891118
+      },
+      "codex": {
+        "url": "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-x86_64-unknown-linux-musl.tar.gz",
+        "sha256": "0246e2e773834e07f0fb5249ed6ebad12e4591e608f8c7bb97dd6a9690544c36",
+        "size": 98970270
+      },
+      "code_mode_host": {
+        "url": "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-code-mode-host-x86_64-unknown-linux-musl.tar.gz",
+        "sha256": "0146adfaac8363ec9fcdb5895f7624db5b2e8617a283887938b7fb97a1dd4356",
+        "size": 18267855
+      }
+    }
+  }
+}

--- a/Tools/SmokeRemoteRuntime.py
+++ b/Tools/SmokeRemoteRuntime.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Exercise an installed package with a local model fixture and an isolated profile.
+
+--service-manager installs a disposable, uniquely named user service, then removes
+only that service/profile. No provider accounts, SSH hosts, or desktop data are used.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import io
+import json
+import os
+import platform
+import socket
+import subprocess
+import sys
+import tarfile
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from PackageRemoteRuntime import digest, host_target
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "agent"))
+from ollama_code import runtime_install as installer
+
+
+class FixtureProvider(BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'{"data":[]}')
+
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        messages = body.get("messages", [])
+        if any("Turn the explicitly selected correction" in str(m.get("content", "")) for m in messages):
+            delta = {"content": json.dumps({"check": {"id": "ready", "kind": "file_contains", "path": "result.txt",
+                                                     "value": "ready", "requirement": "The result contains ready"},
+                                           "verification_limits": "Exact text only."})}
+            finish = "stop"
+        elif messages and messages[-1].get("role") == "tool":
+            delta, finish = {"content": "Created result.txt containing ready."}, "stop"
+        else:
+            delta = {"tool_calls": [{"index": 0, "id": "fixture-write", "type": "function",
+                                     "function": {"name": "write_file", "arguments": json.dumps({"path": "result.txt", "content": "ready\n"})}}]}
+            finish = "tool_calls"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+        for item in [{"choices": [{"delta": delta, "finish_reason": None}]},
+                     {"choices": [{"delta": {}, "finish_reason": finish}], "usage": {"prompt_tokens": 10, "completion_tokens": 2}}]:
+            self.wfile.write(("data: " + json.dumps(item) + "\n\n").encode())
+        self.wfile.write(b"data: [DONE]\n\n")
+
+
+def failed_startup_package(package: Path, output: Path) -> str:
+    """A valid fixture package that imports normally but fails service startup."""
+    with tarfile.open(package, "r:gz") as source:
+        manifest = json.load(source.extractfile("manifest.json"))
+        with tarfile.open(output, "w:gz") as target:
+            for member in source:
+                if member.name == "manifest.json":
+                    continue
+                stream = source.extractfile(member)
+                if member.name == "source/ollama_code/runtime.py":
+                    data = stream.read()
+                    # Future imports must remain first. Appending this before the
+                    # existing main guard triggers failure only during startup.
+                    needle = b'if __name__ == "__main__":'
+                    if needle not in data:
+                        raise ValueError("Cannot locate the runtime entry point for the rollback fixture")
+                    data = data.replace(needle, b'if __name__ == "__main__":\n    raise SystemExit("fixture startup failure")\n\n' + needle)
+                    manifest["files"][member.name] = hashlib.sha256(data).hexdigest()
+                    member.size = len(data)
+                    stream = io.BytesIO(data)
+                target.addfile(member, stream)
+            data = json.dumps(manifest, sort_keys=True).encode()
+            member = tarfile.TarInfo("manifest.json")
+            member.size, member.mode = len(data), 0o600
+            target.addfile(member, io.BytesIO(data))
+    return digest(output)
+
+
+def scenario(base: str, token: str, provider_port: int, workspace: Path) -> dict:
+    from ollama_code.runtime_snapshots import archive, preview
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+    def call(method, path, body=None):
+        request = urllib.request.Request(base + path, method=method,
+                                         data=json.dumps(body).encode() if body is not None else None,
+                                         headers={"X-Locus-Token": token, "Content-Type": "application/json"})
+        with opener.open(request, timeout=90) as response:
+            return json.load(response)
+
+    try:
+        opener.open(base + "/api/runtime", timeout=5)
+        raise AssertionError("The runtime accepted an unauthenticated request")
+    except urllib.error.HTTPError as error:
+        assert error.code in {401, 403}
+    for account in ("smoke-one", "smoke-two"):
+        state = call("GET", "/api/chatgpt/account?account_id=" + account)
+        assert state["runtime_available"] and state["status"] == "signed_out", "Pinned helper handshake failed: " + str(state.get("message", state["status"]))
+    (workspace / "README.md").write_text("Disposable runtime release validation")
+    review = preview(workspace)
+    approved = {"id": "initial", "version": 1, "revision": 2, "state": "approved", "workspace_root": str(workspace),
+                "correction": "Always create result.txt.", "source": {"session_id": "source"},
+                "scope": {"agent_id": "", "files": []}, "verification_limits": "Presence only.",
+                "approved_at": time.time(), "created_at": time.time(),
+                "check": {"id": "exists", "kind": "file_exists", "path": "result.txt", "requirement": "The result exists"}}
+    configuration = {"keep_running": True, "permissions": {"mode": "bypass"}, "reusable_checks": [approved],
+                     "provider": {"provider": "remote", "model": "fixture", "account_id": "fixture",
+                                  "base_url": f"http://127.0.0.1:{provider_port}/v1", "api_key": "fixture"},
+                     "schedule": {"name": "Package validation", "prompt": "Create result.txt containing ready.",
+                                  "mode": "work", "runner": "solo", "provider": "remote", "provider_account_id": "fixture",
+                                  "model": "fixture", "timezone": "UTC",
+                                  "rule": {"kind": "interval", "every": 1, "unit": "hours", "anchor": time.time() + 15}}}
+    deployed = call("POST", "/api/runtime/snapshots/import", {"deployment_id": "package-smoke", "snapshot": review,
+                                                            "archive": base64.b64encode(archive(review)).decode(), "configuration": configuration})
+    call("POST", "/api/runtime/detach", {})
+
+    def result(count):
+        returned = {"runs": []}
+        deadline = time.monotonic() + 90
+        while time.monotonic() < deadline:
+            try:
+                returned = call("GET", "/api/runtime/snapshots/" + deployed["id"])
+            except urllib.error.HTTPError as error:
+                if error.code != 409:
+                    raise
+                error.close()
+                time.sleep(.2)
+                continue
+            if len(returned["runs"]) >= count and all(run["state"] == "completed" for run in returned["runs"]):
+                return returned
+            time.sleep(.2)
+        health = call("GET", "/api/runtime")
+        diagnostic = {"expected_runs": count, "run_states": [run["state"] for run in returned["runs"]],
+                      "paused": health["paused"], "worker_states": [worker["state"] for worker in health["workers"]]}
+        raise AssertionError("Package work did not complete: " + json.dumps(diagnostic))
+
+    returned = result(1)
+    assert returned["task_contracts"] and all(task["verification_status"] == "passed" for task in returned["task_contracts"])
+    assert returned["accounting"]["total_tokens"] > 0 and returned["accounting"]["estimated_api_cost"] is None
+    assert not (workspace / "result.txt").exists()
+    session = returned["runs"][0]["session_id"]
+    worker = "/api/runtime/workers/" + session
+    correction = "Keep result.txt ready."
+    call("POST", worker + "/commands", {"type": "user_message", "text": correction, "request_id": "correction"})
+    result(2)
+    proposal = call("POST", worker + "/api/reusable-checks/propose", {"session_id": session, "correction": correction})
+    assert proposal["state"] == "proposed"
+    saved = call("PATCH", worker + "/api/reusable-checks/" + proposal["id"], {"action": "approve", "expected_revision": proposal["revision"]})
+    call("POST", worker + "/commands", {"type": "user_message", "text": "Create the next result.", "request_id": "next-task"})
+    returned = result(3)
+    latest = max(returned["runs"], key=lambda run: run["created_at"])
+    task = next(task for task in returned["task_contracts"] if task["id"] == "run:" + latest["id"])
+    assert task["verification_status"] == "passed"
+    assert any(check["id"] == saved["id"] and check["version"] == saved["version"] for check in task["reusable_checks"])
+    assert "check_generation" in returned["accounting"]["by_purpose"]
+    call("POST", "/api/runtime/pause", {})
+    assert call("GET", "/api/runtime")["active_work"] == 0
+    return {"run_ids": sorted(run["id"] for run in returned["runs"]), "total_tokens": returned["accounting"]["total_tokens"],
+            "checks": {"authenticated_loopback": True, "helper_handshake_without_accounts": True, "detached_schedule": True,
+                       "verified_result": True, "usage_coverage": True, "approved_correction_enforced": True}}
+
+
+def run(package: Path, checksum: str, output: Path, *, service_manager: bool, exercise_rollback: bool) -> dict:
+    if digest(package) != checksum:
+        raise ValueError("The smoke-test package checksum does not match")
+    validation_id = uuid.uuid4().hex
+    report = {"version": 1, "target": host_target(), "package_sha256": checksum, "provider": "deterministic-fixture",
+              "mode": "user-service" if service_manager else "process", "passed": False, "checks": {}}
+    provider = ThreadingHTTPServer(("127.0.0.1", 0), FixtureProvider)
+    threading.Thread(target=provider.serve_forever, daemon=True).start()
+    process = None
+    with tempfile.TemporaryDirectory(prefix="locus-package-smoke-") as temporary:
+        work = Path(temporary)
+        log = (work / "process.log").open("w")
+        os.environ["OLLAMA_CODE_HOME"] = str(work / "controller-profile")
+        os.environ["LOCUS_CODEX_HOME"] = str(work / "controller-accounts")
+        with socket.socket() as reservation:
+            reservation.bind(("127.0.0.1", 0))
+            port = reservation.getsockname()[1]
+        header = {"action": "install", "sha256": checksum, "port": port, "validation_id": validation_id}
+        info = {"system": platform.system(), "target": host_target()}
+        root = installer.deployment_paths(info, validation_id)[0] if service_manager else work / "runtime"
+        try:
+            if service_manager:
+                installed = installer.install(header, package.read_bytes())
+                token = installed["token"]
+            else:
+                root.mkdir(mode=0o700)
+                (root / "workspaces").mkdir()
+                extracted = installer.extract_package(package.read_bytes(), checksum, root, host_target())
+                _, environment = installer.service_definition(info, root, extracted, port, "fixture")
+                process = subprocess.Popen([str(extracted / "python/bin/python3"), "-m", "ollama_code.runtime", "--home", str(root),
+                                            "--port", str(port), "--cwd", str(root / "workspaces")],
+                                           env={**os.environ, **environment}, stdin=subprocess.DEVNULL, stdout=log, stderr=log)
+                installer.wait_ready(root, port, checksum)
+                token = installer.private_read(root)["controller_token"]
+            source = work / "project"
+            source.mkdir()
+            report.update(scenario(f"http://127.0.0.1:{port}", token, provider.server_port, source))
+            if service_manager:
+                control = {"action": "control", "validation_id": validation_id}
+                installer.control({**control, "control": "stop"})
+                installer.control({**control, "control": "start"})
+                installer.wait_ready(root, port, checksum)
+                returned = installer.api_request(root, port, path="/api/runtime/snapshots/package-smoke")
+                assert sorted(run["id"] for run in returned["runs"]) == report["run_ids"]
+                assert returned["accounting"]["total_tokens"] == report["total_tokens"]
+                report["checks"]["service_restart_preserves_results_and_usage"] = True
+                if exercise_rollback:
+                    candidate = work / "failed-startup.tar.gz"
+                    candidate_sha = failed_startup_package(package, candidate)
+                    try:
+                        installer.install({**header, "sha256": candidate_sha}, candidate.read_bytes())
+                    except ValueError as error:
+                        assert "were restored" in str(error), str(error)
+                    else:
+                        raise AssertionError("The startup failure fixture unexpectedly installed")
+                    installer.wait_ready(root, port, checksum)
+                    returned = installer.api_request(root, port, path="/api/runtime/snapshots/package-smoke")
+                    assert sorted(run["id"] for run in returned["runs"]) == report["run_ids"]
+                    assert returned["accounting"]["total_tokens"] == report["total_tokens"]
+                    report["checks"]["failed_update_restores_service_and_usage"] = True
+            elif exercise_rollback:
+                raise ValueError("Rollback validation requires --service-manager")
+            report["passed"] = True
+        finally:
+            try:
+                if service_manager and root.exists():
+                    installer.control({"action": "control", "control": "remove-validation", "validation_id": validation_id})
+                elif process is not None:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=15)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=5)
+                report["checks"]["isolated_cleanup"] = True
+            except Exception:
+                report["passed"] = False
+                report["checks"]["isolated_cleanup"] = False
+                raise
+            finally:
+                provider.shutdown()
+                provider.server_close()
+                log.close()
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_text(json.dumps(report, indent=2) + "\n")
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package", type=Path, required=True)
+    parser.add_argument("--sha256", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--service-manager", action="store_true")
+    parser.add_argument("--exercise-rollback", action="store_true")
+    args = parser.parse_args()
+    print(json.dumps(run(args.package, args.sha256, args.output, service_manager=args.service_manager, exercise_rollback=args.exercise_rollback)))
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/ollama_code/api/runtime.py
+++ b/agent/ollama_code/api/runtime.py
@@ -17,6 +17,13 @@ def supervisor(app):
     return runtime
 
 
+async def block_runtime_maintenance(request: Request, call_next):
+    runtime = getattr(request.app.state, "runtime", None)
+    if runtime is not None and runtime.maintenance and request.method not in {"GET", "HEAD", "OPTIONS"}:
+        return JSONResponse({"detail": "Runtime installation is in progress; retry when it is ready"}, status_code=409)
+    return await call_next(request)
+
+
 async def status(request: Request):
     runtime = supervisor(request.app)
     value = runtime.status()
@@ -314,6 +321,8 @@ async def providers_ollama(request: Request, body: dict = Body()):
 
 def resume_runtime(request: Request):
     runtime = supervisor(request.app)
+    if runtime.maintenance:
+        raise HTTPException(409, "Finish runtime installation before resuming work")
     runtime.paused = False
     runtime.private.set("paused", False)
     return {"ok": True}

--- a/agent/ollama_code/codex_app_server.py
+++ b/agent/ollama_code/codex_app_server.py
@@ -287,7 +287,10 @@ class CodexAppServerManager:
             raise CodexAppServerError("The bundled ChatGPT helper is unavailable")
         name = Path(path).name
         args = [path]
-        if name == "codex" or (name.startswith("codex-") and "app-server" not in name):
+        kind = os.environ.get("LOCUS_CODEX_HELPER_KIND", "")
+        if kind not in {"", "cli", "app-server"}:
+            raise CodexAppServerError("Unknown bundled ChatGPT helper entry point")
+        if kind == "cli" or (not kind and (name == "codex" or (name.startswith("codex-") and "app-server" not in name))):
             args.append("app-server")
         args.extend(["--listen", "stdio://"])
         return args

--- a/agent/ollama_code/runstore.py
+++ b/agent/ollama_code/runstore.py
@@ -138,6 +138,16 @@ def _alive(pid: int) -> bool:
         return False
 
 
+class _ClosingConnection(sqlite3.Connection):
+    """Commit/rollback and close each operation without relying on cyclic GC."""
+
+    def __exit__(self, *args):
+        try:
+            return super().__exit__(*args)
+        finally:
+            self.close()
+
+
 class RunStore(AgentInspectorStore):
     """Thread-safe SQLite facade shared by the control and worker services."""
 
@@ -160,7 +170,7 @@ class RunStore(AgentInspectorStore):
             if disk_version is not None and disk_version < SCHEMA_VERSION:
                 backup = self.path.with_name(f"{self.path.name}.schema-{disk_version}.backup")
                 if not backup.exists():
-                    with sqlite3.connect(self.path) as source, sqlite3.connect(backup) as destination:
+                    with sqlite3.connect(self.path, factory=_ClosingConnection) as source, sqlite3.connect(backup, factory=_ClosingConnection) as destination:
                         source.backup(destination)
                     backup.chmod(0o600)
             self._initialize()
@@ -179,8 +189,8 @@ class RunStore(AgentInspectorStore):
         if not self.path.exists():
             return None
         try:
-            uri = f"file:{self.path}?mode=ro"
-            with sqlite3.connect(uri, uri=True, timeout=5) as connection:
+            uri = self.path.resolve().as_uri() + "?mode=ro"
+            with sqlite3.connect(uri, uri=True, timeout=5, factory=_ClosingConnection) as connection:
                 exists = connection.execute(
                     "SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_meta'"
                 ).fetchone()
@@ -195,10 +205,10 @@ class RunStore(AgentInspectorStore):
 
     def _connect(self, *, readonly: bool = False) -> sqlite3.Connection:
         if readonly or self.read_only:
-            uri = f"file:{self.path}?mode=ro"
-            connection = sqlite3.connect(uri, uri=True, timeout=5)
+            uri = self.path.resolve().as_uri() + "?mode=ro"
+            connection = sqlite3.connect(uri, uri=True, timeout=5, factory=_ClosingConnection)
         else:
-            connection = sqlite3.connect(self.path, timeout=5)
+            connection = sqlite3.connect(self.path, timeout=5, factory=_ClosingConnection)
         connection.row_factory = sqlite3.Row
         connection.execute("PRAGMA busy_timeout=5000")
         connection.execute("PRAGMA foreign_keys=ON")

--- a/agent/ollama_code/runtime.py
+++ b/agent/ollama_code/runtime.py
@@ -62,11 +62,15 @@ class RuntimeSupervisor:
         self.automation = None
         from .runtime_providers import RuntimeProviders
         self.providers = RuntimeProviders(self)
-        self.paused = bool(self.private.read().get("paused", False))
+        self.paused = self.maintenance or bool(self.private.read().get("paused", False))
         identity = self.private.read().get("runtime_id") or secrets.token_hex(16)
         self.private.set("runtime_id", identity)
         self.runtime_id = identity
         self.package_id = os.environ.get("LOCUS_RUNTIME_PACKAGE_ID", str(Path(__file__).resolve().parents[1]))
+
+    @property
+    def maintenance(self) -> bool:
+        return (self.root / "installation.json").exists()
 
     async def start(self) -> None:
         from .usage_ledger import UsageLedger
@@ -107,13 +111,15 @@ class RuntimeSupervisor:
 
     def status(self) -> dict:
         return {"id": self.runtime_id, "version": 1, "protocol_version": 1,
-                "independent": True, "connected": True, "paused": self.paused, "package_id": self.package_id, "workers": self.store.workers(),
+                "independent": True, "connected": True, "paused": self.paused, "maintenance": self.maintenance, "package_id": self.package_id, "workers": self.store.workers(),
                 "pending_approvals": self.store.decisions(), "max_active_chats": self.limit,
                 "active_work": sum(bool(worker.active_command) for worker in self.workers.values()),
                 "capabilities": {"durable_events": True, "background_schedules": True,
                                  "desktop_requires_controller": True, "remote_chatgpt": True}}
 
     async def ensure_worker(self, session_id: str, workspace: str, *, keep_running: bool | None = None) -> Worker:
+        if self.maintenance:
+            raise RuntimeError("Runtime installation is in progress; retry when it is ready")
         identifier(session_id)
         async with self.launch_lock:
             record = self.store.save_worker(session_id, workspace, keep_running=keep_running)
@@ -197,6 +203,8 @@ class RuntimeSupervisor:
             await worker.ws.send(json.dumps(message))
 
     async def command(self, session_id: str, message: dict) -> dict:
+        if self.maintenance:
+            raise RuntimeError("Runtime installation is in progress; retry when it is ready")
         worker = self.workers.get(session_id)
         if not worker:
             row = self.store.worker(session_id)
@@ -403,7 +411,7 @@ class RuntimeSupervisor:
                 if self.controller_seen and time.monotonic() - self.controller_seen > 35:
                     await self.detach()
                 self.relay_controller_presence()
-                if self.paused:
+                if self.paused or self.maintenance:
                     await asyncio.sleep(1)
                     continue
                 await automation.tick()

--- a/agent/ollama_code/runtime_install.py
+++ b/agent/ollama_code/runtime_install.py
@@ -23,6 +23,9 @@ def host_info():
         raise ValueError("Install Python 3.10 or newer for runtime setup on this host")
     system, architecture = platform.system(), platform.machine()
     if system == "Linux" and architecture in {"x86_64", "aarch64", "arm64"}:
+        libc, version = platform.libc_ver()
+        if libc != "glibc" or tuple(int(part) for part in version.split(".")[:2]) < (2, 28):
+            raise ValueError("Linux runtime packages require glibc 2.28 or newer")
         target = "linux-" + ("arm64" if architecture != "x86_64" else "x86_64")
         command = subprocess.run(["systemctl", "--user", "show-environment"], capture_output=True)
         if command.returncode:
@@ -46,15 +49,6 @@ def extract_package(data, expected, root, target):
     if actual != expected:
         raise ValueError("Runtime package integrity check failed")
     destination = root / "versions" / actual
-    if destination.exists():
-        manifest = json.loads((destination / "manifest.json").read_text())
-        if manifest["target"] != target or manifest["protocol_version"] != PROTOCOL or manifest.get("codex_version") != "0.147.0":
-            raise ValueError("Runtime package is incompatible with this host")
-        for name, checksum in manifest["files"].items():
-            path = destination / name
-            if path.is_symlink() or destination not in path.resolve().parents or hashlib.sha256(path.read_bytes()).hexdigest() != checksum:
-                raise ValueError("Installed runtime integrity check failed")
-        return destination
     destination.parent.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix=".install-", dir=destination.parent))
     try:
@@ -62,7 +56,7 @@ def extract_package(data, expected, root, target):
         with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as archive:
             for member in archive:
                 path = PurePosixPath(member.name)
-                if path.is_absolute() or ".." in path.parts or not member.isfile() or member.name in seen:
+                if path.is_absolute() or ".." in path.parts or str(path) != member.name or not member.isfile() or member.name in seen:
                     raise ValueError("Unsafe runtime package member")
                 total += member.size
                 if total > MAX_PACKAGE or member.size > MAX_PACKAGE:
@@ -76,7 +70,11 @@ def extract_package(data, expected, root, target):
         manifest = json.loads((staging / "manifest.json").read_text())
         if manifest["target"] != target or manifest["protocol_version"] != PROTOCOL or manifest["codex_version"] != "0.147.0":
             raise ValueError("Runtime package is incompatible with this host or controller")
+        if not isinstance(manifest.get("files"), dict) or not manifest["files"]:
+            raise ValueError("Runtime package manifest is invalid")
         for name, checksum in manifest["files"].items():
+            if not isinstance(name, str) or str(PurePosixPath(name)) != name or PurePosixPath(name).is_absolute() or ".." in PurePosixPath(name).parts:
+                raise ValueError("Unsafe runtime manifest path")
             if name not in seen or hashlib.sha256((staging / name).read_bytes()).hexdigest() != checksum:
                 raise ValueError("Runtime package file integrity check failed")
         if seen != set(manifest["files"]) | {"manifest.json"}:
@@ -84,128 +82,348 @@ def extract_package(data, expected, root, target):
         for required in ("python/bin/python3", "source/ollama_code/runtime.py", "codex-app-server", "codex-code-mode-host"):
             if required not in seen:
                 raise ValueError("Runtime package is incomplete")
-        os.replace(staging, destination)
+        if destination.exists():
+            if destination.is_symlink():
+                raise ValueError("Installed runtime integrity check failed")
+            actual_files = set()
+            for path in destination.rglob("*"):
+                if path.is_symlink():
+                    raise ValueError("Installed runtime integrity check failed")
+                if path.is_file():
+                    actual_files.add(path.relative_to(destination).as_posix())
+            if actual_files != seen or (destination / "manifest.json").read_bytes() != (staging / "manifest.json").read_bytes():
+                raise ValueError("Installed runtime integrity check failed")
+            for name, checksum in manifest["files"].items():
+                if hashlib.sha256((destination / name).read_bytes()).hexdigest() != checksum:
+                    raise ValueError("Installed runtime integrity check failed")
+        else:
+            os.replace(staging, destination)
         return destination
     finally:
         if staging.exists():
             shutil.rmtree(staging)
 
 
-def install(header, data):
-    info = host_info()
+
+def deployment_paths(info, validation_id=None):
+    import re
+    if validation_id is not None and not re.fullmatch(r"[a-f0-9]{32}", validation_id):
+        raise ValueError("Invalid isolated runtime validation identifier")
     root = Path.home() / ".local/share/locus-runtime"
-    root.mkdir(parents=True, exist_ok=True, mode=0o700)
-    current = root / "current"
-    # An update cannot replace a runtime while billable or external work is active.
-    if (root / "endpoint.json").exists():
-        import urllib.error
-        import urllib.request
-        endpoint = json.loads((root / "endpoint.json").read_text())
-        secret_path = root / "runtime-secrets.json"
-        if secret_path.exists():
-            token = json.loads(secret_path.read_text()).get("controller_token", "")
-            try:
-                opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
-                request = urllib.request.Request(endpoint["url"] + "/api/runtime", headers={"X-Locus-Token": token})
-                with opener.open(request, timeout=3) as response:
-                    status = json.load(response)
-                if status.get("active_work") or any(worker["state"] not in {"idle", "paused", "completed", "interrupted"} for worker in status["workers"]):
-                    raise ValueError("Pause and drain active agents before updating this runtime")
-            except (urllib.error.URLError, TimeoutError):
-                pass
-    package = extract_package(data, header["sha256"], root, info["target"])
-    helper = subprocess.run([str(package / "codex-app-server"), "--version"], capture_output=True, text=True, timeout=20)
-    if helper.returncode or not helper.stdout.strip().endswith(" 0.147.0"):
-        raise ValueError("The packaged ChatGPT helper does not match pinned version 0.147.0")
+    label = "locus-runtime" if info["system"] == "Linux" else "io.sparktales.locus.runtime.remote"
+    if validation_id:
+        root = Path.home() / ".local/share/locus-runtime-validation" / validation_id
+        label = "locus-runtime-validation-" + validation_id if info["system"] == "Linux" else "io.sparktales.locus.runtime.validation." + validation_id
+    unit = (Path.home() / ".config/systemd/user" / (label + ".service") if info["system"] == "Linux"
+            else Path.home() / "Library/LaunchAgents" / (label + ".plist"))
+    return root, unit, label
+
+
+def atomic_write(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, temporary = tempfile.mkstemp(prefix=".runtime-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+
+
+def private_read(root):
+    path = root / "runtime-secrets.json"
+    if not path.exists():
+        return {}
+    if path.is_symlink() or path.stat().st_mode & 0o077:
+        raise ValueError("Runtime credentials must be a user-only regular file")
+    return json.loads(path.read_text())
+
+
+def set_paused(root, value):
+    private = private_read(root)
+    private["paused"] = value
+    atomic_write(root / "runtime-secrets.json", json.dumps(private).encode())
+
+
+def api_request(root, port, method="GET", path="/api/runtime"):
+    import urllib.error
+    import urllib.request
+    token = private_read(root).get("controller_token")
+    if not token:
+        return None
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    request = urllib.request.Request(f"http://127.0.0.1:{port}" + path,
+                                     headers={"X-Locus-Token": token, "Content-Type": "application/json"},
+                                     method=method, data=b"{}" if method == "POST" else None)
+    try:
+        with opener.open(request, timeout=2) as response:
+            return json.load(response)
+    except (urllib.error.URLError, TimeoutError, ValueError):
+        return None
+
+
+def service_running(info, label):
+    command = (["systemctl", "--user", "is-active", "--quiet", label] if info["system"] == "Linux"
+               else ["launchctl", "print", f"gui/{os.getuid()}/{label}"])
+    return subprocess.run(command, capture_output=True, timeout=15).returncode == 0
+
+
+def service_control(info, unit, label, action):
+    if action == "stop" and not service_running(info, label):
+        return
+    if info["system"] == "Linux":
+        commands = [["systemctl", "--user", "daemon-reload"], ["systemctl", "--user", action, label]]
+        if action == "start":
+            commands.insert(1, ["systemctl", "--user", "enable", label])
+    else:
+        commands = [["launchctl", "bootout" if action == "stop" else "bootstrap", f"gui/{os.getuid()}", str(unit)]]
+    for command in commands:
+        if subprocess.run(command, capture_output=True, timeout=35).returncode:
+            raise ValueError("The host's service manager could not " + action + " Locus")
+
+
+def service_definition(info, root, package, port, label):
     python = str(package / "python/bin/python3")
     environment = {"PYTHONPATH": str(package / "source") + ":" + str(package / "site-packages"),
                    "OLLAMA_CODE_HOME": str(root / "profile"), "LOCUS_CODEX_HOME": str(root / "accounts"),
                    "LOCUS_CODEX_APP_SERVER_PATH": str(package / "codex-app-server"),
-                   "LOCUS_RUNTIME_PACKAGE_ID": header["sha256"], "LOCUS_DOCUMENT_COORDINATOR": "1", "PYTHONDONTWRITEBYTECODE": "1", "PYTHONUNBUFFERED": "1"}
-    check = subprocess.run([python, '-c', 'import sys; assert sys.version_info >= (3,10); import ollama_code.runtime'],
-                           env={**os.environ, **environment}, capture_output=True, timeout=30)
-    if check.returncode:
-        raise ValueError("The packaged Python runtime cannot import its required dependencies")
-    workspaces = root / "workspaces"
-    workspaces.mkdir(exist_ok=True, mode=0o700)
-    port = int(header.get("port", 8793))
-    if not 1024 <= port <= 65535:
-        raise ValueError("Invalid runtime port")
-    arguments = [python, "-m", "ollama_code.runtime", "--home", str(root), "--port", str(port), "--cwd", str(workspaces)]
+                   "LOCUS_CODEX_HELPER_KIND": "cli",
+                   "LOCUS_RUNTIME_PACKAGE_ID": package.name, "LOCUS_DOCUMENT_COORDINATOR": "1",
+                   "PYTHONNOUSERSITE": "1", "PYTHONDONTWRITEBYTECODE": "1", "PYTHONUNBUFFERED": "1"}
+    arguments = [python, "-m", "ollama_code.runtime", "--home", str(root), "--port", str(port), "--cwd", str(root / "workspaces")]
     if info["system"] == "Linux":
-        unit = Path.home() / ".config/systemd/user/locus-runtime.service"
-        unit.parent.mkdir(parents=True, exist_ok=True)
         def quoted(value):
             return '"' + value.replace('\\', '\\\\').replace('"', '\\"').replace('%', '%%').replace('\n', '\\n') + '"'
         text = "[Unit]\nDescription=Locus independent agents\nAfter=network-online.target\n[Service]\nType=simple\n"
         text += "ExecStart=" + " ".join(quoted(value) for value in arguments) + "\n"
         text += "\n".join("Environment=" + quoted(key + "=" + value) for key, value in environment.items())
         text += "\nRestart=on-failure\nRestartSec=5\nKillMode=control-group\nTimeoutStopSec=30\nUMask=0077\n[Install]\nWantedBy=default.target\n"
-        unit.write_text(text)
-        unit.chmod(0o600)
-        commands = [["systemctl", "--user", "daemon-reload"], ["systemctl", "--user", "enable", "locus-runtime"], ["systemctl", "--user", "restart", "locus-runtime"]]
-    else:
-        unit = Path.home() / "Library/LaunchAgents/io.sparktales.locus.runtime.remote.plist"
-        unit.parent.mkdir(parents=True, exist_ok=True)
-        unit.write_bytes(plistlib.dumps({"Label": "io.sparktales.locus.runtime.remote", "ProgramArguments": arguments,
-                                        "EnvironmentVariables": environment, "RunAtLoad": True, "KeepAlive": True,
-                                        "ThrottleInterval": 10, "ProcessType": "Background"}))
-        unit.chmod(0o600)
-        subprocess.run(["launchctl", "bootout", f"gui/{os.getuid()}", str(unit)], capture_output=True)
-        commands = [["launchctl", "bootstrap", f"gui/{os.getuid()}", str(unit)]]
-    for command in commands:
-        result = subprocess.run(command, capture_output=True)
-        if result.returncode:
-            raise ValueError("The host's service manager could not start Locus")
-    if current.is_symlink():
-        previous = root / "previous"
-        previous.unlink(missing_ok=True)
-        previous.symlink_to(current.resolve())
-        current.unlink()
-    current.symlink_to(package)
+        return text.encode(), environment
+    return plistlib.dumps({"Label": label, "ProgramArguments": arguments, "EnvironmentVariables": environment,
+                           "RunAtLoad": True, "KeepAlive": True, "ThrottleInterval": 10, "ProcessType": "Standard",
+                           "WorkingDirectory": str(root / "workspaces"), "Umask": 0o077, "ExitTimeOut": 30,
+                           "StandardOutPath": str(root / "service.log"), "StandardErrorPath": str(root / "service.log")}), environment
+
+
+def assert_idle(status):
+    if status and (status.get("active_work") or any(worker["state"] not in {"idle", "paused", "completed", "interrupted"} for worker in status.get("workers", []))):
+        raise ValueError("Pause and drain active agents before updating this runtime")
+
+
+def wait_ready(root, port, expected):
     import time
-    for _ in range(100):
-        if (root / "runtime-secrets.json").exists():
-            secrets = json.loads((root / "runtime-secrets.json").read_text())
-            if secrets.get("controller_token"):
-                import urllib.error
-                import urllib.request
-                opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
-                request = urllib.request.Request(f"http://127.0.0.1:{port}/api/runtime", headers={"X-Locus-Token": secrets["controller_token"]})
-                try:
-                    with opener.open(request, timeout=1) as response:
-                        ready = json.load(response)
-                    if ready.get("protocol_version") == PROTOCOL and ready.get("package_id") == header["sha256"]:
-                        return {**info, "root": str(root), "port": port, "package": header["sha256"], "token": secrets["controller_token"]}
-                except (urllib.error.URLError, TimeoutError, ValueError):
-                    pass
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        ready = api_request(root, port)
+        if ready and ready.get("protocol_version") == PROTOCOL and ready.get("package_id") == expected:
+            return ready
         time.sleep(.2)
     raise ValueError("The runtime did not become ready")
+
+
+def set_current(root, name, package):
+    path = root / name
+    if path.exists() and not path.is_symlink():
+        raise ValueError("Runtime version references must be symlinks")
+    if package is None:
+        path.unlink(missing_ok=True)
+        return
+    import secrets
+    temporary = root / (".link-" + secrets.token_hex(8))
+    try:
+        temporary.symlink_to(package)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def backup_databases(root, journal):
+    import sqlite3
+    from contextlib import closing
+    folder = root / "install-backups" / journal["id"]
+    folder.mkdir(parents=True, exist_ok=True, mode=0o700)
+    backups = []
+    for path in (root / "profile").rglob("*.sqlite3"):
+        if path.is_symlink():
+            raise ValueError("Runtime databases cannot be symlinks")
+        relative = path.relative_to(root)
+        output = folder / relative
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with closing(sqlite3.connect(path.as_uri() + "?mode=ro", uri=True)) as source, closing(sqlite3.connect(output)) as target:
+            source.backup(target)
+        output.chmod(0o600)
+        backups.append(str(relative))
+    journal["databases"] = backups
+    atomic_write(root / "installation.json", json.dumps(journal).encode())
+
+
+def rollback(info, root, unit, label, journal):
+    import base64
+    # No new work is admitted while installation.json exists. Restore only the
+    # databases captured after the prior service stopped, retaining their backups.
+    service_control(info, unit, label, "stop")
+    if "databases" in journal:
+        # Candidate startup may create a new database. It contains no admitted
+        # work and must not leave a newer schema behind for the previous package.
+        baseline = set(journal["databases"])
+        for path in (root / "profile").rglob("*.sqlite3"):
+            if str(path.relative_to(root)) not in baseline:
+                for suffix in ("", "-wal", "-shm"):
+                    Path(str(path) + suffix).unlink(missing_ok=True)
+    for relative in journal.get("databases", []):
+        path = root / relative
+        backup = root / "install-backups" / journal["id"] / relative
+        if not relative.startswith("profile/") or ".." in PurePosixPath(relative).parts:
+            raise ValueError("Invalid runtime database backup path")
+        for suffix in ("-wal", "-shm"):
+            Path(str(path) + suffix).unlink(missing_ok=True)
+        atomic_write(path, backup.read_bytes())
+    if journal["unit"] is None:
+        if info["system"] == "Linux":
+            subprocess.run(["systemctl", "--user", "disable", label], capture_output=True, timeout=15)
+        unit.unlink(missing_ok=True)
+    else:
+        atomic_write(unit, base64.b64decode(journal["unit"], validate=True))
+    set_current(root, "current", journal["previous_package"])
+    set_current(root, "previous", journal.get("previous_link"))
+    set_paused(root, journal["was_paused"])
+    if journal["was_running"] and journal["unit"] is not None:
+        service_control(info, unit, label, "start")
+        wait_ready(root, journal["previous_port"], Path(journal["previous_package"]).name)
+    (root / "installation.json").unlink()
+    if journal["was_running"] and not journal["was_paused"]:
+        api_request(root, journal["previous_port"], "POST", "/api/runtime/resume")
+
+
+def install(header, data):
+    import base64
+    import fcntl
+    import secrets
+    info = host_info()
+    root, unit, label = deployment_paths(info, header.get("validation_id"))
+    if root.is_symlink() or unit.is_symlink():
+        raise ValueError("Runtime installation paths cannot be symlinks")
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with (root / ".install.lock").open("a") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            raise ValueError("Another runtime installation or control operation is in progress") from None
+        pending = root / "installation.json"
+        if pending.exists():
+            journal = json.loads(pending.read_text())
+            assert_idle(api_request(root, journal["port"]))
+            rollback(info, root, unit, label, journal)
+        port = int(header.get("port", 8793))
+        if not 1024 <= port <= 65535:
+            raise ValueError("Invalid runtime port")
+        endpoint = root / "endpoint.json"
+        previous_port = int(json.loads(endpoint.read_text())["url"].rsplit(":", 1)[1]) if endpoint.exists() else port
+        status = api_request(root, previous_port)
+        assert_idle(status)
+        was_running = service_running(info, label)
+        if was_running and status is None:
+            raise ValueError("Stop the unresponsive runtime explicitly before updating it")
+        if status and not status.get("paused"):
+            raise ValueError("Pause this runtime before installing an update")
+        package = extract_package(data, header["sha256"], root, info["target"])
+        helper = subprocess.run([str(package / "codex-app-server"), "--version"], capture_output=True, text=True, timeout=20)
+        if helper.returncode or helper.stdout.strip() != "codex-cli 0.147.0":
+            raise ValueError("The packaged ChatGPT helper does not match pinned version 0.147.0")
+        definition, environment = service_definition(info, root, package, port, label)
+        with tempfile.TemporaryDirectory(prefix=".preflight-", dir=root) as temporary:
+            check_environment = {**os.environ, **environment, "OLLAMA_CODE_HOME": str(Path(temporary) / "profile"),
+                                 "LOCUS_CODEX_HOME": str(Path(temporary) / "accounts")}
+            check = subprocess.run([str(package / "python/bin/python3"), "-s", "-c", 'import sys; assert sys.version_info >= (3,10); import ollama_code.runtime'],
+                                   env=check_environment, cwd=temporary, capture_output=True, timeout=40)
+            if check.returncode:
+                raise ValueError("The packaged Python runtime cannot import its required dependencies")
+        current = root / "current"
+        previous_package = str(current.resolve()) if current.is_symlink() else None
+        if previous_package is not None and Path(previous_package).parent != root / "versions":
+            raise ValueError("The current package is outside the runtime version directory")
+        journal = {"version": 1, "id": secrets.token_hex(16), "package": package.name, "port": port,
+                   "previous_package": previous_package, "previous_port": previous_port,
+                   "previous_link": str((root / "previous").resolve()) if (root / "previous").is_symlink() else None,
+                   "unit": base64.b64encode(unit.read_bytes()).decode() if unit.exists() else None,
+                   "was_running": was_running, "was_paused": bool(private_read(root).get("paused", False))}
+        if journal["unit"] is not None and previous_package is None:
+            raise ValueError("The existing service has no verified current package; inspect it before installing")
+        atomic_write(pending, json.dumps(journal).encode())
+        try:
+            service_control(info, unit, label, "stop")
+            backup_databases(root, journal)
+            set_paused(root, True)
+            (root / "workspaces").mkdir(exist_ok=True, mode=0o700)
+            atomic_write(unit, definition)
+            service_control(info, unit, label, "start")
+            wait_ready(root, port, package.name)
+            if previous_package and previous_package != str(package):
+                set_current(root, "previous", previous_package)
+            set_current(root, "current", str(package))
+            pending.unlink()
+        except BaseException as error:
+            try:
+                rollback(info, root, unit, label, journal)
+            except Exception:
+                raise ValueError("Runtime update failed and recovery needs attention; the installation journal and database backups were retained") from None
+            raise ValueError("Runtime update failed; the previous service and database state were restored") from error
+        # Existing installations deliberately stay paused. First installs have
+        # no saved work, so enable scheduling only after the transaction commits.
+        if journal["unit"] is None:
+            api_request(root, port, "POST", "/api/runtime/resume")
+        return {**info, "root": str(root), "port": port, "package": package.name,
+                "token": private_read(root)["controller_token"]}
+
+
+def control(header):
+    import fcntl
+    info = host_info()
+    root, unit, label = deployment_paths(info, header.get("validation_id"))
+    action = header.get("control")
+    if action not in {"stop", "start", "remove-validation"} or (action == "remove-validation" and not header.get("validation_id")):
+        raise ValueError("Unknown runtime control")
+    if not root.is_dir() or root.is_symlink() or unit.is_symlink():
+        raise ValueError("Runtime installation was not found")
+    with (root / ".install.lock").open("a") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            raise ValueError("Another runtime installation or control operation is in progress") from None
+        if (root / "installation.json").exists() and action == "start":
+            raise ValueError("Retry the interrupted installation before starting work")
+        service_control(info, unit, label, "stop" if action == "remove-validation" else action)
+        if action == "remove-validation":
+            if info["system"] == "Linux":
+                subprocess.run(["systemctl", "--user", "disable", label], capture_output=True, timeout=15)
+            unit.unlink(missing_ok=True)
+            shutil.rmtree(root)
+    return {"ok": True}
 
 
 def main():
     header = json.loads(sys.stdin.buffer.readline(16384))
     if header.get("action") == "control":
-        info = host_info()
-        action = header.get("control")
-        if action not in {"stop", "start"}:
-            raise ValueError("Unknown runtime control")
-        if info["system"] == "Linux":
-            command = ["systemctl", "--user", action, "locus-runtime"]
-        else:
-            path = str(Path.home() / "Library/LaunchAgents/io.sparktales.locus.runtime.remote.plist")
-            command = ["launchctl", "bootout" if action == "stop" else "bootstrap", f"gui/{os.getuid()}", path]
-        completed = subprocess.run(command, capture_output=True)
-        if completed.returncode:
-            raise ValueError("The host's service manager could not change runtime state")
-        result = {"ok": True}
+        result = control(header)
     elif header.get("action") == "validate":
         result = host_info()
-    else:
+    elif header.get("action") == "install":
         size = int(header.get("size", 0))
         if not 0 < size <= MAX_PACKAGE:
             raise ValueError("Invalid package size")
-        result = install(header, sys.stdin.buffer.read(size + 1))
+        data = sys.stdin.buffer.read(size + 1)
+        if len(data) != size:
+            raise ValueError("The runtime upload was interrupted or exceeded its declared size")
+        result = install(header, data)
+    else:
+        raise ValueError("Unknown installer action")
     print(json.dumps(result))
 
 

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -2852,6 +2852,8 @@ def create_app(
         max_bytes=MAX_HTTP_BODY_BYTES,
         route_limits={("POST", "/api/document-jobs/upload"): MAX_SOURCE_BYTES},
     )
+    from .api.runtime import block_runtime_maintenance
+    application.middleware("http")(block_runtime_maintenance)
     application.middleware("http")(block_browser_origins)
     application.include_router(api)
     return application

--- a/agent/tests/test_runstore_connections.py
+++ b/agent/tests/test_runstore_connections.py
@@ -1,0 +1,45 @@
+"""Run-history transactions release OS resources even without garbage collection."""
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ollama_code.runstore import RunStore
+
+
+def test_run_store_releases_connections_under_service_file_limits(tmp_path):
+    code = """
+import gc, resource, sys
+from pathlib import Path
+from ollama_code.runstore import RunStore
+gc.disable()
+soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+resource.setrlimit(resource.RLIMIT_NOFILE, (min(64, hard), hard))
+store = RunStore(Path(sys.argv[1]))
+for _ in range(400):
+    with store._connect(readonly=True) as db:
+        assert db.execute('SELECT version FROM schema_meta').fetchone()[0] > 0
+print('closed')
+"""
+    result = subprocess.run([sys.executable, "-c", code, str(tmp_path / "history?#.sqlite3")],
+                            cwd=Path(__file__).resolve().parents[1], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "closed"
+
+
+def test_run_store_closes_after_commit_and_rollback(tmp_path):
+    store = RunStore(tmp_path / "history.sqlite3")
+    with store._connect() as db:
+        db.execute("CREATE TABLE fixture(value TEXT)")
+        db.execute("INSERT INTO fixture VALUES('committed')")
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        db.execute("SELECT 1")
+    with pytest.raises(ValueError), store._connect() as db:
+        db.execute("INSERT INTO fixture VALUES('rolled back')")
+        raise ValueError("fixture rollback")
+    with store._connect(readonly=True) as db:
+        assert [row[0] for row in db.execute("SELECT value FROM fixture")] == ["committed"]
+
+

--- a/agent/tests/test_runtime_release.py
+++ b/agent/tests/test_runtime_release.py
@@ -1,0 +1,310 @@
+"""Package provenance, archive boundaries, maintenance admission and update recovery."""
+import asyncio
+import base64
+import hashlib
+import importlib.util
+import io
+import json
+import sqlite3
+import sys
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from ollama_code import runtime_install as installer
+from ollama_code import server
+from ollama_code.api.runtime import resume_runtime
+from ollama_code.runstore import RunStore
+from ollama_code.runtime import RuntimeSupervisor
+
+
+def tool(name):
+    path = Path(__file__).resolve().parents[2] / "Tools" / (name + ".py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+packager = tool("PackageRemoteRuntime")
+builder = tool("PrepareRemoteRuntime")
+
+
+@pytest.fixture
+def layout(tmp_path, monkeypatch):
+    root = tmp_path / "runtime"
+    for name, data in {"python/bin/python3.14": b"python", "source/ollama_code/runtime.py": b"source", "site-packages/example.py": b"dependency"}.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+    (root / "python/bin/python3").symlink_to("python3.14")
+    helper, code_host = tmp_path / "helper", tmp_path / "code-host"
+    for path in (helper, code_host):
+        path.write_bytes(b"fixture executable")
+        path.chmod(0o700)
+    monkeypatch.setattr(packager, "host_target", lambda: "linux-arm64")
+    monkeypatch.setattr(packager, "check_runtime", lambda *_: None)
+    return root, helper, code_host
+
+
+def test_packages_are_reproducible_and_relocatable(layout, tmp_path):
+    root, helper, code_host = layout
+    first, second = tmp_path / "one.tar.gz", tmp_path / "another-name.tar.gz"
+    checksum = packager.package_runtime(root, helper, code_host, "linux-arm64", first)
+    for path in root.rglob("*"):
+        if path.is_file():
+            import os
+            os.utime(path, (1234, 1234))
+    (root / "python/.DS_Store").write_bytes(b"irrelevant metadata")
+    assert packager.package_runtime(root, helper, code_host, "linux-arm64", second) == checksum
+    relocated = installer.extract_package(first.read_bytes(), checksum, tmp_path / "elsewhere", "linux-arm64")
+    assert (relocated / "python/bin/python3").read_bytes() == b"python"
+    assert not (relocated / "python/bin/python3").is_symlink()
+    assert str(tmp_path) not in (relocated / "manifest.json").read_text()
+
+
+def test_package_rejects_external_links_wrong_target_and_private_files(layout, tmp_path):
+    root, helper, code_host = layout
+    output = tmp_path / "package.tar.gz"
+    with pytest.raises(ValueError, match="target"):
+        packager.package_runtime(root, helper, code_host, "linux-x86_64", output)
+    secret = root / "runtime-secrets.json"
+    secret.write_text('{}')
+    with pytest.raises(ValueError, match="Unexpected file"):
+        packager.package_runtime(root, helper, code_host, "linux-arm64", output)
+    secret.unlink()
+    (root / "source/escape").symlink_to(helper)
+    with pytest.raises(ValueError, match="inside"):
+        packager.package_runtime(root, helper, code_host, "linux-arm64", output)
+    assert not output.exists()
+
+
+def test_reused_package_cannot_rewrite_its_own_trust_manifest(layout, tmp_path):
+    output = tmp_path / "package.tar.gz"
+    checksum = packager.package_runtime(*layout, "linux-arm64", output)
+    installed = installer.extract_package(output.read_bytes(), checksum, tmp_path / "install", "linux-arm64")
+    path = installed / "manifest.json"
+    manifest = json.loads(path.read_text())
+    (installed / "codex-app-server").write_bytes(b"changed helper")
+    manifest["files"]["codex-app-server"] = packager.digest(installed / "codex-app-server")
+    path.write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="integrity"):
+        installer.extract_package(output.read_bytes(), checksum, tmp_path / "install", "linux-arm64")
+
+
+@pytest.mark.parametrize("name,link", [("../escape", None), ("/absolute", None), ("inside/link", "../../escape"), ("inside/link", "/absolute")])
+def test_build_inputs_cannot_escape_extraction(tmp_path, name, link):
+    archive = tmp_path / "input.tar.gz"
+    with tarfile.open(archive, "w:gz") as stream:
+        member = tarfile.TarInfo(name)
+        if link is not None:
+            member.type, member.linkname = tarfile.SYMTYPE, link
+            stream.addfile(member)
+        else:
+            member.size = 1
+            stream.addfile(member, io.BytesIO(b"x"))
+    with pytest.raises(ValueError):
+        builder.extract(archive, tmp_path / "staging")
+    assert not (tmp_path / "escape").exists()
+
+
+def test_pins_cover_every_supported_target_without_floating_versions():
+    pins = json.loads(builder.PINS.read_text())
+    assert set(pins["targets"]) == set(packager.TARGETS)
+    assert pins["codex_version"] == packager.CODEX_VERSION
+    for target in pins["targets"].values():
+        for name, component in target.items():
+            assert len(component["sha256"]) == 64
+            assert component["url"].startswith("https://github.com/")
+            assert "/latest/" not in component["url"]
+            assert (pins["python_release"] if name == "python" else "rust-v" + pins["codex_version"]) in component["url"]
+
+
+def test_download_does_not_trust_a_corrupted_cache(tmp_path, monkeypatch):
+    good = b"reviewed release"
+    checksum = hashlib.sha256(good).hexdigest()
+    cached = tmp_path / (checksum + ".tar.gz")
+    cached.write_bytes(b"changed cache")
+    component = {"sha256": checksum, "url": "https://github.com/example/releases/download/v1/asset.tar.gz"}
+    response = io.BytesIO(b"changed remote release")
+    response.geturl = lambda: "https://github.com/example/releases/download/v1/asset.tar.gz"
+    monkeypatch.setattr(builder.urllib.request, "urlopen", lambda *_args, **_kwargs: response)
+    with pytest.raises(ValueError, match="integrity"):
+        builder.download(component, tmp_path)
+    assert cached.read_bytes() == b"changed cache"
+    assert not list(tmp_path.glob(".download-*"))
+    cached.write_bytes(good)
+    assert builder.download(component, tmp_path) == cached
+
+
+@pytest.mark.parametrize("libc,version", [("glibc", "2.17"), ("musl", "1.2")])
+def test_linux_setup_rejects_incompatible_c_libraries(monkeypatch, libc, version):
+    monkeypatch.setattr(installer.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(installer.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(installer.platform, "libc_ver", lambda: (libc, version))
+    with pytest.raises(ValueError, match="glibc 2.28"):
+        installer.host_info()
+
+
+def test_remote_cli_helper_uses_its_declared_entry_point(monkeypatch):
+    from ollama_code.codex_app_server import CodexAppServerManager
+    manager = CodexAppServerManager(helper_path="/fixture/codex-app-server")
+    monkeypatch.setenv("LOCUS_CODEX_HELPER_KIND", "cli")
+    assert manager._command() == ["/fixture/codex-app-server", "app-server", "--listen", "stdio://"]
+    monkeypatch.setenv("LOCUS_CODEX_HELPER_KIND", "app-server")
+    assert manager._command() == ["/fixture/codex-app-server", "--listen", "stdio://"]
+
+
+def test_maintenance_rejects_commands_and_http_mutations(tmp_path):
+    app = server.create_app(auth_token="fixture-token")
+    app.state.service = SimpleNamespace(run_store=RunStore(tmp_path / "runs.sqlite3"))
+    root = tmp_path / "runtime"
+    root.mkdir()
+    (root / "installation.json").write_text('{}')
+    runtime = app.state.runtime = RuntimeSupervisor(app, root, port=1)
+    assert runtime.paused and runtime.status()["maintenance"]
+    with pytest.raises(RuntimeError, match="installation"):
+        asyncio.run(runtime.command("session", {"type": "user_message", "text": "do work"}))
+    with pytest.raises(RuntimeError, match="installation"):
+        asyncio.run(runtime.ensure_worker("session", str(tmp_path)))
+    with pytest.raises(HTTPException) as error:
+        resume_runtime(SimpleNamespace(app=app))
+    assert error.value.status_code == 409
+    client = TestClient(app)
+    try:
+        assert client.post("/api/config", json={}).status_code in {401, 403}
+        response = client.post("/api/config", json={}, headers={"X-Locus-Token": "fixture-token"})
+        assert response.status_code == 409
+    finally:
+        client.close()
+    (root / "installation.json").unlink()
+    resume_runtime(SimpleNamespace(app=app))
+    assert not runtime.paused and not runtime.maintenance
+
+
+@pytest.fixture
+def installation(tmp_path, monkeypatch):
+    info = {"system": "Linux", "target": "linux-arm64", "protocol_version": 1}
+    monkeypatch.setattr(installer, "host_info", lambda: info)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root, unit, label = installer.deployment_paths(info)
+    root.mkdir(parents=True)
+    previous = root / "versions" / ("a" * 64)
+    candidate = root / "versions" / ("b" * 64)
+    previous.mkdir(parents=True)
+    candidate.mkdir()
+    (root / "current").symlink_to(previous)
+    installer.atomic_write(unit, b"old-unit")
+    installer.atomic_write(root / "runtime-secrets.json", b'{"controller_token":"fixture-token","paused":true}')
+    installer.atomic_write(root / "endpoint.json", b'{"url":"http://127.0.0.1:8793"}')
+    profile = root / "profile"
+    profile.mkdir()
+    database = profile / "agent-runs.sqlite3"
+    with sqlite3.connect(database) as db:
+        db.execute("CREATE TABLE evidence(value TEXT)")
+        db.execute("INSERT INTO evidence VALUES('consumed allowance')")
+    state = {"running": True, "package_id": previous.name, "starts": [], "fail": True}
+    monkeypatch.setattr(installer, "extract_package", lambda *_: candidate)
+    monkeypatch.setattr(installer.subprocess, "run", lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout="codex-cli 0.147.0\n"))
+    monkeypatch.setattr(installer, "service_running", lambda *_: state["running"])
+
+    def status(*_args, **_kwargs):
+        return {"package_id": state["package_id"], "paused": True, "workers": [], "active_work": 0} if state["running"] else None
+
+    def service(_info, _unit, _label, action):
+        state["running"] = action == "start"
+        if action == "start":
+            state["package_id"] = previous.name if unit.read_bytes() == b"old-unit" else candidate.name
+            state["starts"].append(state["package_id"])
+            if state["package_id"] == candidate.name:
+                with sqlite3.connect(database) as db:
+                    db.execute("UPDATE evidence SET value='startup migration'")
+                with sqlite3.connect(profile / "new-feature.sqlite3") as db:
+                    db.execute("CREATE TABLE IF NOT EXISTS newer_schema(value TEXT)")
+
+    def ready(_root, _port, expected):
+        if expected == candidate.name and state["fail"]:
+            raise ValueError("Fixture startup failure")
+        assert state["running"] and state["package_id"] == expected
+        return status()
+
+    monkeypatch.setattr(installer, "api_request", status)
+    monkeypatch.setattr(installer, "service_control", service)
+    monkeypatch.setattr(installer, "wait_ready", ready)
+    return SimpleNamespace(root=root, unit=unit, label=label, info=info, previous=previous, candidate=candidate,
+                           database=database, state=state, header={"sha256": candidate.name, "port": 8793})
+
+
+def test_failed_update_restores_unit_package_and_consumed_allowances(installation):
+    value = installation
+    with pytest.raises(ValueError, match="were restored"):
+        installer.install(value.header, b"fixture")
+    assert value.unit.read_bytes() == b"old-unit"
+    assert (value.root / "current").resolve() == value.previous
+    assert value.state["starts"] == [value.candidate.name, value.previous.name]
+    assert not (value.root / "installation.json").exists()
+    with sqlite3.connect(value.database) as db:
+        assert db.execute("SELECT value FROM evidence").fetchone()[0] == "consumed allowance"
+    assert list((value.root / "install-backups").rglob("*.sqlite3"))
+    assert not (value.database.parent / "new-feature.sqlite3").exists()
+
+
+def test_failed_recovery_retains_journal_and_blocks_service_start(installation, monkeypatch):
+    def fail(*_args):
+        raise ValueError("Fixture readiness failure")
+    monkeypatch.setattr(installer, "wait_ready", fail)
+    value = installation
+    with pytest.raises(ValueError, match="recovery needs attention"):
+        installer.install(value.header, b"fixture")
+    assert (value.root / "installation.json").exists()
+    assert list((value.root / "install-backups").rglob("*.sqlite3"))
+    with pytest.raises(ValueError, match="interrupted installation"):
+        installer.control({"control": "start"})
+
+
+def test_install_and_control_share_an_exclusive_lock(installation):
+    import fcntl
+    with (installation.root / ".install.lock").open("a") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with pytest.raises(ValueError, match="in progress"):
+            installer.install(installation.header, b"fixture")
+        with pytest.raises(ValueError, match="in progress"):
+            installer.control({"control": "stop"})
+
+
+def test_successful_update_retains_previous_package_and_stays_paused(installation):
+    value = installation
+    value.state["fail"] = False
+    result = installer.install(value.header, b"fixture")
+    assert result["package"] == value.candidate.name
+    assert (value.root / "current").resolve() == value.candidate
+    assert (value.root / "previous").resolve() == value.previous
+    assert installer.private_read(value.root)["paused"]
+    assert not (value.root / "installation.json").exists()
+
+
+def test_interrupted_install_is_recovered_before_retry(installation):
+    value = installation
+    journal = {"id": "c" * 32, "port": 8793, "previous_port": 8793, "previous_package": str(value.previous),
+               "unit": base64.b64encode(b"old-unit").decode(), "was_running": True, "was_paused": True}
+    installer.backup_databases(value.root, journal)
+    value.unit.write_bytes(b"partially-installed-unit")
+    value.state.update(package_id=value.candidate.name, running=False, fail=False)
+    result = installer.install(value.header, b"fixture")
+    assert value.state["starts"] == [value.previous.name, value.candidate.name]
+    assert result["package"] == value.candidate.name
+
+
+def test_validation_cleanup_cannot_target_production_or_escape_home():
+    info = {"system": "Linux"}
+    for value in ("", "../production", "g" * 32, "a" * 31, "/tmp/host"):
+        with pytest.raises(ValueError):
+            installer.deployment_paths(info, value)
+    root, unit, label = installer.deployment_paths(info, "a" * 32)
+    assert "locus-runtime-validation" in str(root)
+    assert label.startswith("locus-runtime-validation-") and unit.name == label + ".service"


### PR DESCRIPTION
Remote runtime preparation previously depended on a hand-built layout, and a failed service update could leave the new package selected without a working service. This adds a pinned portable builder for Linux x86-64/ARM64 and macOS ARM64, verifies the packaged helper and imports, and makes installation a journaled transaction with paused admission, database backups and rollback to the previous service.

Actual packaged-service validation also found two execution bugs: the full Codex CLI was launched without its app-server subcommand, and run-history connections exhausted macOS background-service file handles. Both are fixed, with explicit helper selection and prompt transaction cleanup.

Validation includes archive/provenance boundaries, constrained file-handle execution, maintenance/authentication, update recovery, and a packaged schedule → verified result → approved reusable check scenario. The new CI matrix exercises real systemd user services and launch agents on all three targets, including service restart and deliberately failed-update recovery. Local validation passed: 2,368 backend tests; Ruff; protocol manifest; branch-history secret scan; and the actual macOS packaged launch-agent scenario including restart, failed-update recovery, and cleanup. The constrained-connection and package/installer tests also pass independently. Linux ARM64 and x86-64 package builds and real systemd service validation passed in CI. The final clean macOS package from commit 21161330 passed the launch-agent scenario locally with 3 completed runs, 84 fixture tokens, preserved results after restart/rollback, and successful cleanup. Hosted macOS 14 package validation and the broader native CI suite remain queued for runners.

The new package workflow produces candidate artifacts, not production releases. Signed SMAppService registration, real SSH hosts, reboot/login, connectors and live provider/account authentication remain release gates; this PR uses deterministic provider fixtures and signed-out helper initialization. The original checkout and its uncommitted transport work are untouched.

Build and service evidence: [Runtime package candidates](https://github.com/nahid-sparktales/locus/actions/runs/34708861752). General checks: [CI](https://github.com/nahid-sparktales/locus/actions/runs/34708861739).
