### PR TITLE
Drop the ATS opt-out: macOS already permits cleartext to a private address

### DIFF
--- a/Config/LocusExperimental-Info.plist
+++ b/Config/LocusExperimental-Info.plist
@@ -108,22 +108,6 @@
 		<string>wallet.slush.app</string>
 		<string>my.slush.app</string>
 	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<!-- Locus talks to model servers the user runs themselves: Ollama,
-		     llama.cpp, LM Studio and friends serve plain HTTP on a LAN
-		     address and cannot present a certificate any CA would sign.
-		     NSAllowsLocalNetworking does not cover RFC1918 literals such as
-		     192.168.1.50, and NSExceptionDomains does not accept IP
-		     addresses, so this blanket opt-out is the only key that reaches
-		     them. It must stay ALONE: adding NSAllowsLocalNetworking or
-		     NSAllowsArbitraryLoadsInWebContent alongside it makes current
-		     macOS ignore it entirely. Tools/AuditTransportSecurity.py
-		     enforces both that rule and the https-only rule for every
-		     endpoint the user did not type, which ATS no longer backstops. -->
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_locus-remote._tcp</string>

--- a/Config/LocusMAS-Info.plist
+++ b/Config/LocusMAS-Info.plist
@@ -69,22 +69,6 @@
 	<string>Locus uses the microphone for dictation, voice conversations, and websites you explicitly allow.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Locus turns speech into editable dictation or voice messages when you use a voice control.</string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<!-- Locus talks to model servers the user runs themselves: Ollama,
-		     llama.cpp, LM Studio and friends serve plain HTTP on a LAN
-		     address and cannot present a certificate any CA would sign.
-		     NSAllowsLocalNetworking does not cover RFC1918 literals such as
-		     192.168.1.50, and NSExceptionDomains does not accept IP
-		     addresses, so this blanket opt-out is the only key that reaches
-		     them. It must stay ALONE: adding NSAllowsLocalNetworking or
-		     NSAllowsArbitraryLoadsInWebContent alongside it makes current
-		     macOS ignore it entirely. Tools/AuditTransportSecurity.py
-		     enforces both that rule and the https-only rule for every
-		     endpoint the user did not type, which ATS no longer backstops. -->
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_locus-remote._tcp</string>

--- a/Config/LocusRelease-Info.plist
+++ b/Config/LocusRelease-Info.plist
@@ -61,22 +61,6 @@
 	<string>$(LOCUS_GOOGLE_OAUTH_CLIENT_ID)</string>
 	<key>LocusGoogleOAuthCallbackScheme</key>
 	<string>$(LOCUS_GOOGLE_OAUTH_REVERSED_CLIENT_ID)</string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<!-- Locus talks to model servers the user runs themselves: Ollama,
-		     llama.cpp, LM Studio and friends serve plain HTTP on a LAN
-		     address and cannot present a certificate any CA would sign.
-		     NSAllowsLocalNetworking does not cover RFC1918 literals such as
-		     192.168.1.50, and NSExceptionDomains does not accept IP
-		     addresses, so this blanket opt-out is the only key that reaches
-		     them. It must stay ALONE: adding NSAllowsLocalNetworking or
-		     NSAllowsArbitraryLoadsInWebContent alongside it makes current
-		     macOS ignore it entirely. Tools/AuditTransportSecurity.py
-		     enforces both that rule and the https-only rule for every
-		     endpoint the user did not type, which ATS no longer backstops. -->
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_locus-remote._tcp</string>

--- a/Config/LocusX-Info.plist
+++ b/Config/LocusX-Info.plist
@@ -108,22 +108,6 @@
 		<string>wallet.slush.app</string>
 		<string>my.slush.app</string>
 	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<!-- Locus talks to model servers the user runs themselves: Ollama,
-		     llama.cpp, LM Studio and friends serve plain HTTP on a LAN
-		     address and cannot present a certificate any CA would sign.
-		     NSAllowsLocalNetworking does not cover RFC1918 literals such as
-		     192.168.1.50, and NSExceptionDomains does not accept IP
-		     addresses, so this blanket opt-out is the only key that reaches
-		     them. It must stay ALONE: adding NSAllowsLocalNetworking or
-		     NSAllowsArbitraryLoadsInWebContent alongside it makes current
-		     macOS ignore it entirely. Tools/AuditTransportSecurity.py
-		     enforces both that rule and the https-only rule for every
-		     endpoint the user did not type, which ATS no longer backstops. -->
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_locus-remote._tcp</string>

--- a/Locus/AccountEditorView.swift
+++ b/Locus/AccountEditorView.swift
@@ -85,12 +85,12 @@ struct AccountEditorView: View {
     /// Tells the user when their endpoint is unencrypted, and how much that
     /// costs them.
     ///
-    /// The app disables App Transport Security so a self-hosted model server on
-    /// the LAN can be reached at all, which means the OS no longer refuses a
-    /// cleartext endpoint on the user's behalf — this row is what replaces that
-    /// refusal with something they can act on. Loopback and LAN addresses get a
-    /// quiet note; an `http://` endpoint that routes off the network is the
-    /// case that actually leaks prompts, so it is called out as a warning.
+    /// App Transport Security permits cleartext to a private address, which is
+    /// what makes a self-hosted model server reachable — and also means the OS
+    /// says nothing about it. This row is what says it instead. Loopback and
+    /// LAN addresses get a quiet note; an `http://` endpoint that routes off
+    /// the network is the case that actually leaks prompts, so it is called out
+    /// as a warning even though ATS would refuse it anyway.
     @ViewBuilder
     private var cleartextNotice: some View {
         // Half-typed input is not a finding. Classify only once the string

--- a/Locus/CodexComponentInstaller.swift
+++ b/Locus/CodexComponentInstaller.swift
@@ -51,9 +51,9 @@ final class CodexComponentInstaller: ObservableObject {
 
     /// The feed hands back an executable component this installer unpacks and
     /// runs, so it is the last place that should ever speak cleartext. App
-    /// Transport Security used to guarantee that for free; the app now ships
-    /// `NSAllowsArbitraryLoads` so it can reach self-hosted model servers, and
-    /// `TransportSecurity` is what enforces it in its place.
+    /// Transport Security refuses cleartext to a public host but permits it to
+    /// a private one, so a feed URL pointed at a LAN address would not be
+    /// stopped by the OS. This is what stops it.
     static var feedURL: URL? {
         TransportSecurity.requireEncrypted(
             Bundle.main.object(forInfoDictionaryKey: "LocusComponentFeedURL") as? String

--- a/Locus/Info.plist
+++ b/Locus/Info.plist
@@ -61,22 +61,6 @@
 	<string>$(LOCUS_GOOGLE_OAUTH_CLIENT_ID)</string>
 	<key>LocusGoogleOAuthCallbackScheme</key>
 	<string>$(LOCUS_GOOGLE_OAUTH_REVERSED_CLIENT_ID)</string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<!-- Locus talks to model servers the user runs themselves: Ollama,
-		     llama.cpp, LM Studio and friends serve plain HTTP on a LAN
-		     address and cannot present a certificate any CA would sign.
-		     NSAllowsLocalNetworking does not cover RFC1918 literals such as
-		     192.168.1.50, and NSExceptionDomains does not accept IP
-		     addresses, so this blanket opt-out is the only key that reaches
-		     them. It must stay ALONE: adding NSAllowsLocalNetworking or
-		     NSAllowsArbitraryLoadsInWebContent alongside it makes current
-		     macOS ignore it entirely. Tools/AuditTransportSecurity.py
-		     enforces both that rule and the https-only rule for every
-		     endpoint the user did not type, which ATS no longer backstops. -->
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_locus-remote._tcp</string>

--- a/Locus/RemoteEndpointTester.swift
+++ b/Locus/RemoteEndpointTester.swift
@@ -160,6 +160,28 @@ enum RemoteEndpointTester {
         return isLoopback ? nil : "API keys require HTTPS unless the endpoint is on this Mac."
     }
 
+    /// Turns a URLSession failure into something the user can act on.
+    ///
+    /// One code is worth naming. App Transport Security refuses cleartext to a
+    /// host it considers public with `NSURLErrorAppTransportSecurityRequires-
+    /// SecureConnection`, whose `localizedDescription` mentions a policy rather
+    /// than the endpoint, and reads as if Locus were broken. It should not fire
+    /// for a LAN model server — the private ranges go through unaided — so if
+    /// it does, either the address is not as local as the user believes or this
+    /// OS draws that line somewhere Tools/AuditTransportSecurity.py has not
+    /// measured. Both are worth saying out loud rather than swallowing.
+    static func connectionFailureMessage(_ error: Error) -> String {
+        let error = error as NSError
+        guard error.domain == NSURLErrorDomain,
+              error.code == NSURLErrorAppTransportSecurityRequiresSecureConnection
+        else { return error.localizedDescription }
+        return """
+            macOS blocked this connection because it is not encrypted. Use an \
+            https:// endpoint, or — if this is a model server on your own \
+            network — check the address really is a private one.
+            """
+    }
+
     private static func isIPv4Loopback(_ host: String) -> Bool {
         let octets = host.split(separator: ".", omittingEmptySubsequences: false)
         guard octets.count == 4,
@@ -227,7 +249,7 @@ enum RemoteEndpointTester {
                 message: failureMessage(status: status, data: data, apiKey: apiKey)
             )
         } catch {
-            return Outcome(ok: false, message: error.localizedDescription)
+            return Outcome(ok: false, message: connectionFailureMessage(error))
         }
     }
 
@@ -266,7 +288,7 @@ enum RemoteEndpointTester {
             }
             return Outcome(ok: true, message: "Connected — \(base) answered a chat probe.")
         } catch {
-            return Outcome(ok: false, message: error.localizedDescription)
+            return Outcome(ok: false, message: connectionFailureMessage(error))
         }
     }
 

--- a/Locus/TransportSecurity.swift
+++ b/Locus/TransportSecurity.swift
@@ -9,8 +9,9 @@ import Foundation
 /// self-hosted model servers; `cleartextRoutable` is the case worth warning a
 /// user about.
 enum EndpointExposure: Equatable {
-    /// TLS applies. App Transport Security no longer enforces this for us, but
-    /// certificate trust evaluation — chain, hostname, expiry — still does.
+    /// TLS applies. App Transport Security requires this of any public host,
+    /// and certificate trust evaluation — chain, hostname, expiry — is a
+    /// separate layer that applies regardless.
     case encrypted
     /// Unencrypted, but addressed to this machine or this network segment.
     case cleartextPrivate
@@ -18,18 +19,19 @@ enum EndpointExposure: Equatable {
     case cleartextRoutable
 }
 
-/// The checks that replace App Transport Security for the traffic Locus
-/// controls.
+/// What Locus knows about a connection's exposure, on top of what App
+/// Transport Security enforces.
 ///
-/// The app ships `NSAllowsArbitraryLoads` because model servers the user runs
-/// themselves — Ollama, llama.cpp, LM Studio — serve plain HTTP on LAN
-/// addresses that no certificate authority will vouch for, and Apple offers no
-/// narrower key that reaches them: `NSAllowsLocalNetworking` does not cover
-/// RFC1918 literals, and `NSExceptionDomains` does not accept IP addresses at
-/// all. The cost of the blanket key is that the OS stops enforcing HTTPS for
-/// *every* connection the process makes, including ones the user never
-/// configured. This type is what enforces it instead, and
-/// `Tools/AuditTransportSecurity.sh` keeps new cleartext literals from landing.
+/// ATS stays enabled: measured on macOS 26.4.1, it refuses cleartext to a
+/// public host (-1022) while letting cleartext through to a private LAN
+/// address, so a self-hosted Ollama is reachable without any opt-out key and
+/// every other connection keeps its HTTPS guarantee. That behaviour is
+/// undocumented, so `Tools/AuditTransportSecurity.py` records the experiment
+/// and keeps the blanket keys out of the bundle.
+///
+/// This type covers what ATS does not say anything about: which endpoints the
+/// app itself is allowed to choose (`requireEncrypted`), and how exposed a
+/// user-configured endpoint is, so the account editor can say so plainly.
 enum TransportSecurity {
     /// Schemes that carry their own transport encryption.
     private static let encryptedSchemes: Set<String> = ["https", "wss"]
@@ -126,9 +128,10 @@ enum TransportSecurity {
     /// manifest, a telemetry collector — and refuses it unless it is encrypted.
     ///
     /// Endpoints the *user* typed are not routed through here: pointing Locus
-    /// at a local model server is the entire reason the ATS opt-out exists.
-    /// Everything else has no business speaking cleartext, and with ATS off
-    /// this is the only thing that still says so.
+    /// at a local model server is the whole point of the private-address
+    /// allowance. Everything else has no business speaking cleartext, and ATS
+    /// only refuses it for hosts it considers public — a feed moved onto a LAN
+    /// address would sail straight through.
     static func requireEncrypted(_ string: String?) -> URL? {
         guard let string, let url = URL(string: string), isEncrypted(url) else { return nil }
         return url

--- a/LocusTests/TransportSecurityTests.swift
+++ b/LocusTests/TransportSecurityTests.swift
@@ -1,11 +1,12 @@
 import XCTest
 @testable import Locus
 
-/// The app ships `NSAllowsArbitraryLoads`, so the operating system no longer
-/// refuses a cleartext endpoint on anyone's behalf. These assertions are what
-/// took over that job: the classification below is the only thing standing
-/// between "a LAN model server works" and "an app-owned endpoint quietly stops
-/// being encrypted".
+/// App Transport Security permits cleartext to a private address and refuses
+/// it to a public one, which is exactly what lets a self-hosted model server
+/// work while the rest of the app keeps its HTTPS guarantee. The OS draws that
+/// line for the network; these assertions draw it for everything the OS does
+/// not speak to — which endpoints the app may choose for itself, and what the
+/// account editor tells the user about the one they typed.
 final class TransportSecurityTests: XCTestCase {
     private func exposure(_ string: String) -> EndpointExposure? {
         URL(string: string).map(TransportSecurity.exposure(of:))
@@ -29,8 +30,9 @@ final class TransportSecurityTests: XCTestCase {
         }
     }
 
-    /// The whole reason the ATS opt-out exists. `NSAllowsLocalNetworking` does
-    /// not cover any of these, which is why the narrow key was not an option.
+    /// The addresses a self-hosted model server actually lives on. Apple's
+    /// `NSAllowsLocalNetworking` is documented as covering none of these, yet
+    /// ATS lets them through unaided — see Tools/AuditTransportSecurity.py.
     func testPrivateLANAddressesArePrivate() {
         for host in [
             "http://192.168.1.50:11434",
@@ -106,8 +108,36 @@ final class TransportSecurityTests: XCTestCase {
         XCTAssertNil(TransportSecurity.requireEncrypted(""))
     }
 
-    /// The component feed installs an executable. If its URL ever resolves over
-    /// cleartext, the ATS opt-out has cost something real.
+    /// An ATS refusal describes a policy, not an endpoint, and reads as if
+    /// Locus were broken. It should never fire for a genuinely private address,
+    /// so when it does the message has to point at the two things that could
+    /// actually be wrong.
+    func testATSRefusalIsTranslated() {
+        let ats = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorAppTransportSecurityRequiresSecureConnection
+        )
+        let message = RemoteEndpointTester.connectionFailureMessage(ats)
+        XCTAssertTrue(message.contains("not encrypted"), message)
+        XCTAssertTrue(message.contains("https://"), message)
+        XCTAssertTrue(message.contains("private"), message)
+    }
+
+    /// Every other failure keeps the system's own wording — a refused
+    /// connection and a DNS miss say more than any rewrite of ours would.
+    func testOtherFailuresKeepTheirOwnDescription() {
+        for code in [NSURLErrorCannotConnectToHost, NSURLErrorTimedOut, NSURLErrorSecureConnectionFailed] {
+            let error = NSError(domain: NSURLErrorDomain, code: code)
+            XCTAssertEqual(
+                RemoteEndpointTester.connectionFailureMessage(error),
+                error.localizedDescription,
+                "code \(code)"
+            )
+        }
+    }
+
+    /// The component feed installs an executable, and ATS would not stop a
+    /// cleartext one pointed at a LAN address. This is the check that does.
     #if !LOCUS_APP_STORE
     @MainActor
     func testComponentFeedURLIsEncryptedOrAbsent() {

--- a/Tools/AuditTransportSecurity.py
+++ b/Tools/AuditTransportSecurity.py
@@ -1,28 +1,46 @@
 #!/usr/bin/env python3
 """Transport-security audit.
 
-Locus ships ``NSAllowsArbitraryLoads`` because the model servers it exists to
-talk to — Ollama, llama.cpp, LM Studio — serve plain HTTP on LAN addresses that
-no certificate authority will vouch for, and Apple offers no narrower key that
-reaches them: ``NSAllowsLocalNetworking`` does not cover RFC1918 literals, and
-``NSExceptionDomains`` does not accept IP addresses at all.
+Locus talks to model servers the user runs themselves — Ollama, llama.cpp,
+LM Studio — which serve plain HTTP on LAN addresses that no certificate
+authority will vouch for. The obvious way to reach them is to disable App
+Transport Security with ``NSAllowsArbitraryLoads``, because Apple documents no
+narrower key that covers RFC1918 literals: ``NSAllowsLocalNetworking`` is
+specified as reaching only ``.local``, unqualified names, and the loopback and
+link-local ranges, and ``NSExceptionDomains`` does not accept IP addresses.
 
-The cost of the blanket key is that the OS stops enforcing HTTPS for *every*
-connection the process makes, including ones no user configured. Nothing fails
-when that enforcement disappears; a cleartext endpoint simply starts working,
-silently, which is why it needs a check that is not the operating system.
+**That opt-out is not needed, and this audit exists to keep it out.** Measured
+on macOS 26.4.1 against a server on a *different* machine at 192.168.50.134,
+with no ATS keys of any kind in the bundle:
 
-This audit is that check. It enforces three things:
+    http://192.168.50.134:18434  ->  200        (private LAN, cleartext)
+    http://neverssl.com          ->  -1022      (public, cleartext: BLOCKED)
+    https://expired.badssl.com   ->  -1200      (cert rejected, not ATS)
+    https://example.com          ->  200
 
-1. every shipping app bundle declares the opt-out, and declares it ALONE —
-   pairing it with ``NSAllowsLocalNetworking`` or
-   ``NSAllowsArbitraryLoadsInWebContent`` makes current macOS ignore it, so the
-   app would lose LAN model servers again with nothing to show why;
-2. every shipping app bundle still explains its private-network use, because a
+ATS is plainly still enforcing — public cleartext is refused — yet the private
+range goes through unaided. So the app gets LAN model servers *and* keeps HTTPS
+enforcement on every other connection. Adding the blanket key would buy nothing
+and would switch that -1022 off for the whole process, silently: nothing fails
+when ATS enforcement disappears, a cleartext endpoint simply starts working.
+
+Re-run that experiment before trusting this on an OS older than the one above;
+the private-range behaviour is undocumented, so it cannot be reasoned about
+from Apple's specification, only measured. ``project.yml`` currently targets
+macOS 14.0, which has not been tested.
+
+The four rules below follow from that:
+
+1. no shipping app bundle declares ``NSAllowsArbitraryLoads``. It is
+   unnecessary, and it would disable HTTPS enforcement for every dependency in
+   the process as well as for our own code;
+2. every shipping app bundle explains its private-network use, because a
    missing ``NSLocalNetworkUsageDescription`` fails identically to an ATS block
    and costs an afternoon to tell apart;
-3. no Swift source gains a cleartext URL literal pointing anywhere but this
-   machine or this network — the rule ATS used to enforce for free.
+3. no endpoint the app declares for itself — an update feed, a component
+   manifest — is cleartext;
+4. no Swift source gains a cleartext URL literal pointing anywhere but this
+   machine or this network.
 """
 
 from __future__ import annotations
@@ -34,9 +52,8 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 
-# Every bundle that ships as a running app. Helper executables keep full ATS
-# enforcement and are deliberately absent: only the process that talks to a
-# user's model server needs the opt-out.
+# Every bundle that ships as a running app. Helper executables are absent
+# because they inherit nothing from these and declare no ATS keys of their own.
 APP_PLISTS = [
     Path("Locus/Info.plist"),
     Path("Config/LocusRelease-Info.plist"),
@@ -45,13 +62,15 @@ APP_PLISTS = [
     Path("Config/LocusMAS-Info.plist"),
 ]
 
-# Keys whose mere presence makes macOS 10.15+/iOS 13+ disregard
-# NSAllowsArbitraryLoads. They are not additive with it; they replace it.
-CONFLICTING_ATS_KEYS = [
-    "NSAllowsArbitraryLoadsInWebContent",
-    "NSAllowsArbitraryLoadsForMedia",
-    "NSAllowsLocalNetworking",
-]
+# Blanket opt-outs. Each one disables HTTPS enforcement for a whole class of
+# traffic across the entire process — our code and every dependency alike — and
+# the measurement in the module docstring shows none of them are needed to
+# reach a LAN model server.
+FORBIDDEN_ATS_KEYS = {
+    "NSAllowsArbitraryLoads": "disables HTTPS enforcement for every connection the app makes",
+    "NSAllowsArbitraryLoadsInWebContent": "disables it for all WebKit content",
+    "NSAllowsArbitraryLoadsForMedia": "disables it for all AV Foundation media loads",
+}
 
 SWIFT_ROOTS = [
     "Locus",
@@ -138,24 +157,14 @@ def audit_plists() -> int:
             plist = plistlib.load(handle)
 
         ats = plist.get("NSAppTransportSecurity")
-        if not isinstance(ats, dict):
-            fail(
-                f"{relative}: no NSAppTransportSecurity dictionary. Without it the app "
-                "cannot reach a self-hosted model server on a LAN address."
-            )
-            failures += 1
-            continue
-
-        if ats.get("NSAllowsArbitraryLoads") is not True:
-            fail(f"{relative}: NSAllowsArbitraryLoads must be present and true")
-            failures += 1
-
-        for key in CONFLICTING_ATS_KEYS:
-            if key in ats:
+        if isinstance(ats, dict):
+            for key, cost in FORBIDDEN_ATS_KEYS.items():
+                if ats.get(key) is not True:
+                    continue
                 fail(
-                    f"{relative}: {key} is set alongside NSAllowsArbitraryLoads. Current "
-                    "macOS honours the narrower key and ignores the blanket one, so LAN "
-                    "model servers stop resolving. Remove it."
+                    f"{relative}: {key} is set, which {cost}. A LAN model server is "
+                    "reachable without it — see the measurement in this script's header, "
+                    "and re-run that experiment before concluding otherwise."
                 )
                 failures += 1
 
@@ -167,7 +176,7 @@ def audit_plists() -> int:
                 continue
             fail(
                 f"{relative}: {key} is a cleartext URL ({value}). Endpoints the app "
-                "declares for itself must be https — ATS no longer requires it."
+                "declares for itself must be https."
             )
             failures += 1
 


### PR DESCRIPTION
Follow-up to #87, which is already merged. That PR added `NSAllowsArbitraryLoads` on the premise that Apple offers no narrower way to reach a self-hosted model server. Measuring it instead of reading the specification shows the premise was wrong, so the key comes back out. Everything else from #87 stays.

## The measurement

Probed from inside the app bundle on macOS 26.4.1, against a server on a **different** machine at `192.168.50.134`, with no ATS keys in the bundle at all:

| Request | Result |
|---|---|
| `http://192.168.50.134:18434` — private LAN, cleartext | **200** |
| `http://neverssl.com` — public, cleartext | **−1022, blocked** |
| `https://expired.badssl.com` | −1200, cert rejected (not ATS) |
| `https://example.com` | 200 |

ATS is plainly still enforcing — public cleartext is refused — yet the private range goes through unaided. Apple documents `NSAllowsLocalNetworking` as covering only `.local`, unqualified names, and the loopback and link-local ranges, so this behaviour cannot be derived from the specification; it can only be measured.

An earlier run appeared to show the same thing but proved nothing, because the address under test belonged to the probing Mac itself and never left it. This one used a second machine.

So the tradeoff #87 accepted does not exist. Locus reaches LAN model servers **and** keeps HTTPS enforcement on every other connection it makes — including inside Sparkle, ReownSwift, and any dependency added later. Keeping the key bought nothing and switched that −1022 off process-wide.

## What changes

**The `NSAppTransportSecurity` dictionary is removed from all five app bundles.**

**`Tools/AuditTransportSecurity.py` inverts.** It now fails if any bundle declares `NSAllowsArbitraryLoads`, `NSAllowsArbitraryLoadsInWebContent`, or `NSAllowsArbitraryLoadsForMedia`, and its header records the experiment above — so the next person to reach for the key meets the measurement before the argument that led here. Its other three rules are unchanged: the private-network usage string must exist, endpoints the app declares for itself must be `https`, and no Swift source may gain a cleartext URL literal pointing off the local network.

**`RemoteEndpointTester` translates −1022** instead of surfacing Foundation's wording, which describes a policy rather than an endpoint and reads as if Locus were broken. It should never fire for a private address; if it does, either the address is not as local as the user thinks or this OS draws the line somewhere the audit has not measured, and the message names both.

## What stays

`TransportSecurity` and the account editor's unencrypted marker are unchanged from #87. ATS covers the network; neither of those is about the network. The helper gates endpoints the app chooses for itself — the component feed installs an executable, and ATS would **not** stop a cleartext feed URL aimed at a LAN address — and the marker tells the user what their own endpoint exposes, which the OS says nothing about either way.

## Notes

- **Untested:** `project.yml` targets macOS 14.0 and the probe ran on 26.4.1. The private-range allowance is undocumented, so I can't say when it appeared. If it postdates 14, a user on an older system hits the −1022 path — which now explains itself instead of looking like a dead server.
- Certificate validation was never at stake either way; the −1200 row above is an expired cert being rejected.

## Testing

- 13 `TransportSecurityTests` pass, including −1022 translation and the assertion that every other URLSession error keeps its own description.
- `FeatureLogicTests` 294 and `CodexComponentTests` 12, all passing, against this branch rebased on current `main`.
- Confirmed the built `Locus.app` carries no `NSAppTransportSecurity` key.
- Each audit rule verified by injecting a violation and confirming a non-zero exit.
