### PR TITLE
Add Claude plan accounts and managed subscription support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ WalletSignerCore/target/
 # Bundled agent runtime cache (downloaded standalone Python + deps)
 .agent-runtime/
 .codex-app-server/
+.claude-runtime/
 
 # Python (agent/)
 agent/.venv/

--- a/Config/ClaudeRuntime.json
+++ b/Config/ClaudeRuntime.json
@@ -1,0 +1,31 @@
+{
+  "sdk_version": "0.2.152",
+  "wheels": [
+    {
+      "filename": "claude_agent_sdk-0.2.152-py3-none-macosx_11_0_arm64.whl",
+      "url": "https://files.pythonhosted.org/packages/a0/d3/ee2b674958e105cf26a2eb4d512c46b02fcfdc8fadbb14dde750bbfaf9b1/claude_agent_sdk-0.2.152-py3-none-macosx_11_0_arm64.whl",
+      "sha256": "6cc1e949743c7634274ae526bfd1c0a216ff9d71c6b36d94cab80f32b0d32b4c"
+    },
+    {
+      "filename": "claude_agent_sdk-0.2.152-py3-none-macosx_11_0_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/92/c4/6564671e6d303012b5c0bd6650b9977317c3b5c83914cf5ac62068fa85e6/claude_agent_sdk-0.2.152-py3-none-macosx_11_0_x86_64.whl",
+      "sha256": "9c79c4ef91b15e5fae6aba62a82afb983dc360bc159902c541046227e2852c86"
+    },
+    {
+      "filename": "claude_agent_sdk-0.2.152-py3-none-manylinux_2_17_aarch64.whl",
+      "url": "https://files.pythonhosted.org/packages/13/5d/1efd9e3332d2909e015c6571a4b5ed937e9126b9c702217813247c1c8052/claude_agent_sdk-0.2.152-py3-none-manylinux_2_17_aarch64.whl",
+      "sha256": "1e5b619e6fa3c98f06ddc107652f7820c4573fb73a9a24263568d9974078bbc2"
+    },
+    {
+      "filename": "claude_agent_sdk-0.2.152-py3-none-manylinux_2_17_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/95/a0/f921e52fdbfd400e46fbc1e707e6004a3ef99ace6cb4555429a3a8d3f371/claude_agent_sdk-0.2.152-py3-none-manylinux_2_17_x86_64.whl",
+      "sha256": "f885bd935054082a599dcf92bbdaf3c0b853117a79375cb3aae74674a8124326"
+    },
+    {
+      "filename": "claude_agent_sdk-0.2.152-py3-none-win_amd64.whl",
+      "url": "https://files.pythonhosted.org/packages/e6/be/dd113754761c6eef6eec1f2b148c825f925d4bfaa3f946656925239c54f9/claude_agent_sdk-0.2.152-py3-none-win_amd64.whl",
+      "sha256": "f422c256358997ffa3a740f9fdc8127aa8404a9d57493502dc7d2ac05ecb5486"
+    }
+  ],
+  "runtime_version": "2.1.259"
+}

--- a/Docs/ClaudePlan.md
+++ b/Docs/ClaudePlan.md
@@ -1,0 +1,84 @@
+# Claude plan accounts
+
+Claude plan is a separate provider (`claude_plan`) from Claude API (`claude`).
+Existing API keys and ChatGPT accounts keep their identifiers and settings.
+
+## Enablement and distribution
+
+Claude plan is enabled by default. Set `LOCUS_CAPABILITY_CLAUDE_PLAN_V1=0` in the
+app/backend launch environment to disable its account picker and backend routes.
+The backend advertises `claude_plan_v1`; older hosts cannot accept Claude routes.
+Anthropic's approval for distributed subscription login has not been confirmed.
+The [June 15 support update](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+describes subscription use by third-party SDK applications, while the
+[SDK overview](https://code.claude.com/docs/en/agent-sdk/overview) still requires
+prior approval.
+
+The Python SDK is pinned to **0.2.152** and its Claude runtime to **2.1.259**.
+`Config/ClaudeRuntime.json` records official wheel URLs and SHA-256 checksums.
+`Tools/PrepareClaudeRuntime.py` verifies and extracts the binary, SDK license, and
+provenance. It was exercised on macOS arm64 without a signed-in account.
+
+- Direct-download Release builds default to `LOCUS_BUNDLE_CLAUDE=component`.
+  Run `Tools/PackageComponents.sh <release-directory>` to package both providers
+  and include their entries in `components.json`.
+  Set `LOCUS_SIGN_IDENTITY` to the distribution signing identity.
+- App Store and development builds default to `LOCUS_BUNDLE_CLAUDE=build`.
+  App Store builds must bundle their runtime; they cannot download it later.
+- Set `LOCUS_BUNDLE_CLAUDE=skip` explicitly to omit Claude from a local build.
+- For a standalone backend, point `LOCUS_CLAUDE_RUNTIME_PATH` at the verified
+  runtime. Installing the SDK alone does not provide Locus's managed runtime path.
+- Remote packages accept `--claude-helper` in `Tools/PackageRemoteRuntime.py`.
+  Including that optional, version-checked binary explicitly enables Claude on
+  the destination. Remote login uses the destination's own account directory;
+  its browser callback is forwarded through the existing SSH connection.
+
+The downloadable runtime uses the existing HTTPS, checksum, signing-identity,
+archive-validation, and atomic activation checks. The SDK's bundled binary is
+removed from the base Python payload so the direct-download app does not carry
+an unused copy.
+
+## Authentication and execution
+
+Each account uses its UUID beneath the profile's `claude-accounts` directory.
+The official runtime handles `auth login`, `auth status`, `auth logout`, and token
+refresh. Locus does not import a user's existing Claude installation credentials
+or read OAuth token files. Inherited API keys, custom endpoint settings, cloud
+billing selectors, and broker secrets are explicitly overridden before launching
+the SDK, whose environment merges with its parent.
+
+The adapter uses persistent SDK session IDs and resumes them between turns.
+Locus exposes its active tool registry through an in-process SDK MCP server;
+Claude built-in execution tools and implicit settings sources are disabled.
+Every action returns to the existing Locus tool/permission boundary. Chat has no
+tools. Plan, Work, team, swarm, and helper restrictions remain enforced there.
+Follow-up guidance is queued through the durable outbox for the next turn boundary.
+
+Account, workspace, model, instructions, tool schema, and Locus session identity
+protect session reuse. Forks rebuild from their copied Locus transcript rather
+than sharing a live SDK session. An incomplete SDK result leaves an uncertainty
+marker; a retry cannot silently replay it. Review resulting files/actions before
+continuing in a new or forked task. SDK interrupts with a terminal result retain
+resumable context.
+
+Claude events are normalized to the existing managed-turn event envelope, shared
+with Codex. Some internal `codex`/`chatgpt_thread` names remain for compatibility;
+provider routes, credential directories, runtime versions, and session
+fingerprints distinguish their owners. Child workers use the authenticated
+broker and do not own credentials.
+
+Model aliases and reasoning capabilities come from runtime initialization.
+Runtime descriptions omit API-equivalent price suffixes. Usage windows are
+optional and timestamped; absent utilization is unknown, not zero. Subscription
+tokens are recorded without treating SDK API-equivalent costs as actual charges.
+Claude plan is not an image-generation provider; separately configured image
+providers remain available through Locus tools.
+
+## Release verification still requiring a test account
+
+Before release, exercise browser login/cancel/logout, token expiry,
+two simultaneous subscription accounts (including macOS Keychain isolation),
+real attachments and tools, interruption/resume, team/swarm execution, scheduled
+execution, and SSH login on a second host. Verify the signed/notarized component
+and an enabled App Store bundle on clean machines. Unit tests and unsigned
+metadata discovery do not establish these authenticated behaviors.

--- a/Locus.xcodeproj/project.pbxproj
+++ b/Locus.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 		646013AB15E7DD4264876516 /* WalletSignerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530DCDEFEDCBE87B25169CB8 /* WalletSignerProtocol.swift */; };
 		646676617FD3ACF8AE67BE80 /* ComputerControlService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731F4ECD2268E698A675A53D /* ComputerControlService.swift */; };
 		647CCF1ABDC75CDB8654F08D /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E25B0D308D2D499E48D903 /* MarkdownRenderer.swift */; };
+		649F42C3A5847A8CC37D99A8 /* ClaudeComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09E3AE782CFF94B92C10492 /* ClaudeComponent.swift */; };
 		65A21C675D227DCACC7EF276 /* WalletUniswapQuoteProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FDE02F2575E8D2A5670594 /* WalletUniswapQuoteProvider.swift */; };
 		65CD7FEF67F63779B1FCA0B8 /* CompanionSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = E940CB9835CFDD6B6864DD28 /* CompanionSecurity.swift */; };
 		65D026E9D53A83820582C55E /* ResponseOutputUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA805481CE7B40D4AD652B4 /* ResponseOutputUITests.swift */; };
@@ -584,6 +585,7 @@
 		7432692999A8039E364E8475 /* TranscriptPresentationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0E76969AEB69AC1D510292 /* TranscriptPresentationModel.swift */; };
 		74582ED4C110C64A06281F61 /* SoloCollaborationModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F816B97F26DAEED686C5B701 /* SoloCollaborationModelTests.swift */; };
 		746E5E2920FB4AF9BBECA561 /* WalletEVMReceiptReconciliationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1406DC05BAA4C8D1B1A4D7 /* WalletEVMReceiptReconciliationTests.swift */; };
+		7487B9924206B0237545D245 /* ClaudeComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09E3AE782CFF94B92C10492 /* ClaudeComponent.swift */; };
 		74972C7F7BD5133E996B2BEA /* AgentTeamsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246491EFA199B2B975050307 /* AgentTeamsModelTests.swift */; };
 		74A5BCF6953128864737A070 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D4CA41C622A34E45EF21F54 /* Assets.xcassets */; };
 		74B231AD518C57E7E352BF79 /* AppFeatureEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A14E63C34A77899861E73ED /* AppFeatureEnvironment.swift */; };
@@ -1111,6 +1113,7 @@
 		DEE086E72E88A3A7C12DCE35 /* CredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D427058C21A8F1993C532E8 /* CredentialStore.swift */; };
 		DF4EED0CBE018E930BAB2E88 /* OptionalQuestionPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273C7C6585F49C796917D50B /* OptionalQuestionPanel.swift */; };
 		DFAC8FDDD0DF98523ACD7947 /* OutputsLibraryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8744B144B8FFDE5CAF58BF58 /* OutputsLibraryStore.swift */; };
+		E020DAE3F1488137787AF6CE /* ClaudeComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09E3AE782CFF94B92C10492 /* ClaudeComponent.swift */; };
 		E03543D17D87ECC965E105DE /* AppModel+Workspaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA1C6E1EB6781CFC36FD21F /* AppModel+Workspaces.swift */; };
 		E039954C2DC920F44707447F /* ActivityCenterModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A6B77A929CA91E6E421529 /* ActivityCenterModelTests.swift */; };
 		E04ACEAAC03B3C0B240E94D4 /* WalletConnectionsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC23CF37CC5F34F35DB69529 /* WalletConnectionsClient.swift */; };
@@ -1193,6 +1196,7 @@
 		EEE17F6B244C086F9BA3BB32 /* DiffHunks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE116E00D831A9EE4433A893 /* DiffHunks.swift */; };
 		EF472274DEBBB5140487ABA3 /* ReusableChecksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309B133C05176D82F1560EE8 /* ReusableChecksView.swift */; };
 		EF68A885B0E376D82798E702 /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5118157AFFA0FF82EDCA5BED /* AppModel.swift */; };
+		EF80E3A90E3DEEE42FEBCEEE /* ClaudeComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09E3AE782CFF94B92C10492 /* ClaudeComponent.swift */; };
 		EFBB3E9696BE5AE00766ADD0 /* NotebookModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7233FFED68A0709BF2F83B9A /* NotebookModel.swift */; };
 		EFD1168F955FCA878E3A30E3 /* BackendStubSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBABE255234EFEAAAE40D72 /* BackendStubSupport.swift */; };
 		F013DC1250C99CFB6D6BA3A3 /* VoiceComposerControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF0FF1E4DCB449530C8ACC2 /* VoiceComposerControls.swift */; };
@@ -1668,6 +1672,7 @@
 		AEFB9A10F8784355D5344D95 /* Locus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Locus.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B082AFE6729F96D2D8606AC9 /* WorkspaceIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceIndex.swift; sourceTree = "<group>"; };
 		B0913B533492F79EF861D382 /* IdentityVaultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityVaultView.swift; sourceTree = "<group>"; };
+		B09E3AE782CFF94B92C10492 /* ClaudeComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeComponent.swift; sourceTree = "<group>"; };
 		B0E25B0D308D2D499E48D903 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		B1189B5E3EF964EF442DEE6C /* OptionalQuestionModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalQuestionModelTests.swift; sourceTree = "<group>"; };
 		B22E256CDFD049DF0A9986A2 /* AppModel+WorkspaceBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+WorkspaceBrowser.swift"; sourceTree = "<group>"; };
@@ -2150,6 +2155,7 @@
 				AB6C801D489BBF80BE16EBD6 /* ChatAttachmentLoader.swift */,
 				C52BF62D925A367764AAAEE9 /* ChatExportRenderer.swift */,
 				863D25BB6163522EFF5A58B4 /* ChatTranscriptBuilder.swift */,
+				B09E3AE782CFF94B92C10492 /* ClaudeComponent.swift */,
 				12CD78F68FC2B3B1CBAFD1AD /* CodexComponent.swift */,
 				07B62C798D0E60793ED30FF0 /* CodexComponentInstaller.swift */,
 				ADFF6B3CE2F946B371F8A9EA /* CommandAction.swift */,
@@ -3204,6 +3210,7 @@
 				86185D36B619CE053008FCA2 /* ChatAttachmentLoader.swift in Sources */,
 				C4135EC752C1A960DAB678E2 /* ChatExportRenderer.swift in Sources */,
 				43F24DA32CE5546306517014 /* ChatTranscriptBuilder.swift in Sources */,
+				649F42C3A5847A8CC37D99A8 /* ClaudeComponent.swift in Sources */,
 				82C4C1954ED61F7FB19DFF7E /* CodexComponent.swift in Sources */,
 				D8F0A3DBE019F9F74B6B8EEF /* CodexComponentInstaller.swift in Sources */,
 				10064D1B949A901C5A6A431A /* CommandAction.swift in Sources */,
@@ -3583,6 +3590,7 @@
 				FB861DE1EB0815DC7FF9BF53 /* ChatAttachmentLoader.swift in Sources */,
 				22661FD9BEDF20356C62C180 /* ChatExportRenderer.swift in Sources */,
 				E8DC03D0AF0457F76ADD775A /* ChatTranscriptBuilder.swift in Sources */,
+				E020DAE3F1488137787AF6CE /* ClaudeComponent.swift in Sources */,
 				9D28E8C16F052407AB02A468 /* CodexComponent.swift in Sources */,
 				B1CE4F1F020F1C9A6504EDFC /* CodexComponentInstaller.swift in Sources */,
 				9BA74BC9037E134CFD57420B /* CommandAction.swift in Sources */,
@@ -3829,6 +3837,7 @@
 				F4310898A6BA981AF86E4CBA /* ChatAttachmentLoader.swift in Sources */,
 				5DDBF7DEEC0F9223CE9FEFD8 /* ChatExportRenderer.swift in Sources */,
 				E4930B28156D2C4C857845EB /* ChatTranscriptBuilder.swift in Sources */,
+				7487B9924206B0237545D245 /* ClaudeComponent.swift in Sources */,
 				BB2C80B74A981FA65EB2C6BB /* CodexComponent.swift in Sources */,
 				E55FCA315272FBDF464F81FE /* CodexComponentInstaller.swift in Sources */,
 				ED01D2FB6F84F4B82660CD05 /* CommandAction.swift in Sources */,
@@ -4213,6 +4222,7 @@
 				78906BCDDF9828D92CB98657 /* ChatAttachmentLoader.swift in Sources */,
 				B18287A7CD575B76EAF2868C /* ChatExportRenderer.swift in Sources */,
 				3BF76BE8EBB84134EC8F01E5 /* ChatTranscriptBuilder.swift in Sources */,
+				EF80E3A90E3DEEE42FEBCEEE /* ClaudeComponent.swift in Sources */,
 				1D25B484AB9C03ED45546A6C /* CodexComponent.swift in Sources */,
 				FFE9529F4CEFED40FC82788E /* CodexComponentInstaller.swift in Sources */,
 				13E80FD09E216DD3DC917149 /* CommandAction.swift in Sources */,

--- a/Locus/AccountEditorView.swift
+++ b/Locus/AccountEditorView.swift
@@ -62,7 +62,7 @@ struct AccountEditorView: View {
         keyStored: Bool,
         typedKey: String
     ) -> String? {
-        if kind == .chatGPT { return nil }
+        if kind.isManagedPlan { return nil }
         if resolvedBaseURL.isEmpty { return "Enter the endpoint URL." }
         // A key is required to reach a hosted provider — an endpoint that has
         // one saved already does not need it typed again — but a custom
@@ -131,8 +131,8 @@ struct AccountEditorView: View {
                     Text(isNew ? "Add \(kind.marketingName) Account" : "Edit \(account.displayName)")
                         .font(.locus(size: 16, weight: .bold))
                     Text(
-                        kind == .chatGPT
-                            ? "Use included usage from your ChatGPT plan"
+                        kind.isManagedPlan
+                            ? "Use your subscription through its managed runtime"
                             : kind.vendorName.isEmpty
                             ? "An OpenAI-compatible endpoint"
                             : "Models served by \(kind.vendorName)"
@@ -168,7 +168,7 @@ struct AccountEditorView: View {
                         .font(.locus(size: 9))
                         .foregroundStyle(LocusTheme.muted)
 
-                    if kind == .chatGPT {
+                    if kind.isManagedPlan {
                         chatGPTControls
                     } else {
                         if kind.allowsBaseURLOverride {
@@ -286,7 +286,7 @@ struct AccountEditorView: View {
             baseURL = account.baseURLOverride ?? ""
             keyStored = account.hasKey(in: model.credentialStore)
             contextWindow = account.contextWindow.map(String.init) ?? ""
-            if kind == .chatGPT {
+            if kind.isManagedPlan {
                 nativeMode = account.codexNativeModeEnabled
                 webSearch = account.codexWebSearchEnabled
                 reasoningEffort = account.codexReasoningEffortValue
@@ -334,7 +334,9 @@ struct AccountEditorView: View {
                         Task { await providerAccounts.cancelChatGPTLogin(for: account) }
                     }
                 }
-            } else if model.chatGPTComponentMissing {
+            } else if kind == .claudePlan && model.claudeComponentMissing {
+                claudeComponentDownload
+            } else if kind == .chatGPT && model.chatGPTComponentMissing {
                 componentDownload
             } else {
                 if let message = status?.message, !message.isEmpty {
@@ -343,13 +345,14 @@ struct AccountEditorView: View {
                         .foregroundStyle(LocusTheme.muted)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                Button("Sign in with ChatGPT") {
+                Button(kind == .claudePlan ? "Sign in with Claude" : "Sign in with ChatGPT") {
                     Task { await providerAccounts.startChatGPTLogin(for: account) }
                 }
                 .disabled(status?.runtimeAvailable == false)
                 .accessibilityIdentifier("accountEditor.chatGPT.signIn")
             }
 
+            if kind == .chatGPT {
             Toggle("Codex-native mode", isOn: $nativeMode)
                 .accessibilityIdentifier("accountEditor.chatGPT.nativeMode")
             Text("Off by default: this account's chats use Locus's prompt, tools, memory, and skills. Turn it on to match OpenAI's Codex instead — native prompt and tools, and no Locus memory or skills here. Changing this restarts conversation context.")
@@ -364,6 +367,7 @@ struct AccountEditorView: View {
                 .foregroundStyle(LocusTheme.muted)
                 .fixedSize(horizontal: false, vertical: true)
 
+            }
             Picker("Reasoning effort", selection: $reasoningEffort) {
                 Text("Default").tag("")
                 ForEach(reasoningEffortOptions, id: \.self) { effort in
@@ -373,14 +377,21 @@ struct AccountEditorView: View {
             .accessibilityIdentifier("accountEditor.chatGPT.reasoningEffort")
 
             Text(
-                "Authentication is managed by OpenAI's bundled agent runtime. "
-                + "Locus never reads or stores its OAuth tokens, and this route never falls back to paid API usage."
+                "Authentication is managed by the provider's agent runtime. "
+                + "Locus never reads or stores its OAuth tokens and does not switch this account to API-key billing."
             )
             .font(.locus(size: 9))
             .foregroundStyle(LocusTheme.muted)
             .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var claudeComponentDownload: some View {
+#if !LOCUS_APP_STORE
+        ClaudeComponentDownloadView(account: account)
+#endif
     }
 
     /// The efforts the account's preferred model supports, from the fetched
@@ -391,7 +402,7 @@ struct AccountEditorView: View {
             .first(where: { $0.id == account.preferredModel })?
             .supportedReasoningEfforts?
             .map(\.effort) ?? []
-        if efforts.isEmpty {
+        if efforts.isEmpty && kind == .chatGPT {
             efforts = ["minimal", "low", "medium", "high", "xhigh"]
         }
         if !reasoningEffort.isEmpty, !efforts.contains(reasoningEffort) {
@@ -534,7 +545,7 @@ struct AccountEditorView: View {
     }
 
     private func save() {
-        if kind == .chatGPT {
+        if kind.isManagedPlan {
             var updated = account
             updated.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
             if updated.preferredModel.isEmpty {

--- a/Locus/AgentTeamsSettingsView.swift
+++ b/Locus/AgentTeamsSettingsView.swift
@@ -1581,7 +1581,7 @@ private struct AgentBehaviorEditor: View {
                         throw NSError(domain: "LocusPromptPreview", code: 2,
                             userInfo: [NSLocalizedDescriptionKey: "This agent's provider account is unavailable. Choose an available account first."])
                     }
-                    body["provider"] = account.kind == .chatGPT ? "chatgpt" : "remote"
+                    body["provider"] = account.kind.backendProvider
                     if account.kind == .chatGPT { body["native_mode"] = account.codexNativeModeEnabled }
                 }
             }

--- a/Locus/AppModel+BackendEvents.swift
+++ b/Locus/AppModel+BackendEvents.swift
@@ -43,13 +43,13 @@ extension AppModel {
             orchestrationEvents.sort { $0.sequence < $1.sequence }
         }
         switch type {
-        case "chatgpt_account_updated":
+        case "chatgpt_account_updated", "claude_account_updated":
             Task {
                 await providerAccountsModel.refreshChatGPTAccounts()
                 await providerAccountsModel.refreshAccountCatalogs(force: true)
             }
 
-        case "chatgpt_usage_updated":
+        case "chatgpt_usage_updated", "claude_usage_updated":
             Task { await providerAccountsModel.refreshActiveChatGPTUsage() }
 
         case "worker_identity":

--- a/Locus/AppModel+ChatWorkers.swift
+++ b/Locus/AppModel+ChatWorkers.swift
@@ -424,9 +424,9 @@ extension AppModel {
             accounts: providerAccounts
         )
         guard let account else { return nil }
-        if provider == "chatgpt", account.kind == .chatGPT {
+        if provider == account.kind.backendProvider, account.kind.isManagedPlan {
             return [
-                "provider": "chatgpt",
+                "provider": account.kind.backendProvider,
                 "account_id": account.id.uuidString,
                 "codex_home_id": account.codexHomeIdentifier,
                 "account_label": account.displayName,
@@ -438,7 +438,7 @@ extension AppModel {
                 "reasoning_effort": account.codexReasoningEffortValue,
             ]
         }
-        guard provider == "remote", account.kind != .chatGPT else { return nil }
+        guard provider == "remote", !account.kind.isManagedPlan else { return nil }
         return [
             "provider": "remote",
             "account_id": account.id.uuidString,
@@ -464,7 +464,7 @@ extension AppModel {
         accounts: [ProviderAccount]
     ) -> ProviderAccount? {
         let compatible = accounts.filter {
-            provider == "chatgpt" ? $0.kind == .chatGPT : $0.kind != .chatGPT
+            $0.kind.backendProvider == provider
         }
         if let exact = reference.flatMap({ value in
             if let id = UUID(uuidString: value),

--- a/Locus/AppModel+Goals.swift
+++ b/Locus/AppModel+Goals.swift
@@ -47,7 +47,7 @@ extension AppModel {
             "workspace_root": sessionInfo?.workspaceRoot ?? workspacePath,
             "execution_path": activeTaskRecord?.executionPath ?? workspacePath,
             "execution_environment": currentExecutionEnvironment.rawValue,
-            "provider": activeAccount.map { $0.kind == .chatGPT ? "chatgpt" : "remote" } ?? "ollama",
+            "provider": activeAccount.map { $0.kind.backendProvider } ?? "ollama",
             "model": activeAccount.map { routedModel(for: $0) } ?? selectedModel,
             "runner": selectedAgentTeam == nil ? "solo" : "team",
             "solo_swarm": true,
@@ -194,7 +194,7 @@ extension AppModel {
                   let id = UUID(uuidString: rawID),
                   let account = providerAccounts.first(where: { $0.id == id }),
                   account.isCredentialReady(in: credentialStore) else { return "The goal's model account is unavailable." }
-            let kind = account.kind == .chatGPT ? "chatgpt" : "remote"
+            let kind = account.kind.backendProvider
             guard execution["provider"]?.string == kind else { return "The goal's model account changed." }
         }
         if execution["runner"]?.string == "team" {

--- a/Locus/AppModel+IdentityVault.swift
+++ b/Locus/AppModel+IdentityVault.swift
@@ -19,7 +19,7 @@ extension AppModel {
     func identityProviderIdentity(accountID: String? = nil, model: String? = nil) -> IdentityProviderIdentity {
         let account = (accountID ?? settings.activeAccountID).flatMap { id in providerAccounts.first { $0.id.uuidString == id } }
         if let account, settings.provider != .ollama || accountID != nil {
-            return .init(accountID: account.id.uuidString, provider: account.kind == .chatGPT ? "chatgpt" : "remote",
+            return .init(accountID: account.id.uuidString, provider: account.kind.backendProvider,
                          endpoint: account.resolvedBaseURL, model: model ?? selectedModel, label: account.displayName)
         }
         return .init(accountID: "", provider: "ollama", endpoint: ollamaHost,
@@ -35,7 +35,7 @@ extension AppModel {
             showToast("Wait for Locus to connect before opening an Identity task.")
             return
         }
-        guard activeAccount?.kind != .chatGPT else {
+        guard activeAccount?.kind.isManagedPlan != true else {
             identityVault.notice = "Private Identity tasks currently require Local Ollama or an API provider. ChatGPT-plan sessions retain provider-side tool context and cannot yet enforce private source handling. Choose another model provider first."
             identityVault.isPresented = true
             return
@@ -108,7 +108,7 @@ extension AppModel {
             return
         }
         guard let provider = runtime?.identityProvider,
-              provider.provider != "chatgpt",
+              !["chatgpt", "claude_plan"].contains(provider.provider),
               (event["provider"] as? String).map({ $0 == provider.provider }) ?? true,
               (event["model"] as? String).map({ $0 == provider.model }) ?? true else {
             reply(["error": "This task's provider changed or is not ready. Reopen the Identity task before sharing."])

--- a/Locus/AppModel+MobileCompanion.swift
+++ b/Locus/AppModel+MobileCompanion.swift
@@ -238,7 +238,7 @@ extension AppModel {
             }
             body["workspace_root"] = workspace.path
             body["execution_environment"] = workspace.environment.rawValue
-            body["provider"] = account == nil ? "ollama" : (account!.kind == .chatGPT ? "chatgpt" : "remote")
+            body["provider"] = account == nil ? "ollama" : (account!.kind.backendProvider)
             body["provider_account_id"] = account?.id.uuidString ?? ""
             body["model"] = model
         } else {

--- a/Locus/AppModel+ModelRouter.swift
+++ b/Locus/AppModel+ModelRouter.swift
@@ -184,7 +184,7 @@ extension AppModel {
                 else { return nil }
                 return profile.id.uuidString
             }
-            let subscription = account.kind == .chatGPT || account.kind == .kimiCode
+            let subscription = account.kind.isManagedPlan || account.kind == .kimiCode
             routes.append(AutomaticModelRouteCandidate(
                 id: id,
                 name: "\(model) · \(account.shortName)",

--- a/Locus/AppModel+RunQueueAndActivity.swift
+++ b/Locus/AppModel+RunQueueAndActivity.swift
@@ -81,7 +81,7 @@ extension AppModel {
             draft.runner = .solo
         }
         if let account = activeAccount {
-            draft.provider = account.kind == .chatGPT ? "chatgpt" : "remote"
+            draft.provider = account.kind.backendProvider
             draft.providerAccountID = account.id.uuidString
             draft.model = routedModel(for: account)
         } else {
@@ -175,7 +175,7 @@ extension AppModel {
             guard let id = draft.providerAccountID.flatMap(UUID.init(uuidString:)),
                   let account = providerAccounts.first(where: { $0.id == id })
             else { return "Choose an available model account" }
-            let expected = account.kind == .chatGPT ? "chatgpt" : "remote"
+            let expected = account.kind.backendProvider
             guard draft.provider == expected else { return "The selected model account changed" }
         }
         return nil
@@ -203,7 +203,7 @@ extension AppModel {
             guard let id = task.providerAccountID.flatMap(UUID.init(uuidString:)),
                   let account = providerAccounts.first(where: { $0.id == id })
             else { return "The configured model account no longer exists" }
-            let expected = account.kind == .chatGPT ? "chatgpt" : "remote"
+            let expected = account.kind.backendProvider
             guard task.provider == expected else { return "The configured model account changed" }
             if let catalog = accountModels[id], !catalog.isEmpty, !catalog.contains(task.model) {
                 return "The configured model is no longer offered by this account"
@@ -1236,7 +1236,7 @@ extension AppModel {
     /// "keep the saved one".
     @discardableResult
     func saveProviderAccount(_ account: ProviderAccount, apiKey: String?) -> Bool {
-        if account.kind != .chatGPT {
+        if !account.kind.isManagedPlan {
             let effectiveKey = apiKey ?? credentialStore.get(account: account.credentialAccount) ?? ""
             if let error = RemoteEndpointTester.securityError(
                 baseURL: account.resolvedBaseURL,

--- a/Locus/AppModel+SendPipeline.swift
+++ b/Locus/AppModel+SendPipeline.swift
@@ -62,7 +62,7 @@ extension AppModel {
             showToast("Slash commands are unavailable in private Identity tasks.")
             return
         }
-        if privateIdentity, capturedIdentityProvider?.provider == "chatgpt" {
+        if privateIdentity, ["chatgpt", "claude_plan"].contains(capturedIdentityProvider?.provider ?? "") {
             showToast("Choose Local Ollama or an API provider for a private Identity task.")
             return
         }

--- a/Locus/AppModel+SettingsAndProvider.swift
+++ b/Locus/AppModel+SettingsAndProvider.swift
@@ -328,9 +328,9 @@ extension AppModel {
             body["context_window"] = settings.localContextWindow ?? 0
             return body
         }
-        if account.kind == .chatGPT {
+        if account.kind.isManagedPlan {
             return [
-                "provider": "chatgpt",
+                "provider": account.kind.backendProvider,
                 "account_id": account.id.uuidString,
                 "codex_home_id": account.codexHomeIdentifier,
                 "account_label": account.displayName,
@@ -388,7 +388,7 @@ extension AppModel {
         let effort = resolvedReasoningEffort
         guard !effort.isEmpty else { return "" }
         let model = routedModel(for: account)
-        guard account.kind == .chatGPT else {
+        guard account.kind.isManagedPlan else {
             return account.kind.publishedReasoningEfforts(for: model)
                 .contains(effort) ? effort : ""
         }
@@ -409,7 +409,7 @@ extension AppModel {
     @discardableResult
     func applyProvider(verify: Bool = false, announce: Bool = true) async -> Bool {
         let account = activeAccount
-        if let account, account.kind != .chatGPT, account.resolvedBaseURL.isEmpty {
+        if let account, !account.kind.isManagedPlan, account.resolvedBaseURL.isEmpty {
             if announce {
                 showToast("Add the endpoint URL for \(account.displayName) in Settings")
             }
@@ -442,7 +442,7 @@ extension AppModel {
             }
             guard announce else { return true }
             showToast(
-                state.provider == "remote" || state.provider == "chatgpt"
+                state.provider == "remote" || state.provider == "chatgpt" || state.provider == "claude_plan"
                     ? "Using \(account?.displayName ?? shortHost(state.host))"
                     : "Using local Ollama"
             )

--- a/Locus/AppModel+TaskCapsules.swift
+++ b/Locus/AppModel+TaskCapsules.swift
@@ -185,8 +185,8 @@ extension AppModel {
             taskCapsules.error = "\(account.displayName) does not report \(profile.model). Choose an available model."
             return nil
         }
-        if account.kind == .chatGPT {
-            return ("chatgpt", account.id.uuidString, ["provider": "chatgpt", "account_id": account.id.uuidString,
+        if account.kind.isManagedPlan {
+            return (account.kind.backendProvider, account.id.uuidString, ["provider": account.kind.backendProvider, "account_id": account.id.uuidString,
                 "codex_home_id": account.codexHomeIdentifier, "account_label": account.displayName,
                 "model": profile.model, "native_mode": account.codexNativeModeEnabled,
                 "web_search": account.codexWebSearchEnabled, "reasoning_effort": account.codexReasoningEffortValue])
@@ -205,7 +205,7 @@ extension AppModel {
         var route = resolved.body
         if resolved.provider == "ollama" { route["host"] = lastOllamaHost }
         let kind = route["account_kind"] as? String
-        let subscription = resolved.provider == "chatgpt" || kind == ProviderKind.kimiCode.rawValue
+        let subscription = ["chatgpt", "claude_plan"].contains(resolved.provider) || kind == ProviderKind.kimiCode.rawValue
         var payload: [String: Any] = ["id": profile.id.uuidString, "name": profile.name, "model": profile.model,
             "role": profile.role.rawValue, "instructions": profile.instructions, "capabilities": profile.capabilityTags,
             "access_ceiling": profile.accessCeiling.rawValue, "timeout_seconds": profile.timeoutSeconds,

--- a/Locus/AppModel+TeamOps.swift
+++ b/Locus/AppModel+TeamOps.swift
@@ -106,9 +106,9 @@ extension AppModel {
                 guard let account = providerAccounts.first(where: { $0.id == accountID }),
                       account.isCredentialReady(in: credentialStore)
                 else { return nil }
-                if account.kind == .chatGPT {
+                if account.kind.isManagedPlan {
                     route = [
-                        "provider": "chatgpt",
+                        "provider": account.kind.backendProvider,
                         "account_id": account.id.uuidString,
                         "codex_home_id": account.codexHomeIdentifier,
                         "account_label": account.displayName,
@@ -140,7 +140,7 @@ extension AppModel {
                 "access_ceiling": profile.accessCeiling.rawValue,
                 "timeout_seconds": profile.timeoutSeconds,
                 "token_limit": profile.tokenLimit,
-                "metering": route["provider"] as? String == "chatgpt"
+                "metering": ["chatgpt", "claude_plan"].contains(route["provider"] as? String ?? "")
                     ? AgentMetering.selfHosted.rawValue
                     : profile.metering.rawValue,
                 "route": route,

--- a/Locus/AppModel.swift
+++ b/Locus/AppModel.swift
@@ -55,6 +55,7 @@ final class AppModel: ObservableObject {
     /// download. Owned here so the account editor and the settings row observe
     /// the same install rather than racing two of them.
     let codexComponent = CodexComponentInstaller()
+    let claudeComponent = ClaudeComponentInstaller()
     #endif
 
     #if !LOCUS_APP_STORE
@@ -83,6 +84,9 @@ final class AppModel: ObservableObject {
         CodexComponent.bundledHelper == nil && !CodexComponent.isInstalled
         #endif
     }
+    var claudePlanEnabled: Bool { backendCapabilities["claude_plan_v1"] == true }
+    var claudeComponentMissing: Bool { ClaudeComponent.bundledHelper == nil && !ClaudeComponent.isInstalled }
+
     let agentTeamsModel: AgentTeamsModel
     @Published var orchestrationRunID: String?  // internal(for: AppModel+UITestFixtures)
     @Published var orchestrationState: TeamRunState?  // internal(for: AppModel+UITestFixtures)
@@ -1207,7 +1211,7 @@ final class AppModel: ObservableObject {
                 guard let self else { return [:] }
                 if let account = self.activeAccount {
                     return [
-                        "provider": account.kind == .chatGPT ? "chatgpt" : "remote",
+                        "provider": account.kind.backendProvider,
                         "provider_account_id": account.id.uuidString,
                         "account_label": account.displayName,
                         "model": self.routedModel(for: account),
@@ -1577,7 +1581,7 @@ final class AppModel: ObservableObject {
     var reasoningEffortOptions: [String] {
         guard let account = activeAccount else { return [] }
         let model = routedModel(for: account)
-        if account.kind == .chatGPT {
+        if account.kind.isManagedPlan {
             var efforts = accountModelCatalogs[account.id]?
                 .first(where: { $0.id == model })?
                 .supportedReasoningEfforts?

--- a/Locus/BackendProcess.swift
+++ b/Locus/BackendProcess.swift
@@ -125,6 +125,9 @@ final class BackendProcess {
         if let helperPath = CodexComponent.helperPathForBackend() {
             environment["LOCUS_CODEX_APP_SERVER_PATH"] = helperPath
         }
+        if let path = ClaudeComponent.helperPathForBackend() {
+            environment["LOCUS_CLAUDE_RUNTIME_PATH"] = path
+        }
         if let packages = launch.packages {
             environment["PYTHONPATH"] = [
                 launch.source.path,

--- a/Locus/ClaudeComponent.swift
+++ b/Locus/ClaudeComponent.swift
@@ -1,0 +1,75 @@
+import Foundation
+import SwiftUI
+
+protocol PlanComponentDescriptor {
+    static var componentID: String { get }
+    static var binaries: [(String, String)] { get }
+    static var supportRoot: URL? { get }
+    static var currentRoot: URL? { get }
+    static var isInstalled: Bool { get }
+    static func installedVersion() -> String?
+}
+
+/// Claude's official runtime is versioned independently from the OpenAI helper.
+enum ClaudeComponent: PlanComponentDescriptor {
+    static let componentID = "claude-plan"
+    static let helperIdentifier = "io.sparktales.locus.claude"
+    static var binaries: [(String, String)] { [("claude", helperIdentifier)] }
+    static var supportRoot: URL? {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+            .appending(path: "\(AppEdition.current.displayName)/Components/\(componentID)", directoryHint: .isDirectory)
+    }
+    static var currentRoot: URL? { supportRoot?.appending(path: "current", directoryHint: .isDirectory) }
+    static var bundledHelper: URL? {
+        let path = Bundle.main.bundleURL.appending(path: "Contents/Helpers/claude")
+        return FileManager.default.isExecutableFile(atPath: path.path) ? path : nil
+    }
+    static var isInstalled: Bool {
+        guard let path = currentRoot?.appending(path: "claude") else { return false }
+        return FileManager.default.isExecutableFile(atPath: path.path)
+    }
+    static func installedVersion() -> String? {
+        guard let path = currentRoot,
+              let target = try? FileManager.default.destinationOfSymbolicLink(atPath: path.path)
+        else { return nil }
+        return URL(fileURLWithPath: target).lastPathComponent
+    }
+    static func helperPathForBackend() -> String? {
+        bundledHelper?.path ?? currentRoot?.appending(path: "claude").path
+    }
+}
+
+#if !LOCUS_APP_STORE
+struct ClaudeComponentDownloadView: View {
+    @EnvironmentObject private var model: AppModel
+    let account: ProviderAccount
+    var body: some View {
+        ClaudeComponentInstallControls(installer: model.claudeComponent, account: account)
+    }
+}
+
+private struct ClaudeComponentInstallControls: View {
+    @EnvironmentObject private var model: AppModel
+    @ObservedObject var installer: ClaudeComponentInstaller
+    let account: ProviderAccount
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Download Claude plan support to connect your subscription.")
+            if installer.state.isBusy {
+                ProgressView()
+                Button("Cancel") { installer.cancel() }
+            } else {
+                if case .failed(let message) = installer.state { Text(message).foregroundStyle(.red) }
+                Button("Download Claude plan support") {
+                    Task {
+                        installer.install()
+                        await installer.waitForCompletion()
+                        await model.providerAccountsModel.refreshChatGPTAccount(for: account)
+                    }
+                }
+                .accessibilityIdentifier("accountEditor.claude.downloadComponent")
+            }
+        }
+    }
+}
+#endif

--- a/Locus/CodexComponent.swift
+++ b/Locus/CodexComponent.swift
@@ -17,7 +17,10 @@ import Security
 /// availability check — so pointing the variable at `current/codex` lets an
 /// install or upgrade take effect without restarting the agent and dropping
 /// live sessions.
-enum CodexComponent {
+enum CodexComponent: PlanComponentDescriptor {
+    static var binaries: [(String, String)] {
+        [("codex", helperIdentifier), ("codex-code-mode-host", codeModeHostIdentifier)]
+    }
     /// Matches the `identifier` BundleBackend.sh and PackageComponents.sh seal
     /// the helpers with. Pinned in the requirement below so a validly signed
     /// SparkTales binary that is not *this* binary cannot be substituted.

--- a/Locus/CodexComponentInstaller.swift
+++ b/Locus/CodexComponentInstaller.swift
@@ -3,14 +3,17 @@ import Foundation
 
 #if !LOCUS_APP_STORE
 
-/// Fetches, verifies, and installs the ChatGPT-plan component.
+typealias CodexComponentInstaller = PlanComponentInstaller<CodexComponent>
+typealias ClaudeComponentInstaller = PlanComponentInstaller<ClaudeComponent>
+
+/// Fetches, verifies, and installs a managed subscription runtime component.
 ///
 /// Order matters and is not negotiable: hash the payload, expand it, verify
-/// *both* binaries against SparkTales' code-signing identity, clear quarantine,
+/// the declared binaries against SparkTales' code-signing identity, clear quarantine,
 /// and only then publish the `current` symlink. A failure at any step leaves
 /// the previous install — or the absence of one — exactly as it was.
 @MainActor
-final class CodexComponentInstaller: ObservableObject {
+final class PlanComponentInstaller<Component: PlanComponentDescriptor>: ObservableObject {
     enum State: Equatable {
         case idle
         case checking
@@ -44,7 +47,7 @@ final class CodexComponentInstaller: ObservableObject {
         // A 100 MB payload on a slow link must not trip the resource timeout.
         configuration.timeoutIntervalForResource = 6 * 60 * 60
         session = ProxyAwareSession(scope: .downloads, configuration: { configuration })
-        if let version = CodexComponent.installedVersion(), CodexComponent.isInstalled {
+        if let version = Component.installedVersion(), Component.isInstalled {
             state = .installed(version: version)
         }
     }
@@ -85,9 +88,9 @@ final class CodexComponentInstaller: ObservableObject {
                 "unsupported schemaVersion \(feed.schemaVersion)"
             )
         }
-        let forComponent = feed.components.filter { $0.id == CodexComponent.componentID }
+        let forComponent = feed.components.filter { $0.id == Component.componentID }
         guard !forComponent.isEmpty else {
-            throw CodexComponentError.manifestInvalid("no \(CodexComponent.componentID) entry")
+            throw CodexComponentError.manifestInvalid("no \(Component.componentID) entry")
         }
         guard let match = forComponent.first(where: { $0.arch == arch }) else {
             throw CodexComponentError.unsupportedArchitecture(arch)
@@ -259,8 +262,8 @@ final class CodexComponentInstaller: ObservableObject {
         archive: URL,
         release: CodexComponentRelease
     ) async throws {
-        guard let supportRoot = CodexComponent.supportRoot,
-              let currentRoot = CodexComponent.currentRoot
+        guard let supportRoot = Component.supportRoot,
+              let currentRoot = Component.currentRoot
         else { throw CodexComponentError.installFailed("no Application Support directory") }
 
         let fileManager = FileManager.default
@@ -280,21 +283,13 @@ final class CodexComponentInstaller: ObservableObject {
         // component is not supposed to contain.
         try Self.validateExpandedTree(at: staging)
 
-        let helper = staging.appending(path: "codex")
-        let codeModeHost = staging.appending(path: "codex-code-mode-host")
-        for binary in [helper, codeModeHost] {
+        for (name, identifier) in Component.binaries {
+            let binary = staging.appending(path: name)
             guard fileManager.fileExists(atPath: binary.path) else {
-                throw CodexComponentError.extractionFailed(
-                    "archive is missing \(binary.lastPathComponent)"
-                )
+                throw CodexComponentError.extractionFailed("archive is missing \(name)")
             }
+            try CodexComponent.verifySignature(at: binary, identifier: identifier)
         }
-        // Nothing has been exec'd yet and nothing is in place — this is the
-        // gate that decides whether the payload is ours.
-        try CodexComponent.verifySignature(at: helper, identifier: CodexComponent.helperIdentifier)
-        try CodexComponent.verifySignature(
-            at: codeModeHost, identifier: CodexComponent.codeModeHostIdentifier
-        )
         // A quarantined binary refuses to launch even with a valid signature.
         try? Self.run("/usr/bin/xattr", ["-dr", "com.apple.quarantine", staging.path]) {
             CodexComponentError.installFailed($0)
@@ -302,9 +297,13 @@ final class CodexComponentInstaller: ObservableObject {
 
         let versioned = supportRoot.appending(path: release.version, directoryHint: .isDirectory)
         if fileManager.fileExists(atPath: versioned.path) {
-            try fileManager.removeItem(at: versioned)
+            try Self.validateExpandedTree(at: versioned)
+            for (name, identifier) in Component.binaries {
+                try CodexComponent.verifySignature(at: versioned.appending(path: name), identifier: identifier)
+            }
+        } else {
+            try fileManager.moveItem(at: staging, to: versioned)
         }
-        try fileManager.moveItem(at: staging, to: versioned)
 
         // Publish atomically: build the new link beside the old one and rename
         // over it, so a crash here can never leave `current` dangling.
@@ -321,9 +320,9 @@ final class CodexComponentInstaller: ObservableObject {
 
     /// Entries a published component may contain. Anything else means the
     /// archive is not what PackageComponents.sh produces.
-    static let permittedEntries: Set<String> = [
-        "codex", "codex-code-mode-host", "LICENSE", "NOTICE", "PROVENANCE",
-    ]
+    nonisolated static var permittedEntries: Set<String> {
+        Set(Component.binaries.map { $0.0 }).union(["LICENSE", "NOTICE", "PROVENANCE"])
+    }
 
     nonisolated static func validateExpandedTree(at staging: URL) throws {
         let fileManager = FileManager.default
@@ -355,10 +354,10 @@ final class CodexComponentInstaller: ObservableObject {
     }
 
     /// Deleting ~268 MB is not instant either, and the settings row reads
-    /// `CodexComponent.isInstalled` — so the state only changes once the tree
+    /// `Component.isInstalled` — so the state only changes once the tree
     /// is actually gone.
     func remove() async {
-        guard let supportRoot = CodexComponent.supportRoot else { return }
+        guard let supportRoot = Component.supportRoot else { return }
         await Self.deleteTree(at: supportRoot)
         state = .idle
     }

--- a/Locus/DuoMode.swift
+++ b/Locus/DuoMode.swift
@@ -134,7 +134,7 @@ extension AppModel {
     var capsuleProfiles: [AgentProfile] { agentProfiles + duo.saved.profiles }
 
     func selectDuoModel(account: ProviderAccount?, model: String, planner: Bool) {
-        let subscription = account == nil || account?.kind == .chatGPT || account?.kind == .kimiCode
+        let subscription = account == nil || account?.kind.isManagedPlan == true || account?.kind == .kimiCode
         let profile = AgentProfile(name: planner ? "Duo planner" : "Duo builder",
             route: account.map { .providerAccount($0.id) } ?? .localOllama, model: model,
             role: planner ? .planner : .implementer,

--- a/Locus/Models/ProviderModels.swift
+++ b/Locus/Models/ProviderModels.swift
@@ -338,6 +338,8 @@ struct ChatGPTUsageResponse: Codable, Hashable {
     let status: String
     let planType: String?
     let rateLimits: RateLimits
+    var observedAt: Double? = nil
+    var limitStatus: String? = nil
     let activity: Activity
     let message: String?
 
@@ -345,5 +347,7 @@ struct ChatGPTUsageResponse: Codable, Hashable {
         case status, activity, message
         case planType = "plan_type"
         case rateLimits = "rate_limits"
+        case observedAt = "observed_at"
+        case limitStatus = "limit_status"
     }
 }

--- a/Locus/OnboardingView.swift
+++ b/Locus/OnboardingView.swift
@@ -170,7 +170,7 @@ struct OnboardingView: View {
                             }
                         }.disabled(providers.providerAccounts.isEmpty)
                         Menu("Add account…") {
-                            ForEach(ProviderKind.allCases) { kind in
+                            ForEach(ProviderKind.allCases.filter { $0 != .claudePlan || model.claudePlanEnabled }) { kind in
                                 Button(kind.marketingName) { editingAccount = ProviderAccount(kind: kind) }
                             }
                         }

--- a/Locus/ProviderAccounts.swift
+++ b/Locus/ProviderAccounts.swift
@@ -6,6 +6,7 @@ import Foundation
 /// protocol. The agent adapter hides that difference from the rest of the app.
 enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     case claude
+    case claudePlan = "claude_plan"
     /// OpenAI-managed ChatGPT subscription access. Authentication and model
     /// traffic stay inside the bundled Codex App Server helper; this is never
     /// interchangeable with an API key account.
@@ -26,7 +27,8 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     /// What the user calls it.
     var marketingName: String {
         switch self {
-        case .claude: "Claude"
+        case .claude: "Claude API"
+        case .claudePlan: "Claude plan"
         case .chatGPT: "ChatGPT plan"
         case .codex: "OpenAI API"
         case .kimi: "Kimi"
@@ -38,7 +40,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     /// Who runs it — shown next to the marketing name so "Codex" is not a riddle.
     var vendorName: String {
         switch self {
-        case .claude: "Anthropic"
+        case .claude, .claudePlan: "Anthropic"
         case .chatGPT, .codex: "OpenAI"
         case .kimi, .kimiCode: "Moonshot AI"
         case .custom: ""
@@ -52,6 +54,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var defaultBaseURL: String {
         switch self {
         case .claude: "https://api.anthropic.com/v1"
+        case .claudePlan: "https://claude.ai"
         // A display/documentation origin only. Managed ChatGPT traffic never
         // uses this as an inference endpoint.
         case .chatGPT: "https://chatgpt.com"
@@ -66,6 +69,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var keyDocsURL: String {
         switch self {
         case .claude: "https://console.anthropic.com/settings/keys"
+        case .claudePlan: "https://code.claude.com/docs/en/agent-sdk/overview"
         case .chatGPT: "https://learn.chatgpt.com/docs/auth#openai-authentication"
         case .codex: "https://platform.openai.com/api-keys"
         case .kimi: "https://platform.moonshot.ai/console/api-keys"
@@ -77,7 +81,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var keyPlaceholder: String {
         switch self {
         case .claude: "sk-ant-…"
-        case .chatGPT: ""
+        case .chatGPT, .claudePlan: ""
         case .codex, .kimi: "sk-…"
         // Moonshot documents no prefix for these; guessing one would contradict
         // what the user is about to paste.
@@ -91,12 +95,15 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var authStyle: String {
         switch self {
         case .claude: "anthropic"
-        case .chatGPT: "managed"
+        case .chatGPT, .claudePlan: "managed"
         case .codex, .kimi, .kimiCode, .custom: "bearer"
         }
     }
 
-    var requiresAPIKey: Bool { self != .chatGPT }
+    var isManagedPlan: Bool { self == .chatGPT || self == .claudePlan }
+    var backendProvider: String { self == .claudePlan ? "claude_plan" : self == .chatGPT ? "chatgpt" : "remote" }
+    var managedAPIPath: String { self == .claudePlan ? "/api/claude" : "/api/chatgpt" }
+    var requiresAPIKey: Bool { !isManagedPlan }
 
     /// Whether the account works with no key at all. Local OpenAI-compatible
     /// servers (llama.cpp, LM Studio, vLLM, Ollama) usually run without
@@ -126,7 +133,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     var supportsImageGeneration: Bool {
         switch self {
         case .codex, .custom, .chatGPT: true
-        case .claude, .kimi, .kimiCode: false
+        case .claude, .claudePlan, .kimi, .kimiCode: false
         }
     }
 
@@ -150,6 +157,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     /// of a fetched list so the newest models are easy to find.
     var curatedModels: [String] {
         switch self {
+        case .claudePlan: ["default"]
         case .claude:
             ["claude-opus-5", "claude-sonnet-5", "claude-fable-5", "claude-haiku-4-5"]
         case .chatGPT:
@@ -183,6 +191,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     func publishedContextWindow(for model: String) -> Int? {
         let name = model.lowercased()
         switch self {
+        case .claudePlan: return nil
         case .claude:
             if name.contains("opus-5")
                 || name.contains("sonnet-5")
@@ -229,6 +238,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     func publishedReasoningEfforts(for model: String) -> [String] {
         let name = model.lowercased()
         switch self {
+        case .claudePlan: return []
         case .claude:
             // Effort is generally available on the Claude 5 family and takes
             // the place of the retired token budget. Haiku 4.5 rejects the
@@ -267,10 +277,8 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
         case .claude:
             ProviderNote(
                 text: """
-                Claude accounts use an API key from console.anthropic.com. \
-                Anthropic does not permit third-party apps to sign in with a \
-                Claude.ai account or to route requests through Pro or Max plan \
-                credentials, so a Claude subscription cannot be used here.
+                Claude API accounts use a key from console.anthropic.com and are billed separately. \
+                To use a supported subscription, add a Claude plan account when available.
                 """,
                 linkTitle: "Anthropic's terms for third-party tools",
                 linkURL: "https://code.claude.com/docs/en/legal-and-compliance"
@@ -296,7 +304,7 @@ enum ProviderKind: String, Codable, CaseIterable, Identifiable {
                 linkTitle: "",
                 linkURL: ""
             )
-        case .chatGPT, .codex, .custom:
+        case .chatGPT, .claudePlan, .codex, .custom:
             nil
         }
     }
@@ -337,6 +345,8 @@ enum ProviderModelFilter {
         let lowered = name.lowercased()
         guard !excludedFragments.contains(where: lowered.contains) else { return false }
         switch kind {
+        case .claudePlan:
+            return true // The managed runtime owns this account's catalog and aliases.
         case .claude:
             return lowered.hasPrefix("claude")
         case .chatGPT, .codex:
@@ -485,6 +495,7 @@ struct ProviderAccount: Identifiable, Codable, Hashable {
     /// The value the agent uses to pick this account's credential home. Empty
     /// is the pre-multi-account home, which is exactly what nil should mean.
     var codexHomeIdentifier: String { codexHomeID ?? "" }
+    var managedHomeIdentifier: String { kind == .claudePlan ? id.uuidString : codexHomeIdentifier }
 
     /// Whether this account answers like Codex rather than under the Locus
     /// contract. New accounts are created with parity off, so they arrive with
@@ -504,7 +515,7 @@ struct ProviderAccount: Identifiable, Codable, Hashable {
     }
 
     func hasKey(in credentialStore: any CredentialStoring) -> Bool {
-        kind.usesManagedChatGPTAuthentication
+        kind.isManagedPlan
             || credentialStore.has(account: credentialAccount)
     }
 
@@ -647,7 +658,7 @@ enum ProviderAccountStatus: Equatable {
 
     var summary: String {
         switch self {
-        case .signingIn: "Waiting for ChatGPT sign-in"
+        case .signingIn: "Waiting for sign-in"
         case let .signedIn(email, plan):
             {
                 let details = [email, plan?.capitalized]
@@ -660,7 +671,7 @@ enum ProviderAccountStatus: Equatable {
         case let .runtimeUnavailable(message): message
         case let .rateLimited(resetAt):
             resetAt.map { "Limit reached · resets \($0.formatted(.relative(presentation: .named)))" }
-                ?? "ChatGPT plan limit reached"
+                ?? "Subscription limit reached"
         case .keySaved: "Key saved"
         case let .connected(models):
             models == 1 ? "Connected · 1 model" : "Connected · \(models) models"

--- a/Locus/ProviderAccountsModel.swift
+++ b/Locus/ProviderAccountsModel.swift
@@ -116,11 +116,11 @@ final class ProviderAccountsModel: ObservableObject {
         guard !due.isEmpty else { return }
         let now = Date()
         for account in due { accountCatalogFetchedAt[account.id] = now }
-        for account in due where account.kind == .chatGPT {
+        for account in due where account.kind.isManagedPlan {
             do {
                 let response = try await backend.get(
-                    "/api/chatgpt/models",
-                    query: [URLQueryItem(name: "account_id", value: account.codexHomeIdentifier)],
+                    account.kind.managedAPIPath + "/models",
+                    query: [URLQueryItem(name: "account_id", value: account.managedHomeIdentifier)],
                     as: ChatGPTModelsResponse.self
                 )
                 let names = response.models.map(\.id)
@@ -132,7 +132,7 @@ final class ProviderAccountsModel: ObservableObject {
                 accountStatus[account.id] = .runtimeUnavailable(error.localizedDescription)
             }
         }
-        let endpointAccounts = due.filter { $0.kind != .chatGPT }
+        let endpointAccounts = due.filter { !$0.kind.isManagedPlan }
         await withTaskGroup(of: (UUID, ProviderModelCatalog.Result).self) { group in
             for account in endpointAccounts {
                 let credentialStore = credentialStore
@@ -177,13 +177,13 @@ final class ProviderAccountsModel: ObservableObject {
     }
 
     func noteLocalHost(from info: SessionInfo) {
-        guard info.provider != "remote", !info.host.isEmpty else { return }
+        guard info.provider == "ollama", !info.host.isEmpty else { return }
         lastOllamaHost = info.host
     }
 
     /// Refreshes every ChatGPT account, each against its own credential home.
     func refreshChatGPTAccounts(forceTokenRefresh: Bool = false) async {
-        for account in providerAccounts where account.kind == .chatGPT {
+        for account in providerAccounts where account.kind.isManagedPlan {
             await refreshChatGPTAccount(for: account, forceTokenRefresh: forceTokenRefresh)
         }
     }
@@ -193,21 +193,24 @@ final class ProviderAccountsModel: ObservableObject {
         forceTokenRefresh: Bool = false
     ) async {
         guard let backend else { return }
-        var query = [URLQueryItem(name: "account_id", value: account.codexHomeIdentifier)]
+        var query = [URLQueryItem(name: "account_id", value: account.managedHomeIdentifier)]
         if forceTokenRefresh {
             query.append(URLQueryItem(name: "refresh", value: "true"))
         }
         do {
             let state = try await backend.get(
-                "/api/chatgpt/account",
+                account.kind.managedAPIPath + "/account",
                 query: query,
                 as: ChatGPTAccountResponse.self
             )
             chatGPTAccounts[account.id] = state
+            if account.kind == .claudePlan && state.status == "signed_out" {
+                chatGPTLoginIDs[account.id] = nil
+            }
             accountStatus[account.id] = switch state.status {
             case "signed_in": .signedIn(email: state.email, plan: state.planType)
             case "runtime_unavailable":
-                .runtimeUnavailable(state.message ?? "The ChatGPT runtime is unavailable")
+                .runtimeUnavailable(state.message ?? "The subscription runtime is unavailable")
             case "signing_in": .signingIn
             default: .signedOut
             }
@@ -224,18 +227,19 @@ final class ProviderAccountsModel: ObservableObject {
         guard let backend else { return }
         do {
             let response = try await backend.post(
-                "/api/chatgpt/login/start",
-                body: ["account_id": account.codexHomeIdentifier],
+                account.kind.managedAPIPath + "/login/start",
+                body: ["account_id": account.managedHomeIdentifier],
                 as: ChatGPTLoginResponse.self
             )
             chatGPTLoginIDs[account.id] = response.loginID
             accountStatus[account.id] = .signingIn
+            if response.authURL.isEmpty { return }
             guard let url = URL(string: response.authURL), NSWorkspace.shared.open(url) else {
-                toastHandler("Could not open the ChatGPT sign-in page")
+                toastHandler("Could not open the subscription sign-in page")
                 return
             }
         } catch {
-            toastHandler("Could not start ChatGPT sign-in: \(error.localizedDescription)")
+            toastHandler("Could not start subscription sign-in: \(error.localizedDescription)")
             await refreshChatGPTAccount(for: account)
         }
     }
@@ -245,10 +249,10 @@ final class ProviderAccountsModel: ObservableObject {
         guard let loginID = chatGPTLoginIDs[account.id] else { return }
         do {
             let state = try await backend.post(
-                "/api/chatgpt/login/cancel",
+                account.kind.managedAPIPath + "/login/cancel",
                 body: [
                     "login_id": loginID,
-                    "account_id": account.codexHomeIdentifier,
+                    "account_id": account.managedHomeIdentifier,
                 ],
                 as: ChatGPTAccountResponse.self
             )
@@ -256,7 +260,7 @@ final class ProviderAccountsModel: ObservableObject {
             chatGPTAccounts[account.id] = state
             await refreshChatGPTAccount(for: account)
         } catch {
-            toastHandler("Could not cancel ChatGPT sign-in: \(error.localizedDescription)")
+            toastHandler("Could not cancel subscription sign-in: \(error.localizedDescription)")
         }
     }
 
@@ -264,8 +268,8 @@ final class ProviderAccountsModel: ObservableObject {
         guard let backend else { return }
         do {
             let state = try await backend.post(
-                "/api/chatgpt/logout",
-                body: ["account_id": account.codexHomeIdentifier],
+                account.kind.managedAPIPath + "/logout",
+                body: ["account_id": account.managedHomeIdentifier],
                 as: ChatGPTAccountResponse.self
             )
             chatGPTAccounts[account.id] = state
@@ -276,19 +280,19 @@ final class ProviderAccountsModel: ObservableObject {
             // of a second plan must leave a chat running on the first alone.
             await accountRoutingDeactivated(account.id)
         } catch {
-            toastHandler("Could not sign out of ChatGPT: \(error.localizedDescription)")
+            toastHandler("Could not sign out of the account: \(error.localizedDescription)")
         }
     }
 
     /// The plan usage of the ChatGPT account currently routing requests, which
     /// is the only one the usage dashboard's plan section can be about.
     var activeChatGPTUsage: ChatGPTUsageResponse? {
-        guard let account = activeAccountProvider(), account.kind == .chatGPT else { return nil }
+        guard let account = activeAccountProvider(), account.kind.isManagedPlan else { return nil }
         return chatGPTUsageByAccount[account.id]
     }
 
     func refreshActiveChatGPTUsage() async {
-        guard let account = activeAccountProvider(), account.kind == .chatGPT else { return }
+        guard let account = activeAccountProvider(), account.kind.isManagedPlan else { return }
         await refreshChatGPTUsage(for: account)
     }
 
@@ -300,11 +304,14 @@ final class ProviderAccountsModel: ObservableObject {
         }
         do {
             let usage = try await backend.get(
-                "/api/chatgpt/usage",
-                query: [URLQueryItem(name: "account_id", value: account.codexHomeIdentifier)],
+                account.kind.managedAPIPath + "/usage",
+                query: [URLQueryItem(name: "account_id", value: account.managedHomeIdentifier)],
                 as: ChatGPTUsageResponse.self
             )
             chatGPTUsageByAccount[account.id] = usage
+            if usage.limitStatus == "rejected" {
+                accountStatus[account.id] = .rateLimited(resetAt: usage.rateLimits.rateLimits?.primary?.resetsAt.map { Date(timeIntervalSince1970: Double($0)) })
+            }
             if let window = usage.rateLimits.rateLimits?.primary,
                window.usedPercent >= 100
             {

--- a/Locus/RemoteRuntimesView.swift
+++ b/Locus/RemoteRuntimesView.swift
@@ -227,7 +227,7 @@ struct DeployAgentView: View {
                         Text("Allow file edits").tag("accept_edits")
                         Text("Allow all tools").tag("bypass")
                     }
-                    Text("Only this account is provisioned. Remote tools ask for permission. ChatGPT accounts sign in independently on this host.").font(.caption).foregroundStyle(.secondary)
+                    Text("Only this account is provisioned. Remote tools ask for permission. Subscription accounts sign in independently on this host.").font(.caption).foregroundStyle(.secondary)
                     if selectedAccountIsChatGPT {
                         Button("Sign in on remote runtime") { perform { await startLogin() } }
                         Button("Use browser login through SSH") { perform { await startLogin(method: "browser") } }
@@ -268,17 +268,18 @@ struct DeployAgentView: View {
             }
         }
     }
-    private var selectedAccountIsChatGPT: Bool { providerAccounts.providerAccounts.first(where: { $0.id.uuidString == accountID })?.kind == .chatGPT }
+    private var selectedAccountIsChatGPT: Bool { providerAccounts.providerAccounts.first(where: { $0.id.uuidString == accountID })?.kind.isManagedPlan == true }
     private var provider: [String: Any] {
         if let account = providerAccounts.providerAccounts.first(where: { $0.id.uuidString == accountID }) {
-            return model.scheduledProviderRequestBody(provider: account.kind == .chatGPT ? "chatgpt" : "remote", accountID: accountID, model: modelName) ?? [:]
+            return model.scheduledProviderRequestBody(provider: account.kind.backendProvider, accountID: accountID, model: modelName) ?? [:]
         }
         return ["provider": "ollama", "model": modelName]
     }
     private func startLogin(method: String = "device_code") async {
         do {
-            let home = provider["codex_home_id"] as? String ?? accountID
-            let value: [String: JSONValue] = try await model.backend.post("/api/runtime/remotes/\(target.id)/login", body: ["account_id": home, "method": method], timeout: 60, as: [String: JSONValue].self)
+            let isClaude = provider["provider"] as? String == "claude_plan"
+            let home = isClaude ? accountID : (provider["codex_home_id"] as? String ?? accountID)
+            let value: [String: JSONValue] = try await model.backend.post("/api/runtime/remotes/\(target.id)/login", body: ["account_id": home, "method": method, "provider": provider["provider"] ?? "chatgpt"], timeout: 60, as: [String: JSONValue].self)
             loginCode = value["user_code"]?.string ?? ""
             loginURL = URL(string: value["auth_url"]?.string ?? "")
         } catch { message = error.localizedDescription }

--- a/Locus/Sheets.swift
+++ b/Locus/Sheets.swift
@@ -3065,7 +3065,7 @@ struct SettingsView: View {
                     // Menu flattens custom Label icons: monogram logos (A, K, …)
                     // replace the item title with invisible white text, so the
                     // dropdown stays text-only.
-                    ForEach(ProviderKind.allCases) { kind in
+                    ForEach(ProviderKind.allCases.filter { $0 != .claudePlan || model.claudePlanEnabled }) { kind in
                         Button(kind.title) {
                             addingAccount = ProviderAccount(kind: kind)
                         }
@@ -3073,7 +3073,7 @@ struct SettingsView: View {
                 }
                 .accessibilityIdentifier("settings.accounts.add")
 
-                Text("API accounts keep their keys in \(CredentialStore.displayPath), readable only by your macOS user account. ChatGPT plan sign-in is isolated in OpenAI's managed runtime and its tokens never enter Locus account files.")
+                Text("API accounts keep their keys in \(CredentialStore.displayPath), readable only by your macOS user account. Subscription sign-in is isolated in each provider's managed runtime and its tokens never enter Locus account files.")
                     .font(.locus(size: 9))
                     .foregroundStyle(LocusTheme.muted)
                     .fixedSize(horizontal: false, vertical: true)
@@ -3399,7 +3399,7 @@ struct SettingsView: View {
     private func accountDetail(_ account: ProviderAccount) -> String {
         let status = providerAccounts.accountStatus[account.id]
             ?? (account.hasKey(in: model.credentialStore) ? .keySaved : .noKey)
-        if account.kind == .chatGPT,
+        if account.kind.isManagedPlan,
            let window = providerAccounts.chatGPTUsageByAccount[account.id]?.rateLimits.rateLimits?.primary
         {
             let reset = window.resetsAt.map {
@@ -3410,7 +3410,10 @@ struct SettingsView: View {
                 .activity.summary?.lifetimeTokens.map {
                 $0.formatted(.number.notation(.compactName)) + " activity tokens"
             }
-            return [status.summary, "\(window.usedPercent)% used", reset, activity]
+            let observed = providerAccounts.chatGPTUsageByAccount[account.id]?.observedAt.map {
+                "updated " + Date(timeIntervalSince1970: $0).formatted(.relative(presentation: .named))
+            }
+            return [status.summary, "\(window.usedPercent)% used", reset, activity, observed]
                 .compactMap { $0 }
                 .joined(separator: " · ")
         }

--- a/Locus/UsageDashboardView.swift
+++ b/Locus/UsageDashboardView.swift
@@ -276,7 +276,7 @@ struct UsageDashboardView: View {
 
     private func chatGPTPlanUsage(_ usage: ChatGPTUsageResponse) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            sectionLabel("CHATGPT PLAN USAGE")
+            sectionLabel("SUBSCRIPTION PLAN USAGE")
             HStack(spacing: 10) {
                 let primary = usage.rateLimits.rateLimits?.primary
                 totalTile(
@@ -303,11 +303,16 @@ struct UsageDashboardView: View {
                     "Plan",
                     usage.planType?
                         .replacingOccurrences(of: "_", with: " ")
-                        .capitalized ?? "ChatGPT",
+                        .capitalized ?? "Subscription",
                     id: "usage.chatgpt.plan"
                 )
             }
-            Text("Subscription limits are reported by OpenAI and are kept separate from API and local cost estimates below.")
+            if let observedAt = usage.observedAt {
+                Text("Updated " + Date(timeIntervalSince1970: observedAt).formatted(.relative(presentation: .named)))
+                    .font(.locus(size: 8))
+                    .foregroundStyle(LocusTheme.muted)
+            }
+            Text("Subscription limits are reported by the provider and are kept separate from API and local cost estimates below.")
                 .font(.locus(size: 8))
                 .foregroundStyle(LocusTheme.muted)
         }

--- a/Locus/WorkspaceView.swift
+++ b/Locus/WorkspaceView.swift
@@ -2320,7 +2320,7 @@ struct ScheduleEditorView: View {
             draft.provider = "ollama"
             draft.providerAccountID = nil
         } else if let account = providerAccounts.providerAccounts.first(where: { $0.id.uuidString == value }) {
-            draft.provider = account.kind == .chatGPT ? "chatgpt" : "remote"
+            draft.provider = account.kind.backendProvider
             draft.providerAccountID = value
         }
         if !catalogModels.contains(draft.model) { draft.model = catalogModels.first ?? "" }

--- a/LocusTests/AppModelTests.swift
+++ b/LocusTests/AppModelTests.swift
@@ -2684,7 +2684,7 @@ final class AppModelTests: XCTestCase {
         XCTAssertEqual(body["model"] as? String, "claude-sonnet-4-5")
         XCTAssertEqual(body["api_key"] as? String, "sk-ant-secret")
         XCTAssertEqual(body["auth_style"] as? String, "anthropic")
-        XCTAssertEqual(body["account_label"] as? String, "Claude — Work")
+        XCTAssertEqual(body["account_label"] as? String, "Claude API — Work")
     }
 
     @MainActor
@@ -3221,7 +3221,7 @@ final class AppModelTests: XCTestCase {
 
         let account = seedAccount(model, kind: .claude, name: "Work")
         model.settings.activeAccountID = account.id.uuidString
-        XCTAssertEqual(model.providerLabel, "Claude ready")
+        XCTAssertEqual(model.providerLabel, "Claude API ready")
     }
 
     @MainActor

--- a/LocusTests/CodexComponentTests.swift
+++ b/LocusTests/CodexComponentTests.swift
@@ -285,3 +285,15 @@ final class CodexComponentManifestSafetyTests: XCTestCase {
         )
     }
 }
+
+extension CodexComponentTests {
+    func testClaudeAndChatGPTComponentsCannotBeSubstituted() throws {
+        let both = feed([release(), release(id: "claude-plan")])
+        let selected = try ClaudeComponentInstaller.selectRelease(from: both, arch: "arm64", appVersion: "2.0.0")
+        XCTAssertEqual(selected.id, "claude-plan")
+        XCTAssertThrowsError(try ClaudeComponentInstaller.selectRelease(from: feed([release()]), arch: "arm64", appVersion: "2.0.0"))
+        XCTAssertEqual(ClaudeComponentInstaller.permittedEntries, ["claude", "LICENSE", "NOTICE", "PROVENANCE"])
+        XCTAssertFalse(ClaudeComponentInstaller.permittedEntries.contains("codex"))
+        XCTAssertNotEqual(ClaudeComponent.helperIdentifier, CodexComponent.helperIdentifier)
+    }
+}

--- a/LocusTests/FeatureLogicTests.swift
+++ b/LocusTests/FeatureLogicTests.swift
@@ -3614,7 +3614,7 @@ final class FeatureLogicTests: XCTestCase {
 
         XCTAssertEqual(restored.count, 1)
         XCTAssertEqual(restored[0].kind, .claude)
-        XCTAssertEqual(restored[0].displayName, "Claude — Work")
+        XCTAssertEqual(restored[0].displayName, "Claude API — Work")
         XCTAssertEqual(restored[0].resolvedBaseURL, "https://api.anthropic.com/v1")
         XCTAssertEqual(restored[0].credentialAccount, CredentialStore.providerAccountKey(account.id))
         XCTAssertFalse(encoded.contains("apikey"))
@@ -3826,8 +3826,8 @@ final class FeatureLogicTests: XCTestCase {
             ProviderAccountStore.uniqueName("Work", kind: .claude, existing: existing),
             "Work 2"
         )
-        // A different provider may reuse the name — "Claude — Work" and
-        // "Codex — Work" are already distinct.
+        // A different provider may reuse the name — "Claude API — Work" and
+        // "OpenAI API — Work" are already distinct.
         XCTAssertEqual(
             ProviderAccountStore.uniqueName("Personal", kind: .claude, existing: existing),
             "Personal"
@@ -3909,7 +3909,7 @@ final class FeatureLogicTests: XCTestCase {
             accountStatus: [kimi.id: .keyRejected]
         )
 
-        XCTAssertEqual(sections.map(\.title), ["Local (Ollama)", "Claude — Work", "Kimi"])
+        XCTAssertEqual(sections.map(\.title), ["Local (Ollama)", "Claude API — Work", "Kimi"])
         XCTAssertNil(sections[0].account)
         XCTAssertEqual(sections[1].models, ["claude-sonnet-4-5"])
         XCTAssertNil(sections[1].emptyMessage)

--- a/LocusTests/ProviderAccountsModelTests.swift
+++ b/LocusTests/ProviderAccountsModelTests.swift
@@ -85,3 +85,42 @@ final class ProviderAccountsModelTests: XCTestCase {
     }
 
 }
+
+extension ProviderAccountsModelTests {
+    func testClaudePlanPreservesAPIAccountAndUsesManagedEndpoints() async throws {
+        let api = ProviderAccount(kind: .claude)
+        let plan = ProviderAccount(kind: .claudePlan)
+        XCTAssertEqual(api.kind.rawValue, "claude")
+        XCTAssertEqual(api.kind.marketingName, "Claude API")
+        XCTAssertTrue(api.kind.requiresAPIKey)
+        XCTAssertEqual(plan.kind.rawValue, "claude_plan")
+        XCTAssertFalse(plan.kind.requiresAPIKey)
+        XCTAssertFalse(plan.kind.supportsImageGeneration)
+        XCTAssertEqual(plan.managedHomeIdentifier, plan.id.uuidString)
+        XCTAssertNotEqual(plan.managedHomeIdentifier, ProviderAccount(kind: .claudePlan).managedHomeIdentifier)
+        let decoded = try JSONDecoder().decode(ProviderAccount.self, from: JSONEncoder().encode(plan))
+        XCTAssertEqual(decoded.id, plan.id)
+        XCTAssertEqual(decoded.kind, .claudePlan)
+        BackendStub.respond(toPath: "/api/claude/account") { request in
+            XCTAssertTrue(request.query?.contains(plan.id.uuidString) == true)
+            return ["status": "signed_in", "runtime_available": true, "plan_type": "max"]
+        }
+        BackendStub.respond(toPath: "/api/claude/usage") { _ in
+            ["status": "signed_in", "rate_limits": ["rateLimits": [:]], "activity": [:]]
+        }
+        let model = makeModel()
+        model.providerAccounts = [plan]
+        await model.refreshChatGPTAccount(for: plan)
+        XCTAssertEqual(model.accountStatus[plan.id], .signedIn(email: nil, plan: "max"))
+        XCTAssertTrue(BackendStub.requestPaths.contains("/api/claude/usage"))
+        XCTAssertFalse(BackendStub.requestPaths.contains("/api/chatgpt/account"))
+        XCTAssertNil(model.chatGPTUsageByAccount[plan.id]?.rateLimits.rateLimits?.primary)
+    }
+
+    func testClaudePlanHasNoInventedReasoningOrContextDefaults() {
+        XCTAssertEqual(ProviderKind.claudePlan.curatedModels, ["default"])
+        XCTAssertEqual(ProviderKind.claudePlan.publishedReasoningEfforts(for: "sonnet"), [])
+        XCTAssertNil(ProviderKind.claudePlan.publishedContextWindow(for: "sonnet"))
+        XCTAssertNil(AccountEditorView.blocker(kind: .claudePlan, resolvedBaseURL: "", keyStored: false, typedKey: ""))
+    }
+}

--- a/Tools/BundleBackend.sh
+++ b/Tools/BundleBackend.sh
@@ -38,6 +38,15 @@ if [[ -z "${LOCUS_BUNDLE_CODEX:-}" \
     LOCUS_BUNDLE_CODEX="component"
 fi
 
+if [[ -z "${LOCUS_BUNDLE_CLAUDE:-}" ]]; then
+    if [[ "${CONFIGURATION:-}" == "Release" \
+        && ( "${TARGET_NAME:-}" == "Locus" || "${TARGET_NAME:-}" == "LocusX" ) ]]; then
+        LOCUS_BUNDLE_CLAUDE="component"
+    else
+        LOCUS_BUNDLE_CLAUDE="build"
+    fi
+fi
+
 if [[ "${mode}" == "skip" ]]; then
     echo "note: LOCUS_BUNDLE_MODE=skip — agent runtime not bundled."
     exit 0
@@ -83,6 +92,27 @@ write_provenance() {
 }
 
 write_provenance
+
+bundle_claude_helper() {
+    [[ "${LOCUS_BUNDLE_CLAUDE}" == "skip" ]] && return 0
+    local arch="$(/usr/bin/uname -m)"
+    local claude_cache="${repo_root}/.claude-runtime/${arch}"
+    python3 "${script_dir}/PrepareClaudeRuntime.py" --target "macos-${arch}" --output "${claude_cache}"
+    /bin/mkdir -p "${resources}/ThirdPartyLicenses/claude"
+    for name in LICENSE NOTICE PROVENANCE; do
+        copy_without_extended_metadata "${claude_cache}/${name}" "${resources}/ThirdPartyLicenses/claude/${name}"
+    done
+    [[ "${LOCUS_BUNDLE_CLAUDE}" == "component" ]] && return 0
+    local helper="${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Helpers/claude"
+    /bin/mkdir -p "${helper:h}"
+    copy_without_extended_metadata "${claude_cache}/claude" "${helper}"
+    local entitlements="${repo_root}/Config/CodexCodeModeHost.entitlements"
+    if [[ "${ENABLE_APP_SANDBOX:-NO}" == "YES" ]]; then
+        entitlements="${repo_root}/Config/CodexCodeModeHostSandbox.entitlements"
+    fi
+    /usr/bin/codesign --force --options runtime --entitlements "${entitlements}" \
+        --identifier io.sparktales.locus.claude --sign "${EXPANDED_CODE_SIGN_IDENTITY:--}" "${helper}"
+}
 
 bundle_codex_helper() {
     # build      embed the helpers in the app (App Store build, local Debug)
@@ -339,6 +369,7 @@ if ! bundle_standalone; then
     exit 1
 fi
 bundle_codex_helper
+bundle_claude_helper
 if [[ "${LOCUS_EDITION:-locus}" == "locusx" ]]; then
     "${script_dir}/PrepareWalletArchive.sh"
 fi

--- a/Tools/PackageClaudeComponent.sh
+++ b/Tools/PackageClaudeComponent.sh
@@ -1,0 +1,46 @@
+#!/bin/zsh
+# Package the pinned official Claude runtime for the existing component feed.
+set -euo pipefail
+out_dir="${1:?usage: PackageClaudeComponent.sh <output-directory>}"
+script_dir="${0:A:h}"
+repo_root="${script_dir:h}"
+arch="${LOCUS_COMPONENT_ARCH:-$(uname -m)}"
+identity="${LOCUS_SIGN_IDENTITY:?set LOCUS_SIGN_IDENTITY to a Developer ID Application identity}"
+cache="${repo_root}/.claude-runtime/${arch}"
+python3 "${script_dir}/PrepareClaudeRuntime.py" --target "macos-${arch}" --output "${cache}"
+mkdir -p "${out_dir}"
+staging="$(mktemp -d "${TMPDIR:-/tmp}/locus-claude-component.XXXXXX")"
+trap 'rm -rf "${staging}"' EXIT
+for name in claude LICENSE NOTICE PROVENANCE; do
+    ditto --norsrc --noextattr --noqtn "${cache}/${name}" "${staging}/${name}"
+done
+codesign --force --timestamp --options runtime --entitlements "${repo_root}/Config/CodexCodeModeHost.entitlements" --identifier io.sparktales.locus.claude --sign "${identity}" "${staging}/claude"
+codesign --verify --strict -R='=identifier "io.sparktales.locus.claude" and anchor apple generic and certificate leaf[subject.OU] = "4X4RJA7GMD"' "${staging}/claude"
+python3 - "${staging}" "${out_dir}" "${arch}" "${repo_root}" <<'PY'
+import hashlib, json, os, subprocess, sys
+from pathlib import Path
+staging, output, arch, root = Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3], Path(sys.argv[4])
+manifest = json.loads((root / 'Config/ClaudeRuntime.json').read_text())
+version = manifest['runtime_version']
+provenance = json.loads((staging / 'PROVENANCE').read_text())
+provenance.update(delivery='component', binary_sha256=hashlib.sha256((staging / 'claude').read_bytes()).hexdigest())
+(staging / 'PROVENANCE').write_text(json.dumps(provenance, indent=2) + '\n')
+archive = output / f'claude-plan-{version}-{arch}.zip'
+subprocess.run(['/usr/bin/ditto', '-c', '-k', str(staging), str(archive)], check=True)
+feed_path = output / 'components.json'
+feed = json.loads(feed_path.read_text()) if feed_path.exists() else {'schemaVersion': 1, 'components': []}
+feed['components'] = [r for r in feed['components'] if (r['id'], r['arch']) != ('claude-plan', arch)]
+feed['components'].append({'id': 'claude-plan', 'version': version, 'arch': arch,
+    'minAppVersion': os.environ.get('LOCUS_COMPONENT_MIN_APP_VERSION', '2.0.0'),
+    'url': os.environ.get('LOCUS_COMPONENT_BASE_URL', 'https://github.com/nahid-sparktales/locus/releases/latest/download') + '/' + archive.name,
+    'sha256': hashlib.sha256(archive.read_bytes()).hexdigest(), 'downloadBytes': archive.stat().st_size,
+    'installedBytes': sum(p.stat().st_size for p in staging.iterdir())})
+feed_path.write_text(json.dumps(feed, indent=2) + '\n')
+PY
+if [[ "${LOCUS_NOTARIZE:-0}" == "1" ]]; then
+    version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["runtime_version"])' "${repo_root}/Config/ClaudeRuntime.json")"
+    xcrun notarytool submit "${out_dir}/claude-plan-${version}-${arch}.zip" \
+        --key "${LOCUS_ASC_KEY_PATH:?set LOCUS_ASC_KEY_PATH}" \
+        --key-id "${LOCUS_ASC_KEY_ID:?set LOCUS_ASC_KEY_ID}" \
+        --issuer "${LOCUS_ASC_ISSUER_ID:?set LOCUS_ASC_ISSUER_ID}" --wait --timeout 30m
+fi

--- a/Tools/PackageComponents.sh
+++ b/Tools/PackageComponents.sh
@@ -157,6 +157,11 @@ with open(sys.argv[1], "w", encoding="utf-8") as handle:
     handle.write("\n")
 PYEOF
 
+if [[ "${LOCUS_BUNDLE_CLAUDE:-component}" != "skip" ]]; then
+    LOCUS_SIGN_IDENTITY="${identity}" LOCUS_COMPONENT_ARCH="${arch}" \
+        "${script_dir}/PackageClaudeComponent.sh" "${out_dir}"
+fi
+
 echo
 echo "Component:     ${archive}"
 echo "Feed:          ${out_dir}/components.json"
@@ -165,4 +170,4 @@ echo "Download:      $(( download_bytes / 1000000 )) MB"
 echo "Installed:     $(( installed_bytes / 1000000 )) MB"
 echo "SHA-256:       ${sha}"
 echo
-echo "Upload ${archive_name} and components.json to the same GitHub release as Locus-macOS.zip."
+echo "Upload all component archives and components.json to the same GitHub release as Locus-macOS.zip."

--- a/Tools/PackageRemoteRuntime.py
+++ b/Tools/PackageRemoteRuntime.py
@@ -18,6 +18,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--runtime', type=Path, required=True)
 parser.add_argument('--codex-helper', type=Path, required=True)
 parser.add_argument('--codex-code-mode-host', type=Path, required=True)
+parser.add_argument('--claude-helper', type=Path)
 parser.add_argument('--target', choices=['linux-x86_64', 'linux-arm64', 'macos-arm64'], required=True)
 parser.add_argument('--output', type=Path, required=True)
 args = parser.parse_args()
@@ -36,6 +37,11 @@ files = {}
 for path in sorted(args.runtime.rglob('*')):
     if path.is_file() and '__pycache__' not in path.parts and path.suffix != '.pyc':
         files[path.relative_to(args.runtime).as_posix()] = path
+if args.claude_helper:
+    version = subprocess.run([str(args.claude_helper.resolve()), '--version'], capture_output=True, text=True, timeout=20)
+    if version.returncode or not version.stdout.startswith('2.1.259 '):
+        parser.error('The Claude runtime must be pinned to version 2.1.259.')
+    files['claude-runtime'] = args.claude_helper
 files['codex-app-server'] = args.codex_helper
 files['codex-code-mode-host'] = args.codex_code_mode_host
 manifest = {'version': 1, 'protocol_version': 1, 'target': args.target, 'codex_version': '0.147.0',

--- a/Tools/PrepareAgentRuntime.sh
+++ b/Tools/PrepareAgentRuntime.sh
@@ -84,7 +84,8 @@ fi
     --target "${workdir}/site-packages" \
     --requirement "${requirements_lock}"
 /bin/rm -rf \
-    "${workdir}/site-packages/bin"
+    "${workdir}/site-packages/bin" \
+    "${workdir}/site-packages/claude_agent_sdk/_bundled"
 
 # Pre-compile EVERYTHING — stdlib included. The bundle is sealed by the app's
 # code signature after this; a .pyc written at first launch would break the

--- a/Tools/PrepareClaudeRuntime.py
+++ b/Tools/PrepareClaudeRuntime.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Extract Anthropic's runtime from a checksum-pinned official SDK wheel."""
+import argparse
+import hashlib
+import io
+import json
+import os
+import platform
+import subprocess
+import urllib.request
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def prepare(target: str, output: Path) -> Path:
+    manifest = json.loads((ROOT / 'Config/ClaudeRuntime.json').read_text())
+    tags = {'macos-arm64': 'macosx_11_0_arm64', 'macos-x86_64': 'macosx_11_0_x86_64',
+            'linux-arm64': 'manylinux_2_17_aarch64', 'linux-x86_64': 'manylinux_2_17_x86_64'}
+    entry = next(row for row in manifest['wheels'] if tags[target] in row['filename'])
+    output.mkdir(parents=True, exist_ok=True)
+    helper = output / 'claude'
+    provenance = output / 'PROVENANCE'
+    if helper.exists() and provenance.exists():
+        previous = json.loads(provenance.read_text())
+        if previous.get('wheel_sha256') == entry['sha256'] and previous.get('binary_sha256') == hashlib.sha256(helper.read_bytes()).hexdigest():
+            return helper
+    with urllib.request.urlopen(entry['url'], timeout=120) as response:
+        data = response.read()
+    if hashlib.sha256(data).hexdigest() != entry['sha256']:
+        raise ValueError('Claude runtime wheel checksum did not match the pinned manifest')
+    with zipfile.ZipFile(io.BytesIO(data)) as archive:
+        binary = archive.read('claude_agent_sdk/_bundled/claude')
+        license_path = next(name for name in archive.namelist() if name.endswith('/licenses/LICENSE'))
+        license_text = archive.read(license_path)
+    temporary = output / 'claude.pending'
+    temporary.write_bytes(binary)
+    temporary.chmod(0o755)
+    # Verify before publishing. This runs only on the build target itself.
+    version = subprocess.run([str(temporary.resolve()), '--version'], capture_output=True, text=True, timeout=20, check=True).stdout
+    if not version.startswith(manifest['runtime_version'] + ' '):
+        raise ValueError('Claude runtime version did not match the pinned manifest')
+    os.replace(temporary, helper)
+    (output / 'LICENSE').write_bytes(license_text)
+    (output / 'NOTICE').write_text('Claude Agent SDK by Anthropic. The bundled Claude Code runtime is governed by Anthropic terms.\nhttps://code.claude.com/docs/en/legal-and-compliance\n')
+    provenance.write_text(json.dumps({'sdk_version': manifest['sdk_version'], 'runtime_version': manifest['runtime_version'],
+        'wheel_url': entry['url'], 'wheel_sha256': entry['sha256'], 'binary_sha256': hashlib.sha256(binary).hexdigest()}, indent=2) + '\n')
+    return helper
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--target', default=('macos' if platform.system() == 'Darwin' else 'linux') + '-' + ('arm64' if platform.machine() in {'arm64', 'aarch64'} else 'x86_64'))
+    parser.add_argument('--output', type=Path, default=ROOT / '.claude-runtime')
+    args = parser.parse_args()
+    print(prepare(args.target, args.output))

--- a/agent/ollama_code/api/__init__.py
+++ b/agent/ollama_code/api/__init__.py
@@ -7,6 +7,7 @@ from . import (
     automation_workflows,
     capsules,
     chat_transport,
+    claude,
     continuity,
     evaluations,
     event_triggers,
@@ -46,6 +47,7 @@ _ROUTE_MODULES = (
     workspace,
     extensions,
     chat_transport,
+    claude,
 )
 
 

--- a/agent/ollama_code/api/chat_transport.py
+++ b/agent/ollama_code/api/chat_transport.py
@@ -55,7 +55,9 @@ async def ws_codex_broker(ws: WebSocket) -> None:
         operation = str(request.get("op") or "")
         # Resolve once per connection so an active-account switch cannot move
         # a worker's thread or tool replies to another account mid-turn.
-        if "codex_home_id" in request:
+        if request.get("provider") == "claude_plan":
+            manager = svc.claude_for(request.get("claude_account_id"))
+        elif "codex_home_id" in request:
             home_id = request["codex_home_id"]
             if not isinstance(home_id, str):
                 raise ValueError("ChatGPT account home id must be a string")
@@ -186,6 +188,7 @@ async def ws_codex_broker(ws: WebSocket) -> None:
                     event_handler=forward_event,
                     should_interrupt=interrupted.is_set,
                     timeout=float(request.get("timeout") or 1_800),
+                    **({"max_turns": int(request.get("max_turns") or 40)} if request.get("provider") == "claude_plan" else {}),
                     **({"client_message_id": str(request["client_message_id"])}
                        if request.get("client_message_id") else {}),
                 )

--- a/agent/ollama_code/api/claude.py
+++ b/agent/ollama_code/api/claude.py
@@ -1,0 +1,113 @@
+"""Secret-free Claude subscription account endpoints."""
+from typing import Any
+
+from fastapi import APIRouter, Body, HTTPException, Query
+
+from ..capabilities import enabled
+from ..codex_app_server import CodexAppServerError
+from .providers import ServiceDependency
+
+
+def manager_for(service, account_id):
+    if not enabled("claude_plan_v1"):
+        raise HTTPException(404, "Claude plan support is not enabled in this release.")
+    try:
+        return service.claude_for(account_id)
+    except ValueError as error:
+        raise HTTPException(422, str(error)) from error
+
+
+def account_payload(service, account_id):
+    manager = manager_for(service, account_id)
+    if not manager.available:
+        return {"status": "runtime_unavailable", "runtime_available": False,
+                "message": "Install Claude plan support to sign in."}
+    try:
+        raw = manager.account()
+    except CodexAppServerError as error:
+        return {"status": "runtime_unavailable", "runtime_available": True, "message": str(error)}
+    identity = raw.get("account") or {}
+    signing = bool(getattr(manager, "_login", None) and manager._login[1].poll() is None)
+    return {"status": "signed_in" if identity else "signing_in" if signing else "signed_out",
+            "runtime_available": True, "runtime_version": raw.get("runtimeVersion"),
+            "email": identity.get("email"), "plan_type": identity.get("planType"),
+            "message": "" if identity else "Sign in with a Claude subscription."}
+
+
+def account(service: ServiceDependency, account_id: str = Query(...)):
+    return account_payload(service, account_id)
+
+
+def login_start(service: ServiceDependency, body: dict[str, Any] = Body(...)):
+    manager = manager_for(service, body.get("account_id"))
+    try:
+        result = manager.start_login()
+    except CodexAppServerError as error:
+        raise HTTPException(409, str(error)) from error
+    return {"status": "signing_in", "login_id": result["loginId"], "auth_url": result["authUrl"]}
+
+
+def login_cancel(service: ServiceDependency, body: dict[str, Any] = Body(...)):
+    manager = manager_for(service, body.get("account_id"))
+    try:
+        manager.cancel_login(body.get("login_id"))
+    except CodexAppServerError as error:
+        raise HTTPException(409, str(error)) from error
+    return account_payload(service, body["account_id"])
+
+
+def logout(service: ServiceDependency, body: dict[str, Any] = Body(...)):
+    manager = manager_for(service, body.get("account_id"))
+    try:
+        manager.logout()
+    except CodexAppServerError as error:
+        raise HTTPException(409, str(error)) from error
+    return account_payload(service, body["account_id"])
+
+
+def models(service: ServiceDependency, account_id: str = Query(...)):
+    state = account_payload(service, account_id)
+    if state["status"] != "signed_in":
+        return {**state, "models": []}
+    try:
+        rows = manager_for(service, account_id).models()
+    except CodexAppServerError as error:
+        raise HTTPException(503, str(error)) from error
+    return {"status": "signed_in", "models": [
+        {"id": row["model"], "display_name": row.get("displayName") or row["model"],
+         "description": row.get("description", ""), "is_default": bool(row.get("isDefault")),
+         "supported_reasoning_efforts": row.get("supportedReasoningEfforts", [])} for row in rows]}
+
+
+def usage(service: ServiceDependency, account_id: str = Query(...)):
+    state = account_payload(service, account_id)
+    raw = manager_for(service, account_id).usage()
+    window = None
+    if raw.get("utilization") is not None:
+        window = {"usedPercent": min(100, max(0, round(raw["utilization"] * 100))),
+                  "resetsAt": raw.get("resets_at"), "windowDurationMins": None}
+    return {"status": state["status"], "plan_type": state.get("plan_type"),
+            "rate_limits": {"rateLimits": {"primary": window}}, "activity": {},
+            "limit_status": raw.get("status"), "observed_at": raw.get("observed_at"),
+            "message": "Usage has not been reported yet." if not raw else ""}
+
+
+def select_claude(service, body):
+    if any(key in body for key in ("api_key", "base_url", "remote_base_url", "token", "authorization")):
+        raise HTTPException(422, "Claude plan accounts reject API credentials and endpoint overrides.")
+    account_id = body.get("account_id")
+    manager = manager_for(service, account_id)
+    try:
+        service.core.use_claude_plan(account_id=account_id, model=str(body.get("model") or "default"),
+            account_label=str(body.get("account_label") or "Claude plan"), manager=manager,
+            reasoning_effort=str(body.get("reasoning_effort") or ""))
+    except (ValueError, CodexAppServerError) as error:
+        raise HTTPException(409, str(error)) from error
+    return service.core.provider_state()
+
+
+def register_routes(router: APIRouter):
+    for path, handler in (("account", account), ("models", models), ("usage", usage)):
+        router.add_api_route("/api/claude/" + path, handler, methods=["GET"])
+    for path, handler in (("login/start", login_start), ("login/cancel", login_cancel), ("logout", logout)):
+        router.add_api_route("/api/claude/" + path, handler, methods=["POST"])

--- a/agent/ollama_code/api/event_triggers.py
+++ b/agent/ollama_code/api/event_triggers.py
@@ -62,7 +62,7 @@ def _agent_route(
     provider = str(
         body.get("provider") or metadata.get("provider") or header.get("provider") or "ollama"
     ).strip()
-    if provider not in {"ollama", "remote", "chatgpt"}:
+    if provider not in {"ollama", "remote", "chatgpt", "claude_plan"}:
         raise HTTPException(422, "the agent provider is not supported")
     model = str(body.get("model") or metadata.get("model") or header.get("model") or "").strip()
     if not model:

--- a/agent/ollama_code/api/providers.py
+++ b/agent/ollama_code/api/providers.py
@@ -278,8 +278,12 @@ def set_provider(
 def _apply_provider(service: ChatService, body: dict[str, Any]) -> dict[str, Any]:
     """Apply a provider request after the service has reserved mutable state."""
     provider = str(body.get("provider") or "").strip().lower()
-    if provider not in ("ollama", "remote", "chatgpt"):
-        raise HTTPException(422, "provider must be 'ollama', 'remote', or 'chatgpt'")
+    if provider not in ("ollama", "remote", "chatgpt", "claude_plan"):
+        raise HTTPException(422, "provider must be 'ollama', 'remote', 'chatgpt', or 'claude_plan'")
+
+    if provider == "claude_plan":
+        from .claude import select_claude
+        return select_claude(service, body)
 
     if provider == "ollama":
         try:
@@ -354,7 +358,7 @@ def _apply_provider(service: ChatService, body: dict[str, Any]) -> dict[str, Any
 
 
 def models(service: ServiceDependency) -> dict[str, Any]:
-    if service.core.provider == "chatgpt":
+    if service.core.provider in {"chatgpt", "claude_plan"}:
         try:
             return {
                 "models": [
@@ -370,7 +374,7 @@ def models(service: ServiceDependency) -> dict[str, Any]:
                             else None
                         ),
                     }
-                    for item in service.codex.models()
+                    for item in service.core.codex_manager.models()
                     if item.get("model") or item.get("id")
                 ],
                 "current": service.core.model,

--- a/agent/ollama_code/api/reusable_checks.py
+++ b/agent/ollama_code/api/reusable_checks.py
@@ -71,9 +71,9 @@ async def propose(service: Service, body: dict = Body()):
 
     def generate():
         client = service.core.client
-        if service.core.provider == 'chatgpt':
+        if service.core.provider in {'chatgpt', 'claude_plan'}:
             from ..orchestration import ChatGPTTeamClient
-            client = ChatGPTTeamClient(service.codex, 180)
+            client = ChatGPTTeamClient(service.core.codex_manager, 180)
         response = tracked_chat(service.core, client, model=service.core.model, purpose='check_generation', context=context,
                                 messages=[{'role': 'system', 'content': instructions}, {'role': 'user', 'content': prompt}],
                                 tools=[], should_stop=service.core._should_stop_stream)

--- a/agent/ollama_code/api/runtime.py
+++ b/agent/ollama_code/api/runtime.py
@@ -26,7 +26,11 @@ async def status(request: Request):
         provider = configuration.get("provider", "remote")
         readiness = "configured; credentials not yet verified"
         try:
-            if provider == "chatgpt":
+            if provider == "claude_plan":
+                from .claude import account_payload
+                account = await asyncio.to_thread(account_payload, runtime.service, str(configuration.get("account_id") or ""))
+                readiness = account["status"]
+            elif provider == "chatgpt":
                 from .providers import chatgpt_account_payload
                 account = await asyncio.to_thread(chatgpt_account_payload, runtime.service, home_id=str(configuration.get("codex_home_id") or ""))
                 readiness = account["status"]

--- a/agent/ollama_code/api/runtime_deploy.py
+++ b/agent/ollama_code/api/runtime_deploy.py
@@ -282,7 +282,7 @@ async def remote_control(runtime_id: str, request: Request, body: dict = Body(de
 
 
 async def remote_login(runtime_id: str, request: Request, body: dict = Body(default_factory=dict)):
-    return await invoke(remotes(request).login, runtime_id, str(body.get("account_id", "")), str(body.get("method", "device_code")))
+    return await invoke(remotes(request).login, runtime_id, str(body.get("account_id", "")), str(body.get("method", "device_code")), str(body.get("provider", "chatgpt")))
 
 
 async def retry_deployment(runtime_id: str, deployment_id: str, request: Request):

--- a/agent/ollama_code/api/schedules.py
+++ b/agent/ollama_code/api/schedules.py
@@ -394,7 +394,7 @@ def _dispatch_companion_chat(
         if environment == "worktree" and not is_git_workspace(workspace_root):
             raise HTTPException(422, "mobile worktrees require a Git repository")
         provider = str(body.get("provider") or "ollama").strip().lower()
-        if provider not in {"ollama", "remote", "chatgpt"}:
+        if provider not in {"ollama", "remote", "chatgpt", "claude_plan"}:
             raise HTTPException(422, "provider is unavailable")
         account = str(body.get("provider_account_id") or "").strip()
         model = str(body.get("model") or "").strip()

--- a/agent/ollama_code/api/system.py
+++ b/agent/ollama_code/api/system.py
@@ -28,7 +28,15 @@ def _busy_http() -> HTTPException:
 
 
 def health(service: ServiceDependency) -> dict[str, Any]:
-    if service.core.provider == "chatgpt":
+    if service.core.provider == "claude_plan":
+        from .claude import account_payload
+        try:
+            state = account_payload(service, service.core.account_id)
+        except HTTPException as exc:
+            state = {"status": "runtime_unavailable", "message": str(exc.detail)}
+        reachable = state["status"] == "signed_in"
+        error = None if reachable else state.get("message")
+    elif service.core.provider == "chatgpt":
         state = chatgpt_account_payload(service)
         reachable = state["status"] == "signed_in"
         error = None if reachable else state.get("message") or "ChatGPT sign-in is required"
@@ -243,7 +251,7 @@ def response_preview(service: ServiceDependency, body: dict[str, Any] = Body(def
     core.config = copy.deepcopy(service.core.config)
     if "provider" in body:
         provider = body["provider"]
-        if not isinstance(provider, str) or provider not in {"ollama", "remote", "chatgpt"}:
+        if not isinstance(provider, str) or provider not in {"ollama", "remote", "chatgpt", "claude_plan"}:
             raise HTTPException(422, "unknown selected provider")
         core.provider = provider
         # A profile preview must not borrow the active account's identity.

--- a/agent/ollama_code/capabilities.py
+++ b/agent/ollama_code/capabilities.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 
 CAPABILITY_ENV = {
+    "claude_plan_v1": "LOCUS_CAPABILITY_CLAUDE_PLAN_V1",
     "persistent_goals_v1": "LOCUS_CAPABILITY_PERSISTENT_GOALS_V1",
     "durable_runs": "LOCUS_CAPABILITY_DURABLE_RUNS",
     "recovery_controls": "LOCUS_CAPABILITY_RECOVERY_CONTROLS",

--- a/agent/ollama_code/capsule_execution.py
+++ b/agent/ollama_code/capsule_execution.py
@@ -44,7 +44,7 @@ def execution_manifest(capsule: dict, profiles: list[dict], run_id: str) -> dict
         members.append(reviewer)
     for profile in members:
         route = profile.get("route") or {}
-        if route.get("provider") in {"chatgpt", "ollama"} or str(route.get("account_kind") or "").lower().replace("_", "") == "kimicode":
+        if route.get("provider") in {"chatgpt", "claude_plan", "ollama"} or str(route.get("account_kind") or "").lower().replace("_", "") == "kimicode":
             profile["metering"] = "self_hosted"
             profile.pop("input_cost_per_million", None)
             profile.pop("output_cost_per_million", None)

--- a/agent/ollama_code/chat_service.py
+++ b/agent/ollama_code/chat_service.py
@@ -17,6 +17,7 @@ from typing import Any
 from fastapi import WebSocket
 
 from . import __version__
+from .claude_runtime import ClaudeBrokerClient, ClaudeManagerRegistry
 from .codex_app_server import CodexBrokerClient, CodexManagerRegistry, codex_home_for_account
 from .core import AgentCore
 from .devserver import DevServerError, DevServerManager
@@ -128,12 +129,20 @@ class ChatService:
             None if broker_url else CodexManagerRegistry(client_version=__version__)
         )
         self._codex_home_id = ""
+        self._claude_registry = ClaudeManagerRegistry() if not broker_url else None
+        self._claude_broker = ClaudeBrokerClient(broker_url, broker_token) if broker_url else None
         if self._codex_registry is not None:
             self._codex_registry.add_listener(self._on_codex_event)
         else:
             self._codex_pinned.add_listener(self._on_codex_event)
         configure_chatgpt_manager(self.codex, account_resolver=self.codex_for)
         self.core.codex_manager = self.codex
+        if self._claude_registry is not None:
+            self._claude_registry.add_listener(self._on_claude_event)
+        from .orchestration import configure_claude_manager
+        configure_claude_manager(self.claude_for)
+        if core.provider == "claude_plan" and core.account_id:
+            core.codex_manager = self.claude_for(core.account_id)
         self.worker_id = uuid.uuid4().hex
         self.loop: asyncio.AbstractEventLoop | None = None
         self.queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
@@ -269,8 +278,19 @@ class ChatService:
         set_chatgpt_manager(manager, account_resolver=self.codex_for)
         return manager
 
+    def claude_for(self, account_id: str) -> Any:
+        if self._claude_broker is not None:
+            return self._claude_broker.for_account(account_id)
+        return self._claude_registry.manager(account_id)
+
+    def _on_claude_event(self, event: dict[str, Any]) -> None:
+        kind = "claude_usage_updated" if event.get("method") == "account/rateLimits/updated" else "claude_account_updated"
+        self.emit({"type": kind, "account_id": event.get("params", {}).get("account_id")})
+
     def close_codex(self) -> None:
         """Shut down every helper this service started."""
+        if self._claude_registry is not None:
+            self._claude_registry.close_all()
         if self._codex_registry is not None:
             self._codex_registry.close_all()
         elif self._codex_pinned is not None:
@@ -1020,7 +1040,7 @@ class ChatService:
         return str(result.get("text") or "Identity Vault action completed.")[:32_000]
 
     def resolve_identity_context(self, references: list[str]) -> list[dict[str, str]]:
-        if not self.core.identity_mode or not self.core.tool_registry.identity_enabled or self.core.provider == "chatgpt":
+        if not self.core.identity_mode or not self.core.tool_registry.identity_enabled or self.core.provider in {"chatgpt", "claude_plan"}:
             raise ValueError("Identity Vault context is unavailable.")
         references = source_references(references)
         request_id = uuid.uuid4().hex

--- a/agent/ollama_code/claude_runtime.py
+++ b/agent/ollama_code/claude_runtime.py
@@ -1,0 +1,570 @@
+"""Subscription transport using Anthropic's SDK, with Locus-owned tools.
+
+The event contract matches the existing managed-turn adapter (whose internal
+names predate multiple subscription providers). No OAuth token is read by Locus.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import queue
+import re
+import subprocess
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .capabilities import enabled
+from .codex_app_server import CodexAppServerError, CodexBrokerClient
+from .paths import APP_DIR
+from .proxy import sanitized_child_environment
+
+SDK_VERSION = "0.2.152"
+RUNTIME_VERSION = "2.1.259"
+_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class ClaudeRuntimeError(CodexAppServerError):
+    pass
+
+
+def claude_home_for_account(account_id: str) -> Path:
+    if not isinstance(account_id, str) or not _ID.fullmatch(account_id):
+        raise ValueError("A valid Claude account identifier is required")
+    return APP_DIR / "claude-accounts" / account_id
+
+
+def subscription_environment(home: Path) -> dict[str, str]:
+    env = sanitized_child_environment()
+    # API keys, alternate hosts, cloud billing and token overrides must never
+    # take precedence over the runtime's own subscription login.
+    for key in list(env):
+        if key.startswith(("ANTHROPIC_", "CLAUDE_", "AWS_", "GOOGLE_", "AZURE_", "LOCUS_")):
+            env.pop(key, None)
+    # SDK subprocesses merge options.env over os.environ; explicit tombstones
+    # are required to remove inherited values there as well as in auth commands.
+    for key in os.environ:
+        if key not in env:
+            env[key] = ""
+    env.update(CLAUDE_CONFIG_DIR=str(home), DISABLE_AUTOUPDATER="1")
+    return env
+
+
+class ClaudeManager:
+    supports_parity = False
+    provider = "claude_plan"
+
+    def __init__(self, account_id: str):
+        self.home = claude_home_for_account(account_id)
+        self.account_id = account_id
+        self.path = os.environ.get("LOCUS_CLAUDE_RUNTIME_PATH", "")
+        self.runtime_version = "claude-sdk-" + SDK_VERSION
+        self._listeners: list = []
+        self._locks: dict[str, threading.Lock] = {}
+        self._guard = threading.RLock()
+        self._login: tuple[str, subprocess.Popen] | None = None
+        self._limits: dict[str, Any] = {}
+        self._stops: set[threading.Event] = set()
+        self._verified_binary = None
+
+    @property
+    def available(self):
+        return (enabled("claude_plan_v1") and bool(self.path)
+                and os.path.isfile(self.path) and os.access(self.path, os.X_OK)
+                and importlib.util.find_spec("claude_agent_sdk") is not None)
+
+    def _ready(self):
+        if not self.available:
+            raise ClaudeRuntimeError("Claude plan support is disabled or its runtime is not installed.")
+        from importlib.metadata import version
+        if version("claude-agent-sdk") != SDK_VERSION:
+            raise ClaudeRuntimeError("The Claude SDK version does not match this Locus release.")
+        stamp = (os.stat(self.path).st_mtime_ns, os.stat(self.path).st_size)
+        if stamp != self._verified_binary:
+            try:
+                result = subprocess.run([self.path, "--version"], capture_output=True, text=True, timeout=15,
+                                        env=subscription_environment(self.home))
+            except (OSError, subprocess.TimeoutExpired) as error:
+                raise ClaudeRuntimeError("Claude could not start. Retry installing its runtime.") from error
+            if result.returncode or not result.stdout.startswith(RUNTIME_VERSION + " "):
+                raise ClaudeRuntimeError("The installed Claude runtime is incompatible. Install the matching component.")
+            self._verified_binary = stamp
+        self.home.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.home.chmod(0o700)
+
+    def add_listener(self, listener):
+        self._listeners.append(listener)
+
+    def _notify(self, method):
+        for listener in self._listeners:
+            listener({"method": method, "params": {"account_id": self.account_id}})
+
+    def _auth(self, operation):
+        self._ready()
+        try:
+            result = subprocess.run([self.path, "auth", operation], env=subscription_environment(self.home),
+                                    capture_output=True, text=True, timeout=30, cwd=str(self.home))
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise ClaudeRuntimeError("Claude authentication could not finish. Refresh the account and retry.") from error
+        if operation == "logout":
+            if result.returncode:
+                raise ClaudeRuntimeError("Claude sign-out failed.")
+            return {}
+        try:
+            return json.loads(result.stdout)
+        except (ValueError, TypeError) as error:
+            raise ClaudeRuntimeError("Claude returned an unreadable authentication status.") from error
+
+    def account(self, *, refresh=False):
+        del refresh  # The official runtime owns token refresh.
+        raw = self._auth("status")
+        signed = raw.get("loggedIn") is True and raw.get("authMethod") == "claude.ai"
+        return {"account": ({"type": self.provider, "email": raw.get("email"),
+                             "planType": raw.get("subscriptionType")} if signed else None),
+                "runtimeVersion": self.runtime_version}
+
+    def start_login(self, **_):
+        self._ready()
+        with self._guard:
+            if self._login and self._login[1].poll() is None:
+                raise ClaudeRuntimeError("Claude sign-in is already in progress.")
+            login_id = uuid.uuid4().hex
+            try:
+                process = subprocess.Popen([self.path, "auth", "login"],
+                    env=subscription_environment(self.home), cwd=str(self.home),
+                    stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                    text=True, bufsize=1)
+            except OSError as error:
+                raise ClaudeRuntimeError("Claude sign-in could not start. Refresh the account and retry.") from error
+            self._login = (login_id, process)
+        urls: queue.Queue = queue.Queue()
+
+        def read_login():
+            # Only return the official login URL, never persist subprocess output.
+            try:
+                for line in process.stdout:
+                    match = re.search(r"https://(?:claude\.ai|platform\.claude\.com|console\.anthropic\.com)/[^\s\x1b]+", line)
+                    if match:
+                        urls.put(match.group(0))
+                process.wait()
+            finally:
+                process.stdout.close()
+                urls.put("")
+                self._notify("account/login/completed")
+        threading.Thread(target=read_login, daemon=True).start()
+        try:
+            url = urls.get(timeout=10)
+        except queue.Empty:
+            url = ""  # The runtime may have opened the system browser itself.
+        return {"loginId": login_id, "authUrl": url}
+
+    def cancel_login(self, login_id):
+        with self._guard:
+            if not self._login or self._login[0] != login_id:
+                raise ClaudeRuntimeError("Unknown Claude sign-in attempt.")
+            process = self._login[1]
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=3)
+            self._login = None
+
+    def logout(self):
+        with self._guard:
+            if self._stops:
+                raise ClaudeRuntimeError("Stop this account's active tasks before signing out.")
+            if self._login:
+                self.cancel_login(self._login[0])
+            self._auth("logout")
+            self._limits = {}
+        self._notify("account/updated")
+
+    def models(self):
+        self._ready()
+        from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+        async def discover():
+            async with ClaudeSDKClient(options=ClaudeAgentOptions(
+                cli_path=self.path, cwd=str(self.home), env=subscription_environment(self.home),
+                tools=[], setting_sources=[], strict_mcp_config=True,
+            )) as client:
+                return await client.get_server_info() or {}
+        try:
+            info = asyncio.run(asyncio.wait_for(discover(), timeout=30))
+        except Exception:
+            # The runtime's default remains usable when metadata is unavailable;
+            # do not substitute an API catalog or guess effort capabilities.
+            info = {}
+        rows = info.get("models") or []
+        return [{"model": row.get("value") or row.get("id"),
+                 "displayName": row.get("displayName") or row.get("value"),
+                 "description": (row.get("description") or "").split(" · $")[0],
+                 "isDefault": row.get("value") == "default",
+                 "supportedReasoningEfforts": [{"effort": value} for value in row.get("supportedEffortLevels", [])]
+                    if row.get("supportsEffort") else []}
+                for row in rows if isinstance(row, dict) and (row.get("value") or row.get("id"))] or [
+                    {"model": "default", "displayName": "Claude default", "isDefault": True}]
+
+    def usage(self):
+        return dict(self._limits)
+
+    def _file(self, thread_id):
+        if not isinstance(thread_id, str) or not _ID.fullmatch(thread_id):
+            raise ValueError("Invalid Claude session identifier")
+        return self.home / "locus-sessions" / (thread_id + ".json")
+
+    def _save(self, thread_id, state):
+        path = self._file(thread_id)
+        path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        with tmp.open("w") as stream:
+            os.chmod(tmp, 0o600)
+            json.dump(state, stream)
+        tmp.replace(path)
+
+    def _load(self, thread_id):
+        try:
+            state = json.loads(self._file(thread_id).read_text())
+        except (OSError, ValueError) as error:
+            raise ClaudeRuntimeError("Claude session is unavailable for this account.") from error
+        if state.get("account_id") != self.account_id:
+            raise ClaudeRuntimeError("Claude session belongs to another account.")
+        return state
+
+    def start_thread(self, *, model, cwd, base_instructions="", tools=(), **_):
+        self._ready()
+        thread_id = uuid.uuid4().hex
+        self._save(thread_id, {"account_id": self.account_id, "model": model, "cwd": cwd,
+            "instructions": base_instructions, "tools": list(tools), "sdk_session": None,
+            "input": 0, "output": 0, "confirmed": [], "uncertain": False})
+        return thread_id
+
+    def resume_thread(self, thread_id, *, model, cwd, **_):
+        state = self._load(thread_id)
+        if state["uncertain"]:
+            raise ClaudeRuntimeError("Claude's previous turn has an uncertain outcome; it was not replayed.")
+        if state["model"] != model or state["cwd"] != cwd:
+            raise ClaudeRuntimeError("Claude session settings changed.")
+        return thread_id
+
+    def read_thread(self, thread_id):
+        state = self._load(thread_id)
+        return {"thread": {"id": thread_id, "turns": [
+            {"items": [{"type": "userMessage", "clientId": value}]} for value in state["confirmed"]]}}
+
+    def steer_turn(self, *_, **__):
+        # Queued guidance is delivered through the existing Locus outbox after
+        # this turn completes. Never acknowledge input the SDK hasn't accepted.
+        raise ClaudeRuntimeError("No active steer channel; guidance will run at the next turn boundary.")
+
+    def run_turn(self, *, thread_id, text, model="", effort="", input_items=None,
+                 client_message_id="", tool_handler=None, event_handler=None,
+                 should_interrupt=None, on_tick=None, timeout=1800, output_schema=None, max_turns=40):
+        self._ready()
+        if should_interrupt and should_interrupt():
+            turn = {"status": "interrupted"}
+            if event_handler:
+                event_handler({"method": "turn/completed", "params": {"threadId": thread_id, "turn": turn}})
+            return turn
+        with self._guard:
+            lock = self._locks.setdefault(thread_id, threading.Lock())
+        if not lock.acquire(blocking=False):
+            raise ClaudeRuntimeError("This Claude session already has an active turn.")
+        events: queue.Queue = queue.Queue()
+        stop = threading.Event()
+        with self._guard:
+            self._stops.add(stop)
+        try:
+            state = self._load(thread_id)
+            if state["uncertain"]:
+                raise ClaudeRuntimeError("Claude's previous turn has an uncertain outcome; resume requires review.")
+            def execute():
+                try:
+                    result = asyncio.run(self._execute(state, thread_id, text, input_items, effort,
+                        output_schema, client_message_id, events, stop, timeout, max_turns))
+                    events.put(("done", result))
+                except Exception as error:
+                    events.put(("error", error))
+            worker = threading.Thread(target=execute, daemon=True)
+            worker.start()
+            deadline = time.monotonic() + timeout + 10
+            while True:
+                if should_interrupt and should_interrupt():
+                    stop.set()
+                if on_tick:
+                    on_tick()
+                if time.monotonic() > deadline:
+                    stop.set()
+                    raise ClaudeRuntimeError("Claude turn timed out; its outcome may be uncertain.")
+                try:
+                    kind, payload = events.get(timeout=.1)
+                except queue.Empty:
+                    continue
+                if kind == "event" and event_handler:
+                    event_handler(payload)
+                elif kind == "tool":
+                    name, arguments, call_id, reply = payload
+                    try:
+                        result = tool_handler(name, arguments, call_id) if tool_handler and not stop.is_set() else "Not run: tool access is unavailable."
+                        reply.put({"content": [{"type": "text", "text": str(result)}],
+                                   "isError": str(result).startswith(("Error", "Permission denied", "Not run:"))})
+                    except Exception as error:
+                        reply.put({"content": [{"type": "text", "text": str(error)}], "isError": True})
+                elif kind == "error":
+                    raise ClaudeRuntimeError(str(payload)) from payload
+                elif kind == "done":
+                    return payload
+        finally:
+            stop.set()
+            if 'worker' in locals():
+                worker.join(timeout=5)
+            def release():
+                with self._guard:
+                    self._stops.discard(stop)
+                lock.release()
+            if 'worker' in locals() and worker.is_alive():
+                # Never let another turn or logout race an SDK still unwinding.
+                def release_after_worker():
+                    worker.join()
+                    release()
+                threading.Thread(target=release_after_worker, daemon=True).start()
+            else:
+                release()
+
+    async def _execute(self, state, thread_id, text, input_items, effort, output_schema,
+                       client_id, events, stop, timeout, max_turns):
+        from claude_agent_sdk import (
+            ClaudeAgentOptions,
+            ClaudeSDKClient,
+            PermissionResultDeny,
+            SdkMcpTool,
+            create_sdk_mcp_server,
+        )
+
+        def emit(method, **params):
+            events.put(("event", {"method": method, "params": {"threadId": thread_id, **params}}))
+
+        sdk_tools = []
+        for schema in state["tools"]:
+            function = schema.get("function", schema)
+            name = function["name"]
+
+            async def call(arguments, name=name):
+                if stop.is_set():
+                    return {"content": [{"type": "text", "text": "Task interrupted."}], "isError": True}
+                reply: queue.Queue = queue.Queue()
+                events.put(("tool", (name, arguments, uuid.uuid4().hex, reply)))
+                while not stop.is_set():
+                    try:
+                        return reply.get_nowait()
+                    except queue.Empty:
+                        await asyncio.sleep(.05)
+                return {"content": [{"type": "text", "text": "Task interrupted."}], "isError": True}
+            sdk_tools.append(SdkMcpTool(name=name, description=function.get("description", ""),
+                input_schema=function.get("parameters", {"type": "object", "properties": {}}), handler=call))
+
+        async def deny_native(*_):
+            return PermissionResultDeny(message="Only Locus tools are available in this task.")
+
+        options = ClaudeAgentOptions(cli_path=self.path, cwd=state["cwd"],
+            env=subscription_environment(self.home), model=None if state["model"] == "default" else state["model"],
+            system_prompt=state["instructions"], tools=[], setting_sources=[], strict_mcp_config=True,
+            mcp_servers={"locus": create_sdk_mcp_server(name="locus", tools=sdk_tools)} if sdk_tools else {},
+            allowed_tools=["mcp__locus__" + tool.name for tool in sdk_tools],
+            can_use_tool=deny_native, permission_mode="dontAsk", include_partial_messages=True,
+            resume=state["sdk_session"], effort=effort or None, max_turns=max(1, int(max_turns)),
+            output_format={"type": "json_schema", "schema": output_schema} if output_schema else None)
+        content = []
+        for item in input_items or [{"type": "text", "text": text}]:
+            if item.get("type") == "text":
+                content.append({"type": "text", "text": item.get("text", "")})
+            elif item.get("type") == "image":
+                match = re.fullmatch(r"data:(image/[\w.+-]+);base64,(.+)", item.get("url", ""), re.S)
+                if not match:
+                    raise ClaudeRuntimeError("Claude attachments require validated image data.")
+                content.append({"type": "image", "source": {"type": "base64", "media_type": match[1], "data": match[2]}})
+
+        async def prompt():
+            yield {"type": "user", "message": {"role": "user", "content": content}}
+
+        async def run():
+            async with ClaudeSDKClient(options=options) as client:
+                async def monitor():
+                    while not stop.is_set():
+                        await asyncio.sleep(.1)
+                    await client.interrupt()
+                monitor_task = asyncio.create_task(monitor())
+                try:
+                    if stop.is_set():
+                        turn = {"status": "interrupted"}
+                        emit("turn/completed", turn=turn)
+                        return turn
+                    state["uncertain"] = True
+                    self._save(thread_id, state)
+                    await client.query(prompt())
+                    message_id = uuid.uuid4().hex
+                    blocks: dict[int, dict] = {}
+                    result = None
+                    account_error = None
+                    async for message in client.receive_response():
+                        kind = type(message).__name__
+                        if kind == "SystemMessage" and message.subtype == "init":
+                            state["sdk_session"] = message.data.get("session_id")
+                            self._save(thread_id, state)
+                        elif kind == "StreamEvent":
+                            event = message.event
+                            index = event.get("index", 0)
+                            if event.get("type") == "message_start":
+                                message_id = event.get("message", {}).get("id") or uuid.uuid4().hex
+                                blocks = {}
+                            elif event.get("type") == "content_block_start":
+                                block = event.get("content_block", {})
+                                blocks[index] = {"id": f"{message_id}-{index}", "type": block.get("type"), "text": ""}
+                            elif event.get("type") == "content_block_delta":
+                                block = blocks.get(index)
+                                delta = event.get("delta", {})
+                                if block and block["type"] in {"text", "thinking"}:
+                                    value = delta.get("text") or delta.get("thinking") or ""
+                                    block["text"] += value
+                                    emit("item/agentMessage/delta" if block["type"] == "text" else "item/reasoning/summaryTextDelta",
+                                         itemId=block["id"], delta=value)
+                        elif kind == "AssistantMessage":
+                            account_error = getattr(message, "error", None) or account_error
+                            if account_error == "authentication_failed":
+                                self._notify("account/updated")
+                            elif account_error == "rate_limit":
+                                self._limits = {"status": "rejected", "observed_at": time.time()}
+                                self._notify("account/rateLimits/updated")
+                            has_tools = any(type(block).__name__ == "ToolUseBlock" for block in message.content)
+                            for index, block in enumerate(message.content):
+                                block_kind = type(block).__name__
+                                if block_kind not in {"TextBlock", "ThinkingBlock"}:
+                                    continue
+                                item_id = blocks.get(index, {}).get("id", f"{message_id}-{index}")
+                                value = getattr(block, "text", None) or getattr(block, "thinking", "")
+                                if index not in blocks:
+                                    emit("item/agentMessage/delta" if block_kind == "TextBlock" else "item/reasoning/summaryTextDelta", itemId=item_id, delta=value)
+                                item = {"id": item_id, "type": "agentMessage" if block_kind == "TextBlock" else "reasoning"}
+                                if block_kind == "TextBlock":
+                                    item.update(text=value, phase="commentary" if has_tools else "final_answer")
+                                else:
+                                    item["summary"] = [{"text": value}]
+                                emit("item/completed", item=item)
+                            blocks = {}
+                            message_id = uuid.uuid4().hex
+                        elif kind == "RateLimitEvent":
+                            info = message.rate_limit_info
+                            self._limits = {"status": info.status, "observed_at": time.time(),
+                                "resets_at": info.resets_at, "utilization": info.utilization,
+                                "window": info.rate_limit_type}
+                            self._notify("account/rateLimits/updated")
+                        elif kind == "ResultMessage":
+                            result = message
+                    if result is None:
+                        raise ClaudeRuntimeError("Claude disconnected without a completed turn; outcome is uncertain.")
+                    state["sdk_session"] = result.session_id
+                    usage = result.usage or {}
+                    inp = sum(int(usage.get(key) or 0) for key in ("input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"))
+                    out = int(usage.get("output_tokens") or 0)
+                    state["input"] += inp
+                    state["output"] += out
+                    state["uncertain"] = False
+                    if client_id:
+                        state["confirmed"].append(client_id)
+                        emit("item/completed", item={"type": "userMessage", "clientId": client_id})
+                    self._save(thread_id, state)
+                    emit("thread/tokenUsage/updated", tokenUsage={"modelCalls": max(int(getattr(result, "num_turns", 1)), 1), "last": {"inputTokens": inp, "outputTokens": out},
+                        "total": {"inputTokens": state["input"], "outputTokens": state["output"]}})
+                    status = "interrupted" if stop.is_set() else "failed" if result.is_error else "completed"
+                    turn = {"status": status}
+                    if status == "failed":
+                        guidance = {
+                            "authentication_failed": "Claude authentication expired. Refresh this account in Manage Accounts or sign in again.",
+                            "rate_limit": "This Claude subscription has reached its usage limit. Check this account's usage and retry after its limit resets.",
+                            "billing_error": "Claude could not authorize this subscription. Check the selected account in Manage Accounts.",
+                        }
+                        turn["error"] = {"message": guidance.get(account_error) or "; ".join(result.errors or []) or "Claude turn failed."}
+                    if result.structured_output is not None:
+                        turn["structured_output"] = result.structured_output
+                    emit("turn/completed", turn=turn)
+                    return turn
+                finally:
+                    monitor_task.cancel()
+                    await asyncio.gather(monitor_task, return_exceptions=True)
+        return await asyncio.wait_for(run(), timeout=timeout)
+
+    def complete(self, *, model, cwd, base_instructions, prompt, output_schema=None, timeout=300):
+        thread_id = self.start_thread(model=model, cwd=cwd, base_instructions=base_instructions)
+        text, usage = [], {}
+
+        def collect(event):
+            nonlocal usage
+            if event["method"] == "item/agentMessage/delta":
+                text.append(event["params"]["delta"])
+            elif event["method"] == "thread/tokenUsage/updated":
+                usage = event["params"]["tokenUsage"]
+        turn = self.run_turn(thread_id=thread_id, text=prompt, output_schema=output_schema,
+                             event_handler=collect, timeout=timeout)
+        answer = json.dumps(turn["structured_output"]) if "structured_output" in turn else "".join(text)
+        return {"text": answer, "turn": turn, "usage": usage, "threadId": thread_id}
+
+    def close(self):
+        with self._guard:
+            for stop in self._stops:
+                stop.set()
+            if self._login:
+                self.cancel_login(self._login[0])
+
+
+class ClaudeBrokerClient(CodexBrokerClient):
+    provider = "claude_plan"
+
+    @property
+    def runtime_version(self):
+        return "claude-sdk-" + SDK_VERSION
+
+    def for_account(self, home_id):
+        claude_home_for_account(home_id)
+        return ClaudeBrokerClient(self.url, self.token, home_id=home_id)
+
+    def _request(self, operation, payload=None):
+        request = super()._request(operation, payload)
+        request["provider"] = "claude_plan"
+        request["claude_account_id"] = self._home_id
+        return request
+
+
+class ClaudeManagerRegistry:
+    def __init__(self):
+        self._managers: dict[str, ClaudeManager] = {}
+        self._guard = threading.Lock()
+        self._listeners = []
+
+    def manager(self, account_id):
+        claude_home_for_account(account_id)
+        with self._guard:
+            if account_id not in self._managers:
+                manager = ClaudeManager(account_id)
+                for listener in self._listeners:
+                    manager.add_listener(listener)
+                self._managers[account_id] = manager
+            return self._managers[account_id]
+
+    def add_listener(self, listener):
+        with self._guard:
+            self._listeners.append(listener)
+            for manager in self._managers.values():
+                manager.add_listener(listener)
+
+    def close_all(self):
+        with self._guard:
+            managers = list(self._managers.values())
+        for manager in managers:
+            manager.close()

--- a/agent/ollama_code/codex_app_server.py
+++ b/agent/ollama_code/codex_app_server.py
@@ -1033,6 +1033,7 @@ class CodexBrokerClient:
         should_interrupt: Callable[[], bool] | None = None,
         on_tick: Callable[[], None] | None = None,
         timeout: float = 1_800,
+        max_turns: int | None = None,
     ) -> dict[str, Any]:
         with self._connect() as socket:
             socket.send(json.dumps(self._request("turn_run", {
@@ -1044,6 +1045,7 @@ class CodexBrokerClient:
                 "effort": effort,
                 "output_schema": output_schema,
                 "timeout": timeout,
+                **({"max_turns": max_turns} if max_turns is not None else {}),
             })))
             while True:
                 if on_tick is not None:

--- a/agent/ollama_code/collaboration_bridge.py
+++ b/agent/ollama_code/collaboration_bridge.py
@@ -179,7 +179,7 @@ class AgentWorkerRuntime:
         core.perms.allowed = set(permission_state["allowed"])
         if spec.mode == "edit":
             core.helper_parent_checkout = parent.cwd
-        core.codex_manager = _HelperNativeTransport(svc.codex, self)
+        core.codex_manager = _HelperNativeTransport(svc.core.codex_manager if parent.provider == "claude_plan" else svc.codex, self)
         core.session.session_id = spec.agent_id
         core._suppress_turn_done = True
         core.configure_agent(

--- a/agent/ollama_code/config.py
+++ b/agent/ollama_code/config.py
@@ -49,6 +49,10 @@ DEFAULTS: dict[str, Any] = {
     "remote_api_key": "",
     # Managed ChatGPT-plan routing. Only identifiers and display metadata are
     # persisted; OAuth credentials remain in the isolated App Server home.
+    "claude_plan_account_id": "",
+    "claude_plan_account_label": "",
+    "claude_plan_model": "default",
+    "claude_plan_reasoning_effort": "",
     "chatgpt_account_id": "",
     "chatgpt_account_label": "",
     "chatgpt_model": "",
@@ -99,7 +103,7 @@ DEFAULTS: dict[str, Any] = {
 
 PERMISSION_MODES = ("ask", "accept_edits", "bypass")
 
-PROVIDERS = ("ollama", "remote", "chatgpt")
+PROVIDERS = ("ollama", "remote", "chatgpt", "claude_plan")
 
 #: Environment variables searched for the remote API key, in order.
 REMOTE_API_KEY_ENV = (
@@ -230,6 +234,8 @@ def load_config() -> dict[str, Any]:
     for key in (
         "remote_auth_style", "remote_account_label", "remote_account_id",
         "remote_reasoning_effort",
+        "claude_plan_account_id", "claude_plan_account_label", "claude_plan_model",
+        "claude_plan_reasoning_effort",
         "chatgpt_account_id", "chatgpt_account_label", "chatgpt_model",
         "chatgpt_reasoning_effort",
     ):

--- a/agent/ollama_code/context_preservation.py
+++ b/agent/ollama_code/context_preservation.py
@@ -15,7 +15,7 @@ def protected_context(core: Any) -> str:
             text = message.get("content")
             if isinstance(text, str) and text and text not in inputs:
                 inputs.append(text)
-    if core.provider == "chatgpt" and core.chatgpt_parity_active(core._turn_allows_tools):
+    if core.provider in {"chatgpt", "claude_plan"} and core.chatgpt_parity_active(core._turn_allows_tools):
         from .sessions import strip_prompt_decoration
         inputs = [strip_prompt_decoration(text) for text in inputs]
     sections = ["Current task context. Preserve the user's constraints; later corrections supersede earlier instructions."]
@@ -112,7 +112,7 @@ def runtime_context(core: Any) -> str:
         return ""
     runtime, capsule = getattr(core, "goal_runtime", None), getattr(core, "capsule_runtime", None)
     if runtime is None and capsule is None:
-        return protected_context(core) if core.provider == "chatgpt" and core._turn_allows_tools else ""
+        return protected_context(core) if core.provider in {"chatgpt", "claude_plan"} and core._turn_allows_tools else ""
     from .sessions import SessionStore
     inputs = SessionStore.authoritative_inputs(core.session.path)
     state = {"requests_and_corrections": [m["content"] for m in inputs],
@@ -131,7 +131,7 @@ def runtime_context(core: Any) -> str:
 
 def summarize_section(core: Any, messages: list[dict]) -> Any:
     """Use the selected route, including the native route, with ordinary metering."""
-    if core.provider != "chatgpt":
+    if core.provider not in {"chatgpt", "claude_plan"}:
         from .task_usage_ledger import reserve_core, settle_core
         task_call = reserve_core(core, stage="compaction", messages=messages)
         reservation = core.goal_runtime.reserve() if core.goal_runtime is not None else None

--- a/agent/ollama_code/core.py
+++ b/agent/ollama_code/core.py
@@ -387,9 +387,9 @@ class AgentCore:
                 )
                 self.config["remote_api_key"] = ""
                 self._build_remote_client()
-        elif self.provider == "chatgpt":
-            self.host = "chatgpt://managed"
-            self.model = model or str(self.config.get("chatgpt_model") or "")
+        elif self.provider in {"chatgpt", "claude_plan"}:
+            self.host = f"{self.provider}://managed"
+            self.model = model or str(self.config.get(f"{self.provider}_model") or "")
         # Injected by ChatService. Keeping the transport out of Swift and out
         # of provider clients prevents managed OAuth from ever entering an API
         # key route.
@@ -525,7 +525,7 @@ class AgentCore:
         self._event_handler = handler
 
     def _emit(self, event: dict[str, Any]) -> None:
-        if self.provider == "chatgpt" and not self.identity_mode and event.get("type") == "tool_result":
+        if self.provider in {"chatgpt", "claude_plan"} and not self.identity_mode and event.get("type") == "tool_result":
             self.session.append_strict({"type": "native_tool_observation", **{
                 key: event[key] for key in ("tool", "id", "summary", "result", "ok", "denied") if key in event}})
         if getattr(self, "capsule_runtime", None) is not None and event.get("type") == "model_usage":
@@ -788,8 +788,8 @@ class AgentCore:
         actually is. Strong self-identifying models broke through; compliant
         ones did not, which read as smart models "knowing" and others not.
         """
-        if self.provider == "chatgpt":
-            provider_label = str(self.config.get("chatgpt_account_label") or "ChatGPT plan")
+        if self.provider in {"chatgpt", "claude_plan"}:
+            provider_label = str(self.config.get(f"{self.provider}_account_label") or ("Claude plan" if self.provider == "claude_plan" else "ChatGPT plan"))
         elif self.provider == "remote":
             provider_label = (
                 str(self.config.get("remote_account_label") or "").strip()
@@ -957,7 +957,7 @@ class AgentCore:
 
     def ensure_model(self) -> str | None:
         """Pick a model if unset. Returns a warning or None. Raises OllamaError."""
-        if self.provider == "chatgpt":
+        if self.provider in {"chatgpt", "claude_plan"}:
             return None
         names = [m.get("name") for m in self.client.list_models() if m.get("name")]
         if not names:
@@ -991,7 +991,7 @@ class AgentCore:
         endpoint that states its own window deserves a working meter just as
         much as a local model does.
         """
-        if self.provider == "chatgpt":
+        if self.provider in {"chatgpt", "claude_plan"}:
             # App Server reports token activity, but does not expose a stable
             # context-window contract through account/model metadata.
             self.context_limit = 0
@@ -1539,6 +1539,36 @@ class AgentCore:
         self.reset_system_message()
         self._emit_info()
 
+    def use_claude_plan(self, *, account_id: str, model: str, account_label: str,
+                        manager: Any, reasoning_effort: str = "") -> None:
+        from .capabilities import enabled
+        if not enabled("claude_plan_v1"):
+            raise ValueError("Claude plan support is not enabled in this release.")
+        identity = manager.account().get("account")
+        if not identity or identity.get("type") != "claude_plan":
+            raise ValueError("Sign in with a Claude subscription before selecting this account.")
+        selected = model.strip() or "default"
+        if reasoning_effort and hasattr(manager, "models"):
+            row = next((row for row in manager.models() if (row.get("model") or row.get("id")) == selected), {})
+            supported = {option["effort"] for option in row.get("supportedReasoningEfforts", [])}
+            if reasoning_effort not in supported:
+                raise ValueError("The selected Claude model does not advertise that reasoning effort.")
+        changed = self.provider != "claude_plan" or self.account_id != account_id or self.model != selected
+        self.provider = "claude_plan"
+        self.host = "claude_plan://managed"
+        self.model = selected
+        self.codex_manager = manager
+        self.config.update(provider=self.provider, claude_plan_account_id=account_id,
+                           claude_plan_account_label=account_label.strip() or "Claude plan",
+                           claude_plan_model=selected, claude_plan_reasoning_effort=reasoning_effort,
+                           remote_api_key="")
+        if changed:
+            self._clear_chatgpt_thread()
+        self.refresh_context_limit()
+        save_config(self.config)
+        self.reset_system_message()
+        self._emit_info()
+
     def provider_state(self) -> dict[str, Any]:
         """Provider description for the UI. Never includes the key itself."""
         return {
@@ -1571,8 +1601,8 @@ class AgentCore:
     @property
     def account_label(self) -> str:
         """The app's name for the account in use, or "" for local Ollama."""
-        if self.provider == "chatgpt":
-            return str(self.config.get("chatgpt_account_label") or "ChatGPT plan")
+        if self.provider in {"chatgpt", "claude_plan"}:
+            return str(self.config.get(f"{self.provider}_account_label") or ("Claude plan" if self.provider == "claude_plan" else "ChatGPT plan"))
         if self.provider != "remote":
             return ""
         return str(self.config.get("remote_account_label") or "")
@@ -1580,8 +1610,8 @@ class AgentCore:
     @property
     def account_id(self) -> str:
         """The stable native account identifier for persisted background work."""
-        if self.provider == "chatgpt":
-            return str(self.config.get("chatgpt_account_id") or "")
+        if self.provider in {"chatgpt", "claude_plan"}:
+            return str(self.config.get(f"{self.provider}_account_id") or "")
         if self.provider != "remote":
             return ""
         return str(self.config.get("remote_account_id") or "")
@@ -1604,7 +1634,7 @@ class AgentCore:
         wanted = name.strip()
         if not wanted:
             return None
-        if self.provider == "chatgpt":
+        if self.provider in {"chatgpt", "claude_plan"}:
             return wanted
         if self.provider == "remote" and not getattr(self.client, "lists_models", True):
             return wanted
@@ -1623,8 +1653,8 @@ class AgentCore:
         self.model = name
         # Each provider remembers its own model, so switching back and forth
         # does not clobber the other's choice.
-        if self.provider == "chatgpt":
-            self.config["chatgpt_model"] = name
+        if self.provider in {"chatgpt", "claude_plan"}:
+            self.config[f"{self.provider}_model"] = name
             self._clear_chatgpt_thread()
         elif self.provider == "remote":
             self.config["remote_model"] = name
@@ -2054,11 +2084,11 @@ class AgentCore:
         self._compaction_completion_pending = 0
         self._compaction_call_limit = model_call_limit
         self._context_preservation_error = ""
-        if self.identity_mode and self.provider == "chatgpt":
+        if self.identity_mode and self.provider in {"chatgpt", "claude_plan"}:
             self._emit({"type": "error", "message": "Private Identity tasks require a local model or an API provider. Managed ChatGPT retains provider-side thread context and cannot use private vault sources."})
             self._emit({"type": "turn_done", "reason": "error", "duration_ms": 0})
             return
-        if self.provider == "chatgpt":
+        if self.provider in {"chatgpt", "claude_plan"}:
             self._run_chatgpt_turn(
                 user_text,
                 decider,
@@ -2147,7 +2177,7 @@ class AgentCore:
             persist=persist_user_message,
         )
         parity = self.chatgpt_parity_active(allow_tools)
-        effort = str(self.config.get("chatgpt_reasoning_effort") or "")
+        effort = str(self.config.get(f"{self.provider}_reasoning_effort") or "")
         if parity:
             # Codex-native contract: the helper applies the model's own base
             # prompt, tools mirror the Codex surface, and the fingerprint
@@ -2187,6 +2217,9 @@ class AgentCore:
                     instructions += "\n\n" + extension_prompt
             thread_options = None
             fingerprint = hashlib.sha256(json.dumps({
+                "provider": self.provider,
+                "account_id": self.account_id,
+                "session_id": self.session.session_id if self.provider == "claude_plan" else None,
                 "cwd": self.cwd,
                 "model": self.model,
                 "instructions": instructions,
@@ -2194,6 +2227,8 @@ class AgentCore:
             }, sort_keys=True, default=str).encode()).hexdigest()
         manager = self.codex_manager
         def run_managed(**kwargs):
+            if self.provider == "claude_plan":
+                kwargs["max_turns"] = dynamic_call_limit
             if self._interrupt.is_set():
                 return {"status": "interrupted"}
             # Older in-process adapters predate correlated turn/start input.
@@ -2215,14 +2250,14 @@ class AgentCore:
             if isinstance(completed, dict):
                 if completed.get("status") == "failed":
                     failure = completed.get("error") or {}
-                    raise CodexAppServerError(str(failure.get("message") or "ChatGPT turn failed"))
+                    raise CodexAppServerError(str(failure.get("message") or "Subscription turn failed"))
                 if completed.get("status") == "interrupted":
                     self._interrupt.set()
             return completed
 
         if manager is None:
             reason = "error"
-            self._emit({"type": "error", "message": "The ChatGPT runtime is unavailable."})
+            self._emit({"type": "error", "message": "The selected subscription runtime is unavailable."})
         else:
             try:
                 # The account home's config.toml must agree with the thread
@@ -2254,6 +2289,8 @@ class AgentCore:
                             )
                             self._chatgpt_thread_needs_resume = False
                         except CodexAppServerError:
+                            if self.provider == "claude_plan":
+                                raise
                             # App Server may have lost or compacted the stored
                             # thread. The Locus transcript is authoritative, so
                             # rebuild below without changing provider routes.
@@ -2497,7 +2534,7 @@ class AgentCore:
                             self._interrupt.set()
                         elif completed.get("status") == "failed":
                             failure = completed.get("error") or {}
-                            raise CodexAppServerError(str(failure.get("message") or "ChatGPT turn failed"))
+                            raise CodexAppServerError(str(failure.get("message") or "Subscription turn failed"))
                     if method in {"item/started", "item/completed"}:
                         user_item = params.get("item") or {}
                         if user_item.get("type") == "userMessage":
@@ -2599,7 +2636,7 @@ class AgentCore:
                                 prompt = max(int(last.get("inputTokens") or 0), 0)
                                 completion = max(int(last.get("outputTokens") or 0), 0)
                                 if prompt or completion:
-                                    native_model_calls += 1
+                                    native_model_calls += max(int(candidate.get("modelCalls") or 1), 1)
                                     native_prompt_tokens += prompt
                                     native_completion_tokens += completion
                                     self._emit({"type": "model_usage", "model_calls": native_model_calls + self._compaction_calls_pending,
@@ -2611,7 +2648,7 @@ class AgentCore:
                                     # the window is carrying.
                                     self._measured_prompt_tokens = prompt
                     elif method in {"item/commandExecution/requestApproval", "item/fileChange/requestApproval"}:
-                        raise RuntimeError("ChatGPT helper requested a disabled native approval")
+                        raise RuntimeError("Subscription helper requested a disabled native approval")
 
                 def handle_tool(name: str, arguments: dict[str, Any], call_id: str) -> str:
                     nonlocal native_tool_steps, native_tool_requests
@@ -2835,8 +2872,9 @@ class AgentCore:
                 reason = "interrupted" if self._interrupt.is_set() else "error"
                 self._emit({"type": "error", "message": str(error)})
                 # A crashed or incompatible helper thread is never silently
-                # reused. The canonical Locus transcript remains untouched.
-                self._clear_chatgpt_thread()
+                # reused. Claude keeps an uncertainty marker to prevent replay.
+                if self.provider != "claude_plan":
+                    self._clear_chatgpt_thread()
         # A later transport or delivery error cannot erase metered calls that
         # were already observed. Successful turns may include a larger totals
         # delta; retain it without adding the per-call counters twice.
@@ -3179,7 +3217,7 @@ class AgentCore:
             self._emit({"type": "error", "message": "Nothing to regenerate yet."})
             self._emit({"type": "turn_done", "reason": "error", "duration_ms": 0})
             return False
-        if self.provider == "chatgpt":
+        if self.provider in {"chatgpt", "claude_plan"}:
             original = dict(self.messages[index])
             self.messages = self.messages[:index]
             self.session = self._new_session_store()
@@ -4061,6 +4099,10 @@ class AgentCore:
         execution_lock: Any | None = None,
         track_active: bool = True,
     ) -> str:
+        if (self.provider == "claude_plan" and self.agent_mode in {"plan", "grill"}
+                and tc.name not in {"ask_user_question", "submit_plan", "todo_write", "attach_output_parts", "get_goal"}
+                and not self.tool_registry.is_read_only_tool(tc.name)):
+            return "Error: Plan mode does not allow this tool to change files or external state."
         if tc.name == "attach_output_parts":
             if (self.identity_mode or not self._turn_allows_tools or self.agent_role_contract
                     or not track_active or getattr(self, "helper_allowed_tools", None) is not None):
@@ -4387,13 +4429,13 @@ class AgentCore:
         if capsule_action:
             self.capsule_runtime.action_finished(call_id, result)
         if goal_action:
-            if self.provider != "chatgpt" and self._in_tool_call and track_active and not getattr(self, "_verification_running", False):
+            if self.provider not in {"chatgpt", "claude_plan"} and self._in_tool_call and track_active and not getattr(self, "_verification_running", False):
                 self._goal_pending_actions[id(tc)] = (call_id, ok, result)
             else:
                 self.goal_runtime.finish_action(call_id, ok=ok, result=result)
         activity_label = self._verified_activity_label(tc, effects) if ok else ""
         if activity_label:
-            if self.provider == "chatgpt":
+            if self.provider in {"chatgpt", "claude_plan"}:
                 self._persist_display_message({"role": "tool", "name": tc.name, "content": result,
                                                "_display_only": True, "_item_id": call_id,
                                                "_activity_label": activity_label})
@@ -4741,7 +4783,7 @@ class AgentCore:
             elif record.get("type") in {"plan_ready", "task_plan"} and isinstance(record.get("plan"), dict):
                 self.tool_ctx.plan_document = record["plan"]
         self._clear_chatgpt_thread()
-        if self.provider == "chatgpt":
+        if self.provider in {"chatgpt", "claude_plan"}:
             marker = SessionStore.chatgpt_thread_state(path)
             if marker is not None:
                 self._chatgpt_thread_id = str(marker["thread_id"])

--- a/agent/ollama_code/evaluation_runtime.py
+++ b/agent/ollama_code/evaluation_runtime.py
@@ -126,7 +126,10 @@ def run_evaluation_suite(
                 # authenticated proxy; they never launch another App Server.
                 evaluation_service.close_codex()
                 evaluation_service.codex = parent.codex
-                evaluation_service.core.codex_manager = parent.codex
+                evaluation_service.core.codex_manager = parent.core.codex_manager if parent.core.provider == "claude_plan" else parent.codex
+                evaluation_service.claude_for = parent.claude_for
+                from .orchestration import configure_claude_manager
+                configure_claude_manager(parent.claude_for)
                 evaluation_service.run_store = parent.run_store
                 evaluation_service.core.usage_store = parent.run_store
                 evaluation_service.core.mcp.task_store = parent.run_store

--- a/agent/ollama_code/evaluations.py
+++ b/agent/ollama_code/evaluations.py
@@ -428,7 +428,7 @@ def configuration_snapshot(core, case: dict, manifest: dict) -> dict:
              "mode": case.get("mode", "write"), "target": case.get("target", "team"),
              "model_version": config.get("model_version", "unreported"),
              "effort": config.get("chatgpt_reasoning_effort", config.get("reasoning_effort")),
-             "account_class": "subscription" if getattr(core, "provider", "") == "chatgpt" else "local" if getattr(core, "provider", "") == "ollama" else "metered",
+             "account_class": "subscription" if getattr(core, "provider", "") in {"chatgpt", "claude_plan"} else "local" if getattr(core, "provider", "") == "ollama" else "metered",
              "recipe": manifest.get("team") or {}, "profiles": profiles,
              "tools": "local_evaluation", "permissions": "isolated_workspace", "app_version": __import__("ollama_code").__version__}
     value["fingerprint"] = hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()

--- a/agent/ollama_code/model_usage.py
+++ b/agent/ollama_code/model_usage.py
@@ -108,7 +108,7 @@ def tracked_chat(core, client, *args, purpose='worker', context=None, runs=None,
 
 def tracked_native(core, call, *, purpose='worker', context=None, runs=None, **kwargs):
     context = dict(context or context_for(core, purpose))
-    context.update(provider='chatgpt', purpose=purpose)
+    context.update(provider=getattr(core, 'provider', None) or context.get('provider') or 'chatgpt', purpose=purpose)
     ledger = ledger_for(core, runs)
     invocation = ledger.begin(context, input_tokens=len(str(kwargs.get('text', ''))) // 3 + 128, output_tokens=8192)
     original = kwargs.get('event_handler')
@@ -134,7 +134,7 @@ def tracked_native(core, call, *, purpose='worker', context=None, runs=None, **k
                 seen.add(current)
                 if current[0] >= totals[0] and current[1] >= totals[1]:
                     totals = current
-                    calls += 1
+                    calls += max(count(token_usage.get("modelCalls")), 1)
                     usage = normalize_usage('openai', {key: max(current[index] - baseline[index], 0) for index, key in enumerate(('inputTokens', 'outputTokens', 'cachedInputTokens', 'reasoningOutputTokens'))})
                     usage['model_calls'] = calls
                     with ledger.runs._connect() as db:

--- a/agent/ollama_code/orchestration.py
+++ b/agent/ollama_code/orchestration.py
@@ -236,7 +236,7 @@ class AgentProfile:
             raise OrchestrationError(f"unknown metering class for {profile.name}")
         _validate_route(profile.route, profile.name)
         account_kind = str(profile.route.get("account_kind") or "").lower().replace("_", "")
-        if profile.route.get("provider") == "chatgpt" or account_kind == "kimicode":
+        if profile.route.get("provider") in {"chatgpt", "claude_plan"} or account_kind == "kimicode":
             # Subscription quota is not per-token API spending. Older/custom
             # manifests may carry metered rates; never charge those estimates
             # against the API-dollar budget for a known subscription route.
@@ -3026,6 +3026,13 @@ _TEAM_CODEX_BROKER = (
     if _TEAM_CODEX_BROKER_URL and _TEAM_CODEX_BROKER_TOKEN else None
 )
 _TEAM_CODEX_ACCOUNT_RESOLVER: Any = None
+_TEAM_CLAUDE_RESOLVER: Any = None
+
+
+def configure_claude_manager(resolver: Any) -> None:
+    global _TEAM_CLAUDE_RESOLVER
+    _TEAM_CLAUDE_RESOLVER = resolver
+
 
 
 def configure_chatgpt_manager(manager: Any, *, account_resolver: Any = None) -> None:
@@ -3055,6 +3062,12 @@ def _client(profile: AgentProfile):
     route = profile.route
     if route.get("provider") == "ollama":
         return OllamaClient(str(route.get("host") or "http://localhost:11434"), profile.timeout_seconds)
+    if route.get("provider") == "claude_plan":
+        if _TEAM_CLAUDE_RESOLVER is None:
+            raise OrchestrationError("The Claude runtime is unavailable.")
+        client = ChatGPTTeamClient(_TEAM_CLAUDE_RESOLVER(str(route.get("account_id") or "")), profile.timeout_seconds)
+        client.host = "claude_plan://managed"
+        return client
     if route.get("provider") == "chatgpt":
         # The module captures this before ChatService removes the environment
         # values, so tools and child processes never inherit the broker token.
@@ -3136,7 +3149,7 @@ def _validate_route(route: dict[str, Any], name: str) -> None:
         if not host:
             raise OrchestrationError(f"local route for {name} has no Ollama host")
         return
-    if provider == "chatgpt":
+    if provider in {"chatgpt", "claude_plan"}:
         if not str(route.get("account_id") or ""):
             raise OrchestrationError(f"ChatGPT route for {name} has no account id")
         forbidden = {"api_key", "base_url", "authorization", "token"}.intersection(route)

--- a/agent/ollama_code/runtime.py
+++ b/agent/ollama_code/runtime.py
@@ -16,6 +16,7 @@ from typing import Any
 import requests
 from websockets.asyncio.client import connect
 
+from .capabilities import enabled as capability_enabled
 from .runtime_store import PrivateStore, RuntimeStore, identifier
 
 TURN_COMMANDS = {"user_message", "retry_last", "evaluation_run"}
@@ -111,7 +112,7 @@ class RuntimeSupervisor:
                 "pending_approvals": self.store.decisions(), "max_active_chats": self.limit,
                 "active_work": sum(bool(worker.active_command) for worker in self.workers.values()),
                 "capabilities": {"durable_events": True, "background_schedules": True,
-                                 "desktop_requires_controller": True, "remote_chatgpt": True}}
+                                 "desktop_requires_controller": True, "remote_chatgpt": True, "remote_claude_plan": capability_enabled("claude_plan_v1")}}
 
     async def ensure_worker(self, session_id: str, workspace: str, *, keep_running: bool | None = None) -> Worker:
         identifier(session_id)

--- a/agent/ollama_code/runtime_automation.py
+++ b/agent/ollama_code/runtime_automation.py
@@ -111,7 +111,7 @@ class RuntimeAutomation:
             from .sessions import SessionMeta
             SessionMeta.update(session_id, agent_profile_id=str(automation_configuration["agent_id"]))
         account = automation_configuration.get("provider") or saved.get(f"account:{manifest.get('provider_account_id', '')}") or saved.get(f"worker:{session_id}", {}).get("/api/provider")
-        if not account and manifest.get("provider") in {"remote", "chatgpt"}:
+        if not account and manifest.get("provider") in {"remote", "chatgpt", "claude_plan"}:
             runtime.store.state(session_id, "waiting_for_account", "Provision the selected model account on this runtime to continue.")
             return
         command = {"type": "user_message", "text": run["request"], "mode": manifest.get("mode", "work"),

--- a/agent/ollama_code/runtime_install.py
+++ b/agent/ollama_code/runtime_install.py
@@ -117,11 +117,19 @@ def install(header, data):
     helper = subprocess.run([str(package / "codex-app-server"), "--version"], capture_output=True, text=True, timeout=20)
     if helper.returncode or not helper.stdout.strip().endswith(" 0.147.0"):
         raise ValueError("The packaged ChatGPT helper does not match pinned version 0.147.0")
+    if (package / "claude-runtime").exists():
+        claude = subprocess.run([str(package / "claude-runtime"), "--version"], capture_output=True, text=True, timeout=20)
+        if claude.returncode or not claude.stdout.startswith("2.1.259 "):
+            raise ValueError("The packaged Claude runtime does not match pinned version 2.1.259")
     python = str(package / "python/bin/python3")
     environment = {"PYTHONPATH": str(package / "source") + ":" + str(package / "site-packages"),
                    "OLLAMA_CODE_HOME": str(root / "profile"), "LOCUS_CODEX_HOME": str(root / "accounts"),
                    "LOCUS_CODEX_APP_SERVER_PATH": str(package / "codex-app-server"),
                    "LOCUS_RUNTIME_PACKAGE_ID": header["sha256"], "LOCUS_DOCUMENT_COORDINATOR": "1", "PYTHONDONTWRITEBYTECODE": "1", "PYTHONUNBUFFERED": "1"}
+    if (package / "claude-runtime").exists():
+        environment["LOCUS_CLAUDE_RUNTIME_PATH"] = str(package / "claude-runtime")
+        # Including the optional runtime is the release builder's explicit opt-in.
+        environment["LOCUS_CAPABILITY_CLAUDE_PLAN_V1"] = "1"
     check = subprocess.run([python, '-c', 'import sys; assert sys.version_info >= (3,10); import ollama_code.runtime'],
                            env={**os.environ, **environment}, capture_output=True, timeout=30)
     if check.returncode:

--- a/agent/ollama_code/runtime_remote.py
+++ b/agent/ollama_code/runtime_remote.py
@@ -153,7 +153,30 @@ class RemoteRuntimes:
         self.disconnect(key)
         return result
 
-    def login(self, key, account_id, method):
+    def login(self, key, account_id, method, provider="chatgpt"):
+        if provider == "claude_plan":
+            from urllib.parse import parse_qs, urlsplit
+            status = self.request(key, "GET", "/api/runtime")
+            if not status.get("capabilities", {}).get("remote_claude_plan"):
+                raise ValueError("This host does not advertise Claude plan support. Update and enable its runtime first.")
+            result = self.request(key, "POST", "/api/claude/login/start", {"account_id": account_id})
+            callback = parse_qs(urlsplit(result.get("auth_url", "")).query).get("redirect_uri", [""])[0]
+            address = urlsplit(callback)
+            if address.hostname in {"localhost", "127.0.0.1"} and address.port and address.port >= 1024:
+                existing = self.login_tunnels.pop(key, None)
+                if existing:
+                    existing.terminate()
+                base = ssh_arguments(self.record(key)["host"])
+                port = address.port
+                args = base[:-2] + ["-N", "-o", "ExitOnForwardFailure=yes", "-L", f"127.0.0.1:{port}:127.0.0.1:{port}"] + base[-2:]
+                process = subprocess.Popen(args, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                self.login_tunnels[key] = process
+                time.sleep(.3)
+                if process.poll() is not None:
+                    raise ValueError("The Claude login callback port is unavailable on this Mac.")
+            return result
+        if provider != "chatgpt":
+            raise ValueError("Unsupported subscription provider")
         if method == "browser":
             existing = self.login_tunnels.pop(key, None)
             if existing:

--- a/agent/ollama_code/runtime_snapshots.py
+++ b/agent/ollama_code/runtime_snapshots.py
@@ -14,7 +14,7 @@ MAX_FILE = 32 * 1024 * 1024
 MAX_SNAPSHOT = 512 * 1024 * 1024
 SECRET_NAME = re.compile(r"(^|/)(\.env(?:\..*)?|credentials(?:\..*)?|auth\.json|id_(?:rsa|ed25519)|.*\.(?:pem|p12|pfx|key))$", re.I)
 SECRET_CONTENT = re.compile(rb"-----BEGIN (?:RSA |OPENSSH |EC )?PRIVATE KEY-----|(?:sk-(?:proj-)?[A-Za-z0-9_-]{24,})|(?:AKIA[0-9A-Z]{16})|(?:gh[pousr]_[A-Za-z0-9]{30,})")
-OMIT = {".git", ".venv", "node_modules", "__pycache__", ".DS_Store", ".codex-app-server", "build", ".build", ".cache"}
+OMIT = {".git", ".venv", "node_modules", "__pycache__", ".DS_Store", ".codex-app-server", ".claude-runtime", "build", ".build", ".cache"}
 
 
 def digest(data: bytes) -> str:

--- a/agent/ollama_code/schedules.py
+++ b/agent/ollama_code/schedules.py
@@ -13,7 +13,7 @@ MAX_INTERVAL_SECONDS = 365 * 24 * 60 * 60
 SCHEDULE_MODES = {"ask", "work", "plan", "grill", "build"}
 SCHEDULE_RUNNERS = {"solo", "solo_swarm", "team"}
 SCHEDULE_ENVIRONMENTS = {"local", "worktree"}
-SCHEDULE_PROVIDERS = {"ollama", "remote", "chatgpt"}
+SCHEDULE_PROVIDERS = {"ollama", "remote", "chatgpt", "claude_plan"}
 INTERVAL_UNITS = {
     "minutes": 60,
     "hours": 60 * 60,
@@ -92,7 +92,7 @@ def normalize_schedule(value: Any, *, now: float) -> dict[str, Any]:
         raise ScheduleValidationError("team_id is required for a team schedule")
     provider = str(value.get("provider") or "ollama").strip().lower()
     if provider not in SCHEDULE_PROVIDERS:
-        raise ScheduleValidationError("provider must be ollama, remote, or chatgpt")
+        raise ScheduleValidationError("provider must be ollama, remote, chatgpt, or claude_plan")
     provider_account_id = str(value.get("provider_account_id") or "").strip()[:160]
     if provider != "ollama" and not provider_account_id:
         raise ScheduleValidationError("provider_account_id is required for hosted schedules")

--- a/agent/ollama_code/server.py
+++ b/agent/ollama_code/server.py
@@ -602,7 +602,7 @@ def _run_user_turn(
 
         try:
             swarm = SoloSwarmExecutor(
-                snapshot_route(svc.core, svc.codex),
+                snapshot_route(svc.core, svc.core.codex_manager if svc.core.provider == "claude_plan" else svc.codex),
                 emit=svc.emit,
                 should_stop=svc.core._should_stop_stream,
                 knowledge_search=knowledge_search,
@@ -1620,7 +1620,7 @@ def _parallel_writer_core(
     core.execution_path = checkout.execution_path
     core.task_metadata = checkout.as_dict()
     core.tool_ctx.memory_workspace = checkout.workspace_root
-    core.codex_manager = svc.codex
+    core.codex_manager = svc.claude_for(core.account_id) if core.provider == "claude_plan" else svc.codex
     core.mcp.task_store = svc.run_store
     from .model_usage import context_for
     core.usage_owner_task_id = context_for(svc.core)["task_id"]
@@ -2188,7 +2188,11 @@ def _install_writer_route(core: AgentCore, writer: AgentProfile) -> dict[str, An
     core.model = writer.model
     core.config["usage_rates"] = getattr(writer, "usage_rates", None) or {"input_tokens": getattr(writer, "input_cost_per_million", None) or None,
         "output_tokens": getattr(writer, "output_cost_per_million", None) or None}
-    if writer.route.get("provider") == "chatgpt":
+    if writer.route.get("provider") == "claude_plan":
+        core.use_claude_plan(account_id=str(writer.route.get("account_id") or ""),
+            model=writer.model, account_label=str(writer.route.get("account_label") or "Claude plan"),
+            manager=writer_client.broker, reasoning_effort=str(writer.route.get("reasoning_effort") or ""))
+    elif writer.route.get("provider") == "chatgpt":
         core.codex_manager = writer_client.broker
         core.provider = "chatgpt"
         core.host = "chatgpt://managed"

--- a/agent/ollama_code/solo_swarm.py
+++ b/agent/ollama_code/solo_swarm.py
@@ -99,7 +99,7 @@ def snapshot_route(core: Any, manager: Any) -> SoloSwarmRoute:
             normalized_model == "gpt-5.6" or normalized_model.startswith("gpt-5.6-")
         )
         label = str(core.account_label or source.base_url or "Hosted provider")
-    elif provider == "chatgpt":
+    elif provider in {"chatgpt", "claude_plan"}:
         if manager is None:
             raise SoloSwarmError("The ChatGPT runtime is unavailable.")
         client = manager
@@ -375,7 +375,7 @@ class SoloSwarmExecutor:
 
     def _run_one(self, task: dict[str, Any]) -> dict[str, Any]:
         self._raise_if_worker_stopped()
-        if self.route.provider == "chatgpt":
+        if self.route.provider in {"chatgpt", "claude_plan"}:
             result = self._run_chatgpt(task)
         else:
             result = self._run_chat_completion(task)
@@ -508,7 +508,7 @@ class SoloSwarmExecutor:
         run_native = (lambda **kwargs: self.goal_runtime.run_native(self.route.client.run_turn, **kwargs)) if self.goal_runtime is not None else self.route.client.run_turn
         task_call = self._reserve_task_usage()
         from .model_usage import tracked_native
-        tracked_native(None, run_native, context=self.usage_context or {"task_id": "solo:" + str(task.get("id", "unknown")), "provider": "chatgpt", "model": self.route.model},
+        tracked_native(None, run_native, context=self.usage_context or {"task_id": "solo:" + str(task.get("id", "unknown")), "provider": self.route.provider, "model": self.route.model},
             thread_id=thread_id,
             text=self._worker_prompt(task),
             model=self.route.model,

--- a/agent/ollama_code/task_usage_ledger.py
+++ b/agent/ollama_code/task_usage_ledger.py
@@ -90,7 +90,7 @@ class UsageLedger:
     def reserve(self, *, provider: str, model: str, stage: str, rates: dict | None = None,
                 upper_bound=None, metering: str | None = None, identifier: str = "",
                 max_calls_per_run: int | None = None, deadline: float | None = None):
-        category = metering or ("subscription" if provider == "chatgpt" else "local" if provider == "ollama" else "metered")
+        category = "subscription" if provider in {"chatgpt", "claude_plan"} else metering or ("local" if provider == "ollama" else "metered")
         if category not in {"subscription", "local", "metered"}:
             raise UsageLimitError("The operation's metering class is unavailable.")
         if rates is not None and not isinstance(rates, dict):

--- a/agent/ollama_code/usage_ledger.py
+++ b/agent/ollama_code/usage_ledger.py
@@ -182,7 +182,7 @@ class UsageLedger:
         # Reserve the full output allowance and the most expensive input category.
         maximum_rate = max((float(value) for name, value in (price or {}).get('rates_per_million', {}).items() if name != 'output_tokens' and value is not None), default=0)
         reservation = (count(input_tokens) * maximum_rate + count(output_tokens) * float(price['rates_per_million'].get('output_tokens') or 0)) / 1e6 if price else None
-        coverage = 'local' if provider == 'ollama' else 'subscription' if provider == 'chatgpt' else 'pending' if price else 'unavailable'
+        coverage = 'local' if provider == 'ollama' else 'subscription' if provider in {'chatgpt', 'claude_plan'} else 'pending' if price else 'unavailable'
         tokens = count(input_tokens) + count(output_tokens)
         with self.runs._connect() as db:
             db.execute('BEGIN IMMEDIATE')
@@ -199,8 +199,8 @@ class UsageLedger:
             consumed = sum(count(json.loads(row['usage']).get('total_tokens')) if row['state'] == 'settled' else max(row['reserved_tokens'], count(json.loads(row['usage']).get('total_tokens'))) for row in previous)
             if limits.get('max_tokens') and consumed + tokens > limits['max_tokens']:
                 raise UsageLimitError('The remaining token allowance cannot reserve this call')
-            if limits.get('max_estimated_usd') and provider not in {'ollama', 'chatgpt'}:
-                billable = [row for row in previous if row['provider'] not in {'ollama', 'chatgpt'}]
+            if limits.get('max_estimated_usd') and provider not in {'ollama', 'chatgpt', 'claude_plan'}:
+                billable = [row for row in previous if row['provider'] not in {'ollama', 'chatgpt', 'claude_plan'}]
                 if price is None or any(row['state'] == 'uncertain' or row['coverage'] in {'partial', 'unavailable'} or (row['state'] == 'pending' and row['reserved_cost'] is None) for row in billable):
                     raise UsageLimitError('Estimated spending control is paused until pricing and unsettled usage are reconciled')
                 spent = sum(float(row['estimated_cost'] if row['state'] == 'settled' else row['reserved_cost'] or 0) for row in billable)
@@ -234,7 +234,7 @@ class UsageLedger:
                 price = None
             full_cost = estimate(usage, price)
             cost = estimate(usage, price, partial=True)
-            coverage = 'local' if row['provider'] == 'ollama' else 'subscription' if row['provider'] == 'chatgpt' else 'known' if cost is not None and usage.get('reported') else 'unavailable'
+            coverage = 'local' if row['provider'] == 'ollama' else 'subscription' if row['provider'] in {'chatgpt', 'claude_plan'} else 'known' if cost is not None and usage.get('reported') else 'unavailable'
             if coverage == 'known' and (full_cost is None or usage.get('unpriced_tools')):
                 coverage = 'partial'
             if usage.get('reported_tool_cost_usd') is not None:

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -14,6 +14,7 @@ requires-python = ">=3.10"
 license = "Apache-2.0"
 license-files = ["../LICENSE"]
 dependencies = [
+    "claude-agent-sdk==0.2.152",
     "requests>=2.31",
     "rich>=13.7",
     "prompt_toolkit>=3.0",

--- a/agent/requirements-runtime.in
+++ b/agent/requirements-runtime.in
@@ -1,3 +1,4 @@
+claude-agent-sdk==0.2.152
 requests==2.34.2
 pysocks==1.7.1
 socksio==1.0.0

--- a/agent/requirements-runtime.lock
+++ b/agent/requirements-runtime.lock
@@ -16,6 +16,7 @@ anyio==4.14.2 \
     --hash=sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494 \
     --hash=sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f
     # via
+    #   claude-agent-sdk
     #   httpx2
     #   mcp
     #   sse-starlette
@@ -227,6 +228,14 @@ charset-normalizer==3.4.9 \
     --hash=sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf \
     --hash=sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115
     # via requests
+claude-agent-sdk==0.2.152 \
+    --hash=sha256:0822bbdf700ccdd1acecf8365345a56bde07833afe7f8bd1bee68cba0e2fcf9a \
+    --hash=sha256:1e5b619e6fa3c98f06ddc107652f7820c4573fb73a9a24263568d9974078bbc2 \
+    --hash=sha256:6cc1e949743c7634274ae526bfd1c0a216ff9d71c6b36d94cab80f32b0d32b4c \
+    --hash=sha256:9c79c4ef91b15e5fae6aba62a82afb983dc360bc159902c541046227e2852c86 \
+    --hash=sha256:f422c256358997ffa3a740f9fdc8127aa8404a9d57493502dc7d2ac05ecb5486 \
+    --hash=sha256:f885bd935054082a599dcf92bbdaf3c0b853117a79375cb3aae74674a8124326
+    # via -r agent/requirements-runtime.in
 click==8.4.2 \
     --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
     --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
@@ -319,7 +328,9 @@ idna==3.18 \
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
-    # via mcp
+    # via
+    #   claude-agent-sdk
+    #   mcp
 jsonschema-specifications==2025.9.1 \
     --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe \
     --hash=sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d
@@ -509,7 +520,9 @@ markdown-it-py==4.2.0 \
 mcp==2.0.0 \
     --hash=sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728 \
     --hash=sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6
-    # via -r agent/requirements-runtime.in
+    # via
+    #   -r agent/requirements-runtime.in
+    #   claude-agent-sdk
 mcp-types==2.0.0 \
     --hash=sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0 \
     --hash=sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379
@@ -860,6 +873,10 @@ rpds-py==2026.6.3 \
     # via
     #   jsonschema
     #   referencing
+sniffio==1.3.1 \
+    --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
+    --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
+    # via claude-agent-sdk
 socksio==1.0.0 \
     --hash=sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3 \
     --hash=sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac

--- a/agent/tests/fixtures/server-routes.txt
+++ b/agent/tests/fixtures/server-routes.txt
@@ -267,3 +267,9 @@ POST /api/runtime/workers/{session_id}/commands
 POST /api/usage/invocations/{invocation_id}/reconcile
 PUT /api/usage/tasks/{task_id}/limits
 WEBSOCKET /ws/runtime/{session_id}
+GET /api/claude/account
+GET /api/claude/models
+GET /api/claude/usage
+POST /api/claude/login/start
+POST /api/claude/login/cancel
+POST /api/claude/logout

--- a/agent/tests/test_claude_runtime.py
+++ b/agent/tests/test_claude_runtime.py
@@ -1,0 +1,384 @@
+"""Claude subscription contract tests: no network or paid model calls."""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from ollama_code import claude_runtime as runtime
+from ollama_code.api import claude
+from ollama_code.capabilities import enabled
+from ollama_code.core import AgentCore
+from ollama_code.orchestration import AgentProfile, _validate_route
+from ollama_code.schedules import SCHEDULE_PROVIDERS
+
+
+def msg(kind, **fields):
+    return type(kind, (), {})(**{}) if not fields else type(kind, (), fields)()
+
+
+@pytest.fixture
+def manager(monkeypatch, tmp_path):
+    monkeypatch.setattr(runtime, 'APP_DIR', tmp_path)
+    value = runtime.ClaudeManager('account-a')
+    monkeypatch.setattr(value, '_ready', lambda: None)
+    return value
+
+
+@pytest.fixture
+def sdk(monkeypatch):
+    import claude_agent_sdk
+    captured = SimpleNamespace(options=[], prompts=[], calls=[], resume=[], interrupt=0,
+                               response=[], tool_reply=None, tool_input={'path': 'README.md'}, fail=False, result_error=False)
+
+    class Client:
+        def __init__(self, *, options):
+            captured.options.append(options)
+            self.options = options
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+        async def query(self, prompt):
+            captured.prompts.append([item async for item in prompt])
+
+        async def get_server_info(self):
+            return {'models': [{'value': 'entitled-model', 'displayName': 'Entitled model'}]}
+
+        async def interrupt(self):
+            captured.interrupt += 1
+
+        async def receive_response(self):
+            if captured.fail:
+                raise RuntimeError('transport closed')
+            yield msg('SystemMessage', subtype='init', data={'session_id': 'sdk-session'})
+            if captured.calls:
+                captured.tool_reply = await captured.calls[0].handler(captured.tool_input)
+            for value in captured.response:
+                yield value
+            yield msg('ResultMessage', session_id='sdk-session', usage={'input_tokens': 5,
+                      'cache_read_input_tokens': 3, 'output_tokens': 2}, is_error=captured.result_error,
+                      errors=[], structured_output=None)
+
+    def server(*, name, tools):
+        captured.calls = tools
+        return {'type': 'sdk', 'name': name, 'instance': object()}
+    monkeypatch.setattr(claude_agent_sdk, 'ClaudeSDKClient', Client)
+    monkeypatch.setattr(claude_agent_sdk, 'create_sdk_mcp_server', server)
+    return captured
+
+
+def test_public_capability_is_on_by_default_and_can_be_disabled(monkeypatch):
+    monkeypatch.delenv('LOCUS_CAPABILITY_CLAUDE_PLAN_V1', raising=False)
+    assert enabled('claude_plan_v1')
+    monkeypatch.setenv('LOCUS_CAPABILITY_CLAUDE_PLAN_V1', '0')
+    assert not enabled('claude_plan_v1')
+
+
+@pytest.mark.parametrize('identifier', ['', '../escape', '/tmp/home', '.hidden', 'a/b', None])
+def test_account_ids_cannot_escape_home(identifier):
+    with pytest.raises(ValueError):
+        runtime.claude_home_for_account(identifier)
+
+
+def test_environment_overrides_sdk_inheritance(monkeypatch, tmp_path):
+    for key in ('ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_BASE_URL',
+                'CLAUDE_CODE_OAUTH_TOKEN', 'CLAUDE_CODE_USE_BEDROCK', 'LOCUS_CODEX_BROKER_TOKEN'):
+        monkeypatch.setenv(key, 'must-not-reach-sdk')
+    env = runtime.subscription_environment(tmp_path)
+    assert env['CLAUDE_CONFIG_DIR'] == str(tmp_path)
+    assert all(value != 'must-not-reach-sdk' for value in env.values())
+    assert env['ANTHROPIC_API_KEY'] == ''
+    assert env['CLAUDE_CODE_USE_BEDROCK'] == ''
+
+
+def test_account_rejects_console_billing(manager, monkeypatch):
+    monkeypatch.setattr(manager, '_auth', lambda _: {'loggedIn': True, 'authMethod': 'api_key'})
+    assert manager.account()['account'] is None
+    monkeypatch.setattr(manager, '_auth', lambda _: {'loggedIn': True, 'authMethod': 'claude.ai', 'email': 'person@example.com'})
+    assert manager.account()['account']['type'] == 'claude_plan'
+
+
+def test_logout_and_auth_refresh_stay_in_selected_account(manager, monkeypatch):
+    other = runtime.ClaudeManager('account-b')
+    calls = []
+    def command(args, **kwargs):
+        calls.append((args, kwargs['env']['CLAUDE_CONFIG_DIR']))
+        return SimpleNamespace(returncode=0, stdout='{"loggedIn": false}')
+    monkeypatch.setattr(runtime.subprocess, 'run', command)
+    manager.logout()
+    assert manager.account()['account'] is None
+    assert [call[0][-1] for call in calls] == ['logout', 'status']
+    assert all(call[1] == str(manager.home) for call in calls)
+    assert not other.home.exists()
+
+
+def test_cancel_login_terminates_only_selected_attempt(manager):
+    stopped = []
+    process = SimpleNamespace(poll=lambda: None, terminate=lambda: stopped.append('terminate'),
+                              wait=lambda **_: stopped.append('wait'))
+    manager._login = ('selected', process)
+    with pytest.raises(runtime.ClaudeRuntimeError, match='Unknown'):
+        manager.cancel_login('another')
+    assert not stopped
+    manager.cancel_login('selected')
+    assert stopped == ['terminate', 'wait']
+    assert manager._login is None
+
+
+def test_auth_timeout_is_actionable_and_retryable(manager, monkeypatch):
+    def timeout(*args, **kwargs):
+        raise runtime.subprocess.TimeoutExpired('claude', 30)
+    monkeypatch.setattr(runtime.subprocess, 'run', timeout)
+    with pytest.raises(runtime.ClaudeRuntimeError, match='Refresh the account'):
+        manager.account()
+    monkeypatch.setattr(runtime.subprocess, 'run', lambda *_, **__: SimpleNamespace(returncode=0,
+        stdout='{"loggedIn": true, "authMethod": "claude.ai"}'))
+    assert manager.account()['account']['type'] == 'claude_plan'
+
+
+@pytest.mark.parametrize(('error', 'guidance'), [('authentication_failed', 'sign in again'),
+                                                ('rate_limit', 'limit resets')])
+def test_runtime_account_errors_provide_recovery_guidance(manager, sdk, error, guidance):
+    sdk.result_error = True
+    sdk.response = [msg('AssistantMessage', content=[], error=error)]
+    notifications = []
+    manager.add_listener(notifications.append)
+    thread = manager.start_thread(model='default', cwd='/workspace')
+    result = manager.run_turn(thread_id=thread, text='hello')
+    assert result['status'] == 'failed'
+    assert guidance in result['error']['message']
+    assert notifications[0]['params']['account_id'] == 'account-a'
+    if error == 'rate_limit':
+        assert manager.usage()['status'] == 'rejected'
+        assert manager.usage().get('utilization') is None
+
+
+def test_locus_tools_and_images_use_sdk_with_no_native_tools(manager, sdk):
+    schema = {'type': 'function', 'function': {'name': 'read_file', 'description': 'Read',
+              'parameters': {'type': 'object', 'properties': {'path': {'type': 'string'}}}}}
+    thread = manager.start_thread(model='default', cwd='/workspace', base_instructions='Locus instructions', tools=[schema])
+    calls = []
+    manager.run_turn(thread_id=thread, text='read', tool_handler=lambda *args: calls.append(args) or 'contents',
+        input_items=[{'type': 'text', 'text': 'read'}, {'type': 'image', 'url': 'data:image/png;base64,YQ=='}])
+    options = sdk.options[-1]
+    assert options.tools == []
+    assert options.setting_sources == [] and options.strict_mcp_config
+    assert options.allowed_tools == ['mcp__locus__read_file']
+    assert options.model is None
+    assert options.system_prompt == 'Locus instructions'
+    assert asyncio.run(options.can_use_tool('Bash', {}, None)).behavior == 'deny'
+    assert calls[0][0:2] == ('read_file', {'path': 'README.md'})
+    assert sdk.tool_reply['content'][0]['text'] == 'contents'
+    assert sdk.prompts[0][0]['message']['content'][1]['source']['media_type'] == 'image/png'
+
+
+def test_streaming_and_complete_messages_are_not_duplicated(manager, sdk):
+    sdk.response = [
+        msg('StreamEvent', event={'type': 'message_start', 'message': {'id': 'm'}}),
+        msg('StreamEvent', event={'type': 'content_block_start', 'index': 0, 'content_block': {'type': 'text'}}),
+        msg('StreamEvent', event={'type': 'content_block_delta', 'index': 0, 'delta': {'text': 'Hello'}}),
+        msg('AssistantMessage', content=[msg('TextBlock', text='Hello')]),
+    ]
+    thread = manager.start_thread(model='default', cwd='/workspace')
+    events = []
+    manager.run_turn(thread_id=thread, text='hi', event_handler=events.append, client_message_id='delivery')
+    assert [e['params']['delta'] for e in events if e['method'] == 'item/agentMessage/delta'] == ['Hello']
+    assert manager.read_thread(thread)['thread']['turns'][0]['items'][0]['clientId'] == 'delivery'
+    manager.run_turn(thread_id=thread, text='follow up', event_handler=events.append)
+    assert sdk.options[-1].resume == 'sdk-session'
+    assert manager._load(thread)['input'] == 16
+
+
+def test_model_discovery_never_uses_api_catalog(manager, sdk):
+    assert manager.models()[0]['model'] == 'entitled-model'
+
+
+def test_uncertain_turn_is_never_replayed(manager, sdk):
+    sdk.fail = True
+    thread = manager.start_thread(model='default', cwd='/workspace')
+    with pytest.raises(runtime.ClaudeRuntimeError, match='transport closed'):
+        manager.run_turn(thread_id=thread, text='edit')
+    sdk.fail = False
+    with pytest.raises(runtime.ClaudeRuntimeError, match='uncertain'):
+        manager.resume_thread(thread, model='default', cwd='/workspace')
+    with pytest.raises(runtime.ClaudeRuntimeError, match='uncertain'):
+        manager.run_turn(thread_id=thread, text='retry')
+    assert len(sdk.options) == 1
+
+
+def test_sessions_cannot_cross_accounts(manager):
+    thread = manager.start_thread(model='default', cwd='/workspace')
+    other = runtime.ClaudeManager('account-b')
+    with pytest.raises(runtime.ClaudeRuntimeError, match='unavailable'):
+        other.resume_thread(thread, model='default', cwd='/workspace')
+    assert manager.home != other.home
+
+
+def test_unknown_usage_is_not_zero(manager, monkeypatch):
+    monkeypatch.setenv('LOCUS_CAPABILITY_CLAUDE_PLAN_V1', '1')
+    monkeypatch.setattr(claude, 'account_payload', lambda *_: {'status': 'signed_in'})
+    service = SimpleNamespace(claude_for=lambda _: manager)
+    result = claude.usage(service, 'account-a')
+    assert result['observed_at'] is None
+    assert result['rate_limits']['rateLimits']['primary'] is None
+
+
+def test_selection_is_atomic_and_keeps_api_accounts_separate(manager, monkeypatch, tmp_path):
+    monkeypatch.setenv('LOCUS_CAPABILITY_CLAUDE_PLAN_V1', '1')
+    core = AgentCore(cwd=str(tmp_path), config={'provider': 'ollama', 'model': 'local'})
+    monkeypatch.setattr(manager, 'account', lambda: {'account': None})
+    with pytest.raises(ValueError, match='Sign in'):
+        core.use_claude_plan(account_id='account-a', model='default', account_label='Claude', manager=manager)
+    assert core.provider == 'ollama'
+    monkeypatch.setattr(manager, 'account', lambda: {'account': {'type': 'claude_plan'}})
+    core.use_claude_plan(account_id='account-a', model='default', account_label='Claude', manager=manager)
+    assert core.provider == 'claude_plan' and core.account_id == 'account-a'
+    assert not core.chatgpt_parity_active(True)
+    assert core.config['remote_api_key'] == ''
+    assert core.ensure_model() is None
+
+
+def test_scheduled_and_team_routes_are_subscription_only():
+    assert 'claude_plan' in SCHEDULE_PROVIDERS
+    route = {'provider': 'claude_plan', 'account_id': 'account-a'}
+    _validate_route(route, 'Claude')
+    profile = AgentProfile.parse({'id': 'a', 'name': 'Claude', 'model': 'default', 'route': route, 'metering': 'metered'})
+    assert profile.metering == 'self_hosted'
+    assert profile.input_cost_per_million == profile.output_cost_per_million == 0
+    with pytest.raises(Exception, match='credentials'):
+        _validate_route({**route, 'api_key': 'not-allowed'}, 'Claude')
+
+
+def test_no_tools_mode_and_interruption(manager, sdk):
+    thread = manager.start_thread(model='default', cwd='/workspace')
+    manager.run_turn(thread_id=thread, text='hello')
+    assert sdk.options[-1].mcp_servers == {}
+    assert sdk.options[-1].allowed_tools == []
+    sdk.prompts.clear()
+    stopped = manager.run_turn(thread_id=thread, text='hello', should_interrupt=lambda: True)
+    assert stopped['status'] == 'interrupted'
+    assert not sdk.prompts
+    assert not manager._load(thread)['uncertain']
+
+
+def test_invalid_image_is_rejected_before_query(manager, sdk):
+    thread = manager.start_thread(model='default', cwd='/workspace')
+    with pytest.raises(runtime.ClaudeRuntimeError, match='validated image'):
+        manager.run_turn(thread_id=thread, text='read', input_items=[{'type': 'image', 'url': 'https://example.com/image.png'}])
+    assert not sdk.prompts
+    assert not manager._load(thread)['uncertain']
+
+
+def test_tool_failure_returns_an_error_without_reexecution(manager, sdk):
+    thread = manager.start_thread(model='default', cwd='/workspace', tools=[{
+        'name': 'read_file', 'parameters': {'type': 'object', 'properties': {}}}])
+    calls = []
+    def fail(*args):
+        calls.append(args)
+        raise ValueError('not permitted')
+    manager.run_turn(thread_id=thread, text='read', tool_handler=fail)
+    assert len(calls) == 1
+    assert sdk.tool_reply['isError']
+
+
+def test_subscription_routes_reject_secrets_and_disabled_capability(monkeypatch):
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as error:
+        claude.select_claude(SimpleNamespace(), {'account_id': 'a', 'api_key': 'secret'})
+    assert error.value.status_code == 422
+    monkeypatch.setenv('LOCUS_CAPABILITY_CLAUDE_PLAN_V1', '0')
+    with pytest.raises(HTTPException) as error:
+        claude.manager_for(SimpleNamespace(), 'a')
+    assert error.value.status_code == 404
+
+
+def test_broker_pins_the_claude_account_without_changing_chatgpt():
+    broker = runtime.ClaudeBrokerClient('ws://localhost/ws/internal/codex', 'fixture')
+    first, second = broker.for_account('one'), broker.for_account('two')
+    assert first._request('account')['claude_account_id'] == 'one'
+    assert second._request('account')['claude_account_id'] == 'two'
+    assert first._request('turn_run')['provider'] == 'claude_plan'
+    assert broker._home_id is None
+
+
+def test_claude_task_keeps_plan_permission_checks(manager, sdk, monkeypatch, tmp_path):
+    monkeypatch.setenv('LOCUS_CAPABILITY_CLAUDE_PLAN_V1', '1')
+    monkeypatch.setattr(manager, 'account', lambda: {'account': {'type': 'claude_plan'}})
+    core = AgentCore(cwd=str(tmp_path), config={'provider': 'ollama', 'model': 'local', 'agent_mode': 'plan'})
+    core.use_claude_plan(account_id='account-a', model='default', account_label='Claude', manager=manager)
+    core.agent_mode = 'plan'
+    sdk.tool_input = {'path': 'README.md', 'content': 'must not be written'}
+    writes = []
+    results = []
+    core.tool_registry.schemas = lambda: [{'type': 'function', 'function': {'name': 'write_file', 'description': 'write',
+        'parameters': {'type': 'object', 'properties': {'path': {'type': 'string'}}}}}]
+    # The adapter must call the very same permission boundary as other providers.
+    original = core._run_tool_call
+    def record(call, decider):
+        writes.append(call.name)
+        result = original(call, decider)
+        results.append(result)
+        return result
+    monkeypatch.setattr(core, '_run_tool_call', record)
+    core.run_turn('Inspect only', lambda *_: 'once')
+    assert writes == ['write_file']
+    assert 'Plan mode' in results[0]
+    assert not (tmp_path / 'README.md').exists()
+    assert core.provider == 'claude_plan'
+
+
+def test_disabled_saved_claude_route_does_not_break_backend_health(monkeypatch):
+    from ollama_code.api.system import health
+    monkeypatch.setenv('LOCUS_CAPABILITY_CLAUDE_PLAN_V1', '0')
+    service = SimpleNamespace(core=SimpleNamespace(provider='claude_plan', account_id='account-a', host='claude_plan://managed', model='default'))
+    state = health(service)
+    assert state['ok'] is True
+    assert state['ollama'] is False
+    assert 'not enabled' in state['error']
+
+
+def test_swarm_keeps_selected_claude_transport(manager, monkeypatch, tmp_path):
+    from ollama_code.solo_swarm import snapshot_route
+    monkeypatch.setenv('LOCUS_CAPABILITY_CLAUDE_PLAN_V1', '1')
+    monkeypatch.setattr(manager, 'account', lambda: {'account': {'type': 'claude_plan'}})
+    core = AgentCore(cwd=str(tmp_path), config={'provider': 'ollama', 'model': 'local'})
+    core.use_claude_plan(account_id='account-a', model='default', account_label='Claude', manager=manager)
+    route = snapshot_route(core, core.codex_manager)
+    assert route.provider == 'claude_plan'
+    assert route.client is manager
+    assert not route.native_web_search
+
+
+def test_compaction_uses_claude_without_task_tools(manager, sdk, monkeypatch, tmp_path):
+    from claude_agent_sdk import TextBlock
+
+    from ollama_code.context_preservation import summarize_section
+    monkeypatch.setenv('LOCUS_CAPABILITY_CLAUDE_PLAN_V1', '1')
+    monkeypatch.setattr(manager, 'account', lambda: {'account': {'type': 'claude_plan'}})
+    core = AgentCore(cwd=str(tmp_path), config={'provider': 'ollama', 'model': 'local'})
+    core.use_claude_plan(account_id='account-a', model='default', account_label='Claude', manager=manager)
+    sdk.response = [msg('AssistantMessage', content=[TextBlock(text='Preserved decisions and constraints')])]
+    response = summarize_section(core, [{'role': 'system', 'content': 'Summarize'},
+                                         {'role': 'user', 'content': 'Prior history'}])
+    assert response.content == 'Preserved decisions and constraints'
+    assert response.prompt_eval_count == 8
+    assert sdk.options[-1].tools == []
+    assert sdk.options[-1].mcp_servers == {}
+
+
+def test_fork_does_not_share_claude_runtime_session(manager, sdk, monkeypatch, tmp_path):
+    from claude_agent_sdk import TextBlock
+    monkeypatch.setenv('LOCUS_CAPABILITY_CLAUDE_PLAN_V1', '1')
+    monkeypatch.setattr(manager, 'account', lambda: {'account': {'type': 'claude_plan'}})
+    core = AgentCore(cwd=str(tmp_path), config={'provider': 'ollama', 'model': 'local'})
+    core.use_claude_plan(account_id='account-a', model='default', account_label='Claude', manager=manager)
+    sdk.response = [msg('AssistantMessage', content=[TextBlock(text='Answer')])]
+    core.run_turn('First question', allow_tools=False)
+    original = core._chatgpt_thread_id
+    core.session = core._new_session_store()
+    core.run_turn('Follow-up in a fork', allow_tools=False)
+    assert core._chatgpt_thread_id != original
+    assert sdk.options[-1].resume is None


### PR DESCRIPTION
Locus can now connect a Claude subscription as a separate **Claude plan** account. The account option is enabled by default, while existing Claude API and ChatGPT accounts retain their identifiers and behavior.

Adds managed runtime installation and account-scoped sign-in, model discovery, Locus tools and permissions, streaming, session recovery, and subscription usage reporting. Claude routing is available to tasks, teams, swarms, schedules, evaluations, and remote runtimes. Direct-download releases package Claude as a component; App Store builds bundle it. Claude plan does not provide image generation.

This branch builds on #87. Merge that networking fix first; this PR then contains only the Claude support change.

Validation:
- Full backend suite: 2,372 tests passed before the final default-enablement change.
- Final Claude contract suite: 32 tests passed.
- Final enablement, Claude, and release-packaging checks: 86 tests passed.
- Selected Swift account, component, schedule, and team tests: 36 passed.
- Direct-download and App Store release source builds passed with code signing disabled and runtime bundling skipped.
- Python lint, shell syntax, and patch checks passed.

Live subscription login, two-account macOS Keychain isolation, second-host execution, and signed distribution checks remain outstanding. Anthropic's distributed subscription-login approval has not been confirmed. Setup and remaining release verification are documented in `Docs/ClaudePlan.md`.
